### PR TITLE
Possible to create a deadlock using mutual exclusive conditions and group operations.

### DIFF
--- a/Operations/Operations/GroupOperation.swift
+++ b/Operations/Operations/GroupOperation.swift
@@ -22,19 +22,16 @@ import Foundation
 */
 public class GroupOperation: Operation {
 
-    private let _queue = OperationQueue()
-    private let _finishingOperation = NSBlockOperation(block: {})
-    private var _aggregateErrors = Array<ErrorType>()
+    private let queue = OperationQueue()
+    private let operations: [NSOperation]
+    private let finishingOperation = NSBlockOperation(block: {})
+    private var aggregateErrors = Array<ErrorType>()
 
-    public init(operations: [NSOperation]) {
+    public init(operations ops: [NSOperation]) {
+        operations = ops
         super.init()
-
-        _queue.suspended = true
-        _queue.delegate = self
-
-        for operation in operations {
-            _queue.addOperation(operation)
-        }
+        queue.suspended = true
+        queue.delegate = self
     }
 
     public convenience init(operations: NSOperation...) {
@@ -42,21 +39,24 @@ public class GroupOperation: Operation {
     }
 
     public override func cancel() {
-        _queue.cancelAllOperations()
+        queue.cancelAllOperations()
         super.cancel()
     }
 
     public override func execute() {
-        _queue.suspended = false
-        _queue.addOperation(_finishingOperation)
+        for operation in operations {
+            queue.addOperation(operation)
+        }
+        queue.suspended = false
+        queue.addOperation(finishingOperation)
     }
 
     public func addOperation(operation: NSOperation) {
-        _queue.addOperation(operation)
+        queue.addOperation(operation)
     }
 
     final func aggregateError(error: ErrorType) {
-        _aggregateErrors.append(error)
+        aggregateErrors.append(error)
     }
 
     public func operationDidFinish(operation: NSOperation, withErrors errors: [ErrorType]) {
@@ -67,19 +67,19 @@ public class GroupOperation: Operation {
 extension GroupOperation: OperationQueueDelegate {
 
     public func operationQueue(queue: OperationQueue, willAddOperation operation: NSOperation) {
-        assert(!_finishingOperation.finished && !_finishingOperation.executing, "Cannot add new operations to a group after the group has completed.")
+        assert(!finishingOperation.finished && !finishingOperation.executing, "Cannot add new operations to a group after the group has completed.")
 
-        if operation !== _finishingOperation {
-            _finishingOperation.addDependency(operation)
+        if operation !== finishingOperation {
+            finishingOperation.addDependency(operation)
         }
     }
 
     public func operationQueue(queue: OperationQueue, operationDidFinish operation: NSOperation, withErrors errors: [ErrorType]) {
-        _aggregateErrors.extend(errors)
+        aggregateErrors.extend(errors)
 
-        if operation === _finishingOperation {
-            _queue.suspended = true
-            finish(errors: _aggregateErrors)
+        if operation === finishingOperation {
+            queue.suspended = true
+            finish(errors: aggregateErrors)
         }
         else {
             operationDidFinish(operation, withErrors: errors)

--- a/OperationsTests/GroupOperationTests.swift
+++ b/OperationsTests/GroupOperationTests.swift
@@ -46,5 +46,24 @@ class GroupOperationTests: OperationTests {
         XCTAssertTrue(operation.finished)
         XCTAssertTrue(extra.didExecute)
     }
+
+    func test__that_group_conditions_are_evaluated_before_the_child_operations() {
+        let operations: [TestOperation] = (0..<3).map { i in
+            let op = TestOperation()
+            op.addCondition(BlockCondition { true })
+            let exp = self.expectationWithDescription("Group Operation, child \(i): \(__FUNCTION__)")
+            self.addCompletionBlockToTestOperation(op, withExpectation: exp)
+            return op
+        }
+
+        let group = GroupOperation(operations: operations)
+        addCompletionBlockToTestOperation(group, withExpectation: expectationWithDescription("Test: \(__FUNCTION__)"))
+
+        runOperation(group)
+        waitForExpectationsWithTimeout(5, handler: nil)
+        XCTAssertTrue(group.finished)
+    }
 }
+
+
 


### PR DESCRIPTION
It is possible to achieve a deadlock through the use of mutually exclusive conditions (such as alert) and group operations.

When a group operation has a child operation which has a mutually exclusive condition. Adding a condition with the same mutual exclusivity condition type to the group will create a deadlock. This is because the child's condition is added first to the exclusivity manager, and so the group condition will never evaluate. This stops the group from executing, and the child relinquishing it's lock on that mutually exclusive condition.

A simple workaround is to either

1. If you're adding the group's condition inside the group itself, then you can add the child operations during it's `execute` method.

2. If you're adding the group's condition outside of the group, you will need to setup another operation (say a `BlockOperation` and then add what would be the group's condition to it. From inside this operation you can then `produceOperation` the group operation.

I'm currently thinking of a proper solution to this problem as it's that obvious, especially considering an operation's conditions might not be known if using ones from this framework (e.g. `AddressBookCondition` acquires a lock on `AlertPresentation`)