### PR TITLE
Improve the cloud condition errors.

### DIFF
--- a/framework/Operations/Conditions/Permissions/CloudCondition.swift
+++ b/framework/Operations/Conditions/Permissions/CloudCondition.swift
@@ -26,6 +26,7 @@ public protocol CloudContainer {
 public struct CloudContainerCondition: OperationCondition {
 
     public enum Error: ErrorType {
+        case NotAuthenticated
         case AccountStatusError(NSError?)
         case PermissionRequestRequired
         case PermissionStatusError(NSError?)
@@ -91,6 +92,8 @@ extension CloudContainerCondition.Error: Equatable { }
 
 public func ==(a: CloudContainerCondition.Error, b: CloudContainerCondition.Error) -> Bool {
     switch (a, b) {
+    case (.NotAuthenticated, .NotAuthenticated):
+        return true
     case let (.AccountStatusError(aError), .AccountStatusError(bError)):
         return aError == bError
     case    (.PermissionRequestRequired, .PermissionRequestRequired):
@@ -113,17 +116,23 @@ extension CKContainer: CloudContainer {
 
 public func verifyAccountStatusForContainer(container: CloudContainer, permissions: CKApplicationPermissions, shouldRequest: Bool, completion: ErrorType? -> Void) {
     container.accountStatusWithCompletionHandler { (status, error) in
-        if status == .Available {
+        
+        switch status {
+        
+        case .Available:
             if permissions != nil {
                 verifyPermissionsForContainer(container, permissions, shouldRequest, completion)
             }
             else {
                 completion(.None)
             }
-        }
-        else {
+
+        case .NoAccount:
+            completion(CloudContainerCondition.Error.NotAuthenticated)
+        
+        default:
             completion(CloudContainerCondition.Error.AccountStatusError(error))
-        }
+        }        
     }
 }
 

--- a/framework/Operations/Queue/ExclusivityManager.swift
+++ b/framework/Operations/Queue/ExclusivityManager.swift
@@ -8,9 +8,9 @@
 
 import Foundation
 
-class ExclusivityManager {
+public class ExclusivityManager {
 
-    static let sharedInstance = ExclusivityManager()
+    public static let sharedInstance = ExclusivityManager()
 
     private let queue = Queue.Initiated.serial("me.danthorpe.Operations.Exclusivity")
     private var operations: [String: [Operation]] = [:]
@@ -60,3 +60,18 @@ class ExclusivityManager {
     }
 }
 
+extension ExclusivityManager {
+
+    /// This should only be used as part of the unit testing
+    /// and in v2+ will not be publically accessible
+    public func __tearDownForUnitTesting() {
+        dispatch_sync(queue) {
+            for (category, operations) in self.operations {
+                for operation in operations {
+                    operation.cancel()
+                    self._removeOperation(operation, category: category)
+                }
+            }
+        }
+    }
+}

--- a/framework/OperationsTests/CloudConditionTests.swift
+++ b/framework/OperationsTests/CloudConditionTests.swift
@@ -72,7 +72,7 @@ class CloudConditionTests: OperationTests {
         XCTAssertTrue(self.operation.didExecute)
         XCTAssertTrue(self.operation.finished)
     }
-/*
+
     func test__cloud_container_executes_when_permissions_are_discoverable() {
         let expectation = expectationWithDescription("Test: \(__FUNCTION__)")
         operation.addCompletionBlockToTestOperation(operation, withExpectation: expectation)
@@ -84,7 +84,7 @@ class CloudConditionTests: OperationTests {
         XCTAssertTrue(operation.didExecute)
         XCTAssertTrue(operation.finished)
     }
-*/
+
     func test__cloud_container_errors_when_account_status_is_not_available() {
         let expectation = expectationWithDescription("Test: \(__FUNCTION__)")
         container = TestableCloudContainer(accountStatus: CKAccountStatus.NoAccount)
@@ -105,13 +105,13 @@ class CloudConditionTests: OperationTests {
         XCTAssertFalse(operation.didExecute)
         XCTAssertTrue(operation.cancelled)
         if let error = receivedErrors.first as? CloudContainerCondition.Error {
-            XCTAssertTrue(error == CloudContainerCondition.Error.AccountStatusError(accountStatusError))
+            XCTAssertTrue(error == CloudContainerCondition.Error.NotAuthenticated)
         }
         else {
             XCTFail("No error message was observed")
         }
     }
-/*
+
     func test__cloud_container_requests_permissions_which_would_be_granted_if_requested() {
         let expectation = expectationWithDescription("Test: \(__FUNCTION__)")
 
@@ -138,6 +138,4 @@ class CloudConditionTests: OperationTests {
             XCTFail("No error message was observer")
         }
     }
-*/
-
 }

--- a/framework/OperationsTests/OperationsTests.swift
+++ b/framework/OperationsTests/OperationsTests.swift
@@ -78,6 +78,7 @@ class OperationTests: XCTestCase {
     override func tearDown() {
         queue = nil
         delegate = nil
+        ExclusivityManager.sharedInstance.__tearDownForUnitTesting()
         super.tearDown()
     }
 


### PR DESCRIPTION
If the use is not logged in, the error returned from CloudKit is nil, but the status is `.NotSet`.