### PR TITLE
User confirmation alert condition.

### DIFF
--- a/framework/Operations.xcodeproj/project.pbxproj
+++ b/framework/Operations.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		654308481B6490740081C211 /* SlientCondition.swift in Sources */ = {isa = PBXBuildFile; fileRef = 654308471B6490740081C211 /* SlientCondition.swift */; };
 		654D7E701B600FA5005108E8 /* BlockConditionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 654D7E6F1B600FA5005108E8 /* BlockConditionTests.swift */; };
 		654D7E721B6024C6005108E8 /* CloudKitOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 654D7E711B6024C6005108E8 /* CloudKitOperation.swift */; };
+		654EE1431B72308A00B8B265 /* UserConfirmationCondition.swift in Sources */ = {isa = PBXBuildFile; fileRef = 654EE1421B72308A00B8B265 /* UserConfirmationCondition.swift */; };
 		6558091A1B60292500CF0722 /* CloudKitOperationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 655809191B60292500CF0722 /* CloudKitOperationTests.swift */; };
 		6558091C1B6049F700CF0722 /* AlertOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6558091B1B6049F700CF0722 /* AlertOperation.swift */; };
 		6558091E1B604FD300CF0722 /* AlertOperationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6558091D1B604FD300CF0722 /* AlertOperationTests.swift */; };
@@ -86,6 +87,7 @@
 		654308471B6490740081C211 /* SlientCondition.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SlientCondition.swift; sourceTree = "<group>"; };
 		654D7E6F1B600FA5005108E8 /* BlockConditionTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BlockConditionTests.swift; sourceTree = "<group>"; };
 		654D7E711B6024C6005108E8 /* CloudKitOperation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CloudKitOperation.swift; sourceTree = "<group>"; };
+		654EE1421B72308A00B8B265 /* UserConfirmationCondition.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserConfirmationCondition.swift; sourceTree = "<group>"; };
 		655809191B60292500CF0722 /* CloudKitOperationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CloudKitOperationTests.swift; sourceTree = "<group>"; };
 		6558091B1B6049F700CF0722 /* AlertOperation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AlertOperation.swift; sourceTree = "<group>"; };
 		6558091D1B604FD300CF0722 /* AlertOperationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AlertOperationTests.swift; sourceTree = "<group>"; };
@@ -242,6 +244,7 @@
 				6577297E1B3DAA0400B5D153 /* OperationCondition.swift */,
 				65D6F58C1B5BFE59003D35AD /* ReachabilityCondition.swift */,
 				654308471B6490740081C211 /* SlientCondition.swift */,
+				654EE1421B72308A00B8B265 /* UserConfirmationCondition.swift */,
 				656010081B5C557D0052EE78 /* Permissions */,
 			);
 			path = Conditions;
@@ -402,6 +405,7 @@
 				65D6F5891B5BEAC9003D35AD /* NetworkObserver.swift in Sources */,
 				6597EAD81B65A8B100129294 /* LocationOperation.swift in Sources */,
 				65CB76FF1B3F284A00791E18 /* OperationQueue.swift in Sources */,
+				654EE1431B72308A00B8B265 /* UserConfirmationCondition.swift in Sources */,
 				65D6F5851B5BE620003D35AD /* BackgroundObserver.swift in Sources */,
 				65343F8A1B6670230022968E /* AddressBookOperation.swift in Sources */,
 				657729801B3DAA0400B5D153 /* OperationCondition.swift in Sources */,

--- a/framework/Operations/Conditions/UserConfirmationCondition.swift
+++ b/framework/Operations/Conditions/UserConfirmationCondition.swift
@@ -1,0 +1,75 @@
+//
+//  UserConfirmationCondition.swift
+//  Operations
+//
+//  Created by Daniel Thorpe on 05/08/2015.
+//  Copyright (c) 2015 Daniel Thorpe. All rights reserved.
+//
+
+import UIKit
+
+/**
+    Attach this condition to an operation to present an alert
+    to the user requesting their confirmation before proceeding.
+*/
+public class UserConfirmationCondition: OperationCondition {
+
+    enum Confirmation {
+        case Unknown
+        case Confirmed
+        case Cancelled
+    }
+
+    enum Error: ErrorType {
+        case ConfirmationUnknown
+        case ConfirmationCancelled
+    }
+
+    public let name: String
+    public let isMutuallyExclusive = false
+
+    public let title: String
+    public let message: String?
+    public let action: String
+    public let isDestructive: Bool
+    public let cancelAction: String
+
+    var presentingController: PresentingViewController?
+    var confirmation: Confirmation = .Unknown
+
+    public init(title: String, message: String? = .None, action: String, isDestructive: Bool = true, cancelAction: String = NSLocalizedString("Cancel", comment: "Cancel"), presentingController: PresentingViewController? = .None) {
+        self.name = "UserConfirmationCondition(\(title))"
+        self.title = title
+        self.message = message
+        self.action = action
+        self.isDestructive = isDestructive
+        self.cancelAction = cancelAction
+        self.presentingController = presentingController
+    }
+
+    public func dependencyForOperation(operation: Operation) -> NSOperation? {
+        let alert = AlertOperation(presentFromController: presentingController)
+        alert.title = title
+        alert.message = message
+        alert.addActionWithTitle(action, style: isDestructive ? .Destructive : .Default) { [weak self] _ in
+            self?.confirmation = .Confirmed
+        }
+        alert.addActionWithTitle(cancelAction, style: .Cancel) { [weak self] _ in
+            self?.confirmation = .Cancelled
+        }
+        return alert
+    }
+
+    public func evaluateForOperation(operation: Operation, completion: OperationConditionResult -> Void) {
+        switch confirmation {
+        case .Unknown:
+            // This should never happen, but you never know.
+            completion(.Failed(Error.ConfirmationUnknown))
+        case .Cancelled:
+            completion(.Failed(Error.ConfirmationCancelled))
+        case .Confirmed:
+            completion(.Satisfied)
+        }
+    }
+
+}


### PR DESCRIPTION
It's a fairly common requirement to get the user to confirm a destructive, or potentially destructive action. E.g. we ask the use if they're sure they want to delete a resource before we just do it.

So... here we want an `UserConfirmationCondition` which can be initialised with a title, message and action title and it will present an alert (to this effect) and if the user taps in the affirmative, the operation will run.