### PR TITLE
Support a ReachableOperation

### DIFF
--- a/framework/Operations.xcodeproj/project.pbxproj
+++ b/framework/Operations.xcodeproj/project.pbxproj
@@ -42,6 +42,8 @@
 		65D6F5891B5BEAC9003D35AD /* NetworkObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65D6F5881B5BEAC9003D35AD /* NetworkObserver.swift */; };
 		65D6F58B1B5BF264003D35AD /* NetworkObserverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65D6F58A1B5BF264003D35AD /* NetworkObserverTests.swift */; };
 		65D6F58D1B5BFE59003D35AD /* ReachabilityCondition.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65D6F58C1B5BFE59003D35AD /* ReachabilityCondition.swift */; };
+		65DADF631B62D73100EAD25B /* ReachableOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65DADF621B62D73100EAD25B /* ReachableOperation.swift */; };
+		65DADF651B62D75400EAD25B /* ReachableOperationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65DADF641B62D75400EAD25B /* ReachableOperationTests.swift */; };
 		65FABD601B600DA40072B599 /* BlockCondition.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65FABD5F1B600DA40072B599 /* BlockCondition.swift */; };
 /* End PBXBuildFile section */
 
@@ -94,6 +96,8 @@
 		65D6F5881B5BEAC9003D35AD /* NetworkObserver.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NetworkObserver.swift; sourceTree = "<group>"; };
 		65D6F58A1B5BF264003D35AD /* NetworkObserverTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NetworkObserverTests.swift; sourceTree = "<group>"; };
 		65D6F58C1B5BFE59003D35AD /* ReachabilityCondition.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReachabilityCondition.swift; sourceTree = "<group>"; };
+		65DADF621B62D73100EAD25B /* ReachableOperation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReachableOperation.swift; sourceTree = "<group>"; };
+		65DADF641B62D75400EAD25B /* ReachableOperationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReachableOperationTests.swift; sourceTree = "<group>"; };
 		65FABD5F1B600DA40072B599 /* BlockCondition.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BlockCondition.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -179,6 +183,7 @@
 				65D6F58A1B5BF264003D35AD /* NetworkObserverTests.swift */,
 				6577296F1B3D9E0E00B5D153 /* OperationsTests.swift */,
 				652122D11B5C2F4700E26052 /* ReachabilityConditionTests.swift */,
+				65DADF641B62D75400EAD25B /* ReachableOperationTests.swift */,
 				655E43FE1B3F43D60013A3E1 /* TimeoutObserverTests.swift */,
 				6577296D1B3D9E0E00B5D153 /* Supporting Files */,
 			);
@@ -237,6 +242,7 @@
 				65D6F5781B5AE925003D35AD /* GroupOperation.swift */,
 				650630321B629161005BD9F8 /* GatedOperation.swift */,
 				65D6F5741B5AC453003D35AD /* Operation.swift */,
+				65DADF621B62D73100EAD25B /* ReachableOperation.swift */,
 			);
 			path = Operations;
 			sourceTree = "<group>";
@@ -360,6 +366,7 @@
 				650630331B629161005BD9F8 /* GatedOperation.swift in Sources */,
 				65FABD601B600DA40072B599 /* BlockCondition.swift in Sources */,
 				65D6F5751B5AC453003D35AD /* Operation.swift in Sources */,
+				65DADF631B62D73100EAD25B /* ReachableOperation.swift in Sources */,
 				65D6F58D1B5BFE59003D35AD /* ReachabilityCondition.swift in Sources */,
 				6558091C1B6049F700CF0722 /* AlertOperation.swift in Sources */,
 				65CB77011B3F28E800791E18 /* ExclusivityManager.swift in Sources */,
@@ -386,6 +393,7 @@
 				652122D21B5C2F4700E26052 /* ReachabilityConditionTests.swift in Sources */,
 				65D6F57B1B5AF091003D35AD /* GroupOperationTests.swift in Sources */,
 				6558091A1B60292500CF0722 /* CloudKitOperationTests.swift in Sources */,
+				65DADF651B62D75400EAD25B /* ReachableOperationTests.swift in Sources */,
 				6558091E1B604FD300CF0722 /* AlertOperationTests.swift in Sources */,
 				654D7E701B600FA5005108E8 /* BlockConditionTests.swift in Sources */,
 				65D6F5871B5BE62C003D35AD /* BackgroundObserverTests.swift in Sources */,

--- a/framework/Operations/Operations/ReachableOperation.swift
+++ b/framework/Operations/Operations/ReachableOperation.swift
@@ -1,0 +1,12 @@
+//
+//  ReachableOperation.swift
+//  Operations
+//
+//  Created by Daniel Thorpe on 24/07/2015.
+//  Copyright (c) 2015 Daniel Thorpe. All rights reserved.
+//
+
+import Foundation
+
+
+

--- a/framework/Operations/Operations/ReachableOperation.swift
+++ b/framework/Operations/Operations/ReachableOperation.swift
@@ -8,6 +8,15 @@
 
 import Foundation
 
+/**
+    Compose your `NSOperation` inside a `ReachableOperation` to
+    ensure that it is executed when the desired connectivity is
+    available.
+
+    If the device is not reachable, the operation will observe
+    the default route reachability, and add your operation as
+    soon as the conditions are met.
+*/
 public class ReachableOperation<O: NSOperation>: GroupOperation {
 
     public let operation: O
@@ -35,16 +44,13 @@ public class ReachableOperation<O: NSOperation>: GroupOperation {
     }
 
     private func evaluate() {
-        println("Evaluating...")
         if checkStatus() {
-            println("  status: true")
             if let token = token {
                 reachability.removeObserverWithToken(token)
             }
             addOperation(operation)
         }
         else {
-            println("  status: false")
             checkStatusAgain()
         }
     }
@@ -72,8 +78,7 @@ public class ReachableOperation<O: NSOperation>: GroupOperation {
         if delay > 0.0 {
             reevaluate.addDependency(DelayOperation(interval: delay))
         }
-        
-        println("Will re-evaluate..")
+
         addOperation(reevaluate)
     }
 }

--- a/framework/Operations/Operations/ReachableOperation.swift
+++ b/framework/Operations/Operations/ReachableOperation.swift
@@ -8,5 +8,74 @@
 
 import Foundation
 
+public class ReachableOperation<O: NSOperation>: GroupOperation {
+
+    public let operation: O
+    public let connectivity: Reachability.Connectivity
+    private let reachability: SystemReachability
+    private var token: String? = .None
+    private var status: Reachability.NetworkStatus? = .None
+
+    public convenience init(operation: O, connectivity: Reachability.Connectivity = .AnyConnectionKind) {
+        self.init(operation: operation, connectivity: connectivity, reachability: Reachability.sharedInstance)
+    }
+
+    // Testing interface
+    public init(operation: O, connectivity: Reachability.Connectivity = .AnyConnectionKind, reachability: SystemReachability) {
+        self.operation = operation
+        self.connectivity = connectivity
+        self.reachability = reachability
+        super.init(operations: [])
+
+        token = reachability.addObserver { status in
+            self.status = status
+        }
+
+        checkStatusAgain(delay: 0.0)
+    }
+
+    private func evaluate() {
+        println("Evaluating...")
+        if checkStatus() {
+            println("  status: true")
+            if let token = token {
+                reachability.removeObserverWithToken(token)
+            }
+            addOperation(operation)
+        }
+        else {
+            println("  status: false")
+            checkStatusAgain()
+        }
+    }
+
+    private func checkStatus() -> Bool {
+        if let status = status {
+            switch (connectivity, status) {
+            case (_, .NotReachable), (.ViaWiFi, .Reachable(.ViaWWAN)):
+                return false
+            case (.AnyConnectionKind, _), (.ViaWWAN, _), (.ViaWiFi, .Reachable(.ViaWiFi)):
+                return true
+            default:
+                return false
+            }
+        }
+        return false
+    }
+
+    private func checkStatusAgain(delay: NSTimeInterval = 1.0) {
+
+        let reevaluate = BlockOperation { [weak self] continuation in
+            self?.evaluate()
+        }
+
+        if delay > 0.0 {
+            reevaluate.addDependency(DelayOperation(interval: delay))
+        }
+        
+        println("Will re-evaluate..")
+        addOperation(reevaluate)
+    }
+}
 
 

--- a/framework/OperationsTests/ReachabilityConditionTests.swift
+++ b/framework/OperationsTests/ReachabilityConditionTests.swift
@@ -29,7 +29,7 @@ class ReachabilityConditionTests: OperationTests {
     func test__condition_is_satisfied_when_host_is_reachable_via_wifi() {
 
         let operation = TestOperation(delay: 1)
-        let condition = ReachabilityCondition(url: url, reachability: TestableReachability(networkStatus: .ReachableViaWiFi))
+        let condition = ReachabilityCondition(url: url, reachability: TestableReachability(networkStatus: .Reachable(.ViaWiFi)))
         operation.addCondition(condition)
 
         addCompletionBlockToTestOperation(operation, withExpectation: expectationWithDescription("Test: \(__FUNCTION__)"))
@@ -44,7 +44,7 @@ class ReachabilityConditionTests: OperationTests {
     func test__condition_is_satisfied_when_host_is_reachable_via_wwan() {
 
         let operation = TestOperation(delay: 1)
-        let condition = ReachabilityCondition(url: url, connectivity: .ConnectedViaWWAN, reachability: TestableReachability(networkStatus: .ReachableViaWWAN))
+        let condition = ReachabilityCondition(url: url, connectivity: .ViaWWAN, reachability: TestableReachability(networkStatus: .Reachable(.ViaWWAN)))
         operation.addCondition(condition)
 
         addCompletionBlockToTestOperation(operation, withExpectation: expectationWithDescription("Test: \(__FUNCTION__)"))
@@ -61,7 +61,7 @@ class ReachabilityConditionTests: OperationTests {
         let expectation = expectationWithDescription("Test: \(__FUNCTION__)")
         let operation = TestOperation(delay: 1)
 
-        let condition = ReachabilityCondition(url: url, connectivity: .ConnectedViaWiFi, reachability: TestableReachability(networkStatus: .ReachableViaWWAN))
+        let condition = ReachabilityCondition(url: url, connectivity: .ViaWiFi, reachability: TestableReachability(networkStatus: .Reachable(.ViaWWAN)))
         operation.addCondition(condition)
 
         var observedErrors = Array<ErrorType>()
@@ -77,7 +77,7 @@ class ReachabilityConditionTests: OperationTests {
         waitForExpectationsWithTimeout(3) { _ in
             XCTAssertFalse(operation.didExecute)            
             if let error = observedErrors[0] as? ReachabilityCondition.Error {
-                XCTAssertTrue(error == ReachabilityCondition.Error.NotReachableWithConnectivity(.ConnectedViaWiFi))
+                XCTAssertTrue(error == ReachabilityCondition.Error.NotReachableWithConnectivity(.ViaWiFi))
             }
             else {
                 XCTFail("No error message was observer")
@@ -90,7 +90,7 @@ class ReachabilityConditionTests: OperationTests {
         let expectation = expectationWithDescription("Test: \(__FUNCTION__)")
         let operation = TestOperation(delay: 1)
 
-        let condition = ReachabilityCondition(url: url, reachability: TestableReachability(networkStatus: .NotConnected))
+        let condition = ReachabilityCondition(url: url, reachability: TestableReachability(networkStatus: .NotReachable))
         operation.addCondition(condition)
 
         var observedErrors = Array<ErrorType>()

--- a/framework/OperationsTests/ReachableOperationTests.swift
+++ b/framework/OperationsTests/ReachableOperationTests.swift
@@ -9,8 +9,65 @@
 import XCTest
 import Operations
 
+class TestableSystemReachability: SystemReachability {
+
+    var observers = Array<Reachability.ObserverBlockType>()
+    var status: Reachability.NetworkStatus {
+        didSet {
+            observers.map { $0(self.status) }
+        }
+    }
+
+    init(networkStatus: Reachability.NetworkStatus = .Reachable(.ViaWiFi)) {
+        status = networkStatus
+    }
+
+    func addObserver(observer: Reachability.ObserverBlockType) -> String {
+        let after = dispatch_time(DISPATCH_TIME_NOW, Int64(Double(0.3) * Double(NSEC_PER_SEC)))
+        dispatch_after(after, Queue.Default.queue) {
+            observer(self.status)
+        }
+        observers.append(observer)
+        return NSUUID().UUIDString
+    }
+
+    func removeObserverWithToken(token: String) {
+        // no-op
+    }
+}
+
 class ReachableOperationTests: OperationTests {
 
+    var reachability: TestableSystemReachability!
+
+    override func setUp() {
+        super.setUp()
+        reachability = TestableSystemReachability()
+    }
+
+    func test__operation_executes_when_network_is_available() {
+
+        let operation = ReachableOperation(operation: TestOperation(), reachability: reachability)
+
+        addCompletionBlockToTestOperation(operation, withExpectation: expectationWithDescription("Test: \(__FUNCTION__)"))
+        runOperation(operation)
+        reachability.status = .Reachable(.ViaWiFi)
+        waitForExpectationsWithTimeout(3, handler: nil)
+        XCTAssertTrue(operation.operation.didExecute)
+    }
+
+    func test__operation_executes_when_network_becomes_available() {
+        reachability.status = .NotReachable
+        let operation = ReachableOperation(operation: TestOperation(), reachability: reachability)
+
+        addCompletionBlockToTestOperation(operation, withExpectation: expectationWithDescription("Test: \(__FUNCTION__)"))
+        runOperation(operation)
+
+        reachability.status = .Reachable(.ViaWWAN)
+
+        waitForExpectationsWithTimeout(3, handler: nil)
+        XCTAssertTrue(operation.operation.didExecute)
+    }
 
 }
 

--- a/framework/OperationsTests/ReachableOperationTests.swift
+++ b/framework/OperationsTests/ReachableOperationTests.swift
@@ -1,0 +1,16 @@
+//
+//  ReachableOperationTests.swift
+//  Operations
+//
+//  Created by Daniel Thorpe on 24/07/2015.
+//  Copyright (c) 2015 Daniel Thorpe. All rights reserved.
+//
+
+import XCTest
+import Operations
+
+class ReachableOperationTests: OperationTests {
+
+
+}
+


### PR DESCRIPTION
While `ReachableCondition` will fail an operation if the network is not available, we also want a way to be able to run an operation when the network comes back.