### PR TITLE
Fix compilation and warnings on Xcode7b6.

### DIFF
--- a/Operations/Operations/GroupOperation.swift
+++ b/Operations/Operations/GroupOperation.swift
@@ -75,7 +75,7 @@ extension GroupOperation: OperationQueueDelegate {
     }
 
     public func operationQueue(queue: OperationQueue, operationDidFinish operation: NSOperation, withErrors errors: [ErrorType]) {
-        _aggregateErrors.extend(errors)
+        _aggregateErrors.appendContentsOf(errors)
 
         if operation === _finishingOperation {
             _queue.suspended = true

--- a/Operations/Operations/Operation.swift
+++ b/Operations/Operations/Operation.swift
@@ -162,7 +162,7 @@ public class Operation: NSOperation {
 
         if _internalErrors.isEmpty && cancelled == false {
             state = .Executing
-            observers.map { $0.operationDidStart(self) }
+            for o in observers { o.operationDidStart(self) }
             execute()
         }
         else {
@@ -191,7 +191,7 @@ public class Operation: NSOperation {
     }
     
     public final func produceOperation(operation: NSOperation) {
-        observers.map { $0.operation(self, didProduceOperation: operation) }
+        for o in observers { o.operation(self, didProduceOperation: operation) }
     }
     
     // MARK: Finishing
@@ -214,7 +214,7 @@ public class Operation: NSOperation {
             let combinedErrors = _internalErrors + errors
             finished(combinedErrors)
             
-            observers.map { $0.operationDidFinish(self, errors: combinedErrors) }
+            for o in observers { o.operationDidFinish(self, errors: combinedErrors) }
             
             state = .Finished
         }
@@ -295,7 +295,7 @@ extension NSOperation {
     
     /// Add multiple depdendencies to the operation.
     func addDependencies(dependencies: [NSOperation]) {
-        dependencies.map { self.addDependency($0) }
+        for d in dependencies { self.addDependency(d) }
     }
 }
 

--- a/Operations/Operations/Operation.swift
+++ b/Operations/Operations/Operation.swift
@@ -117,7 +117,7 @@ public class Operation: NSOperation {
         assert(state == .Pending && cancelled == false, "\(__FUNCTION__) was called out of order.")
         state = .EvaluatingConditions
         OperationConditionEvaluator.evaluate(conditions, operation: self) { errors in
-            self._internalErrors.extend(errors)
+            self._internalErrors.appendContentsOf(errors)
             self.state = .Ready
         }
     }
@@ -175,7 +175,7 @@ public class Operation: NSOperation {
     They must call a finish methods in order to complete.
     */
     public func execute() {
-        print("\(self.dynamicType) must override `execute()`.", appendNewline: false)
+        print("\(self.dynamicType) must override `execute()`.", terminator: "")
         
         finish()
     }

--- a/Operations/Queue/OperationQueue.swift
+++ b/Operations/Queue/OperationQueue.swift
@@ -76,7 +76,7 @@ public class OperationQueue: NSOperationQueue {
     }
 
     public override func addOperations(ops: [NSOperation], waitUntilFinished wait: Bool) {
-        ops.map(addOperation)
+        for o in ops { addOperation(o) }
 
         if wait {
             for operation in operations {

--- a/OperationsTests/CalendarConditionTests.swift
+++ b/OperationsTests/CalendarConditionTests.swift
@@ -34,7 +34,7 @@ class TestableEventKitAuthorizationManager: EventKitAuthorizationManagerType {
     func requestAccessToEntityType(entityType: EKEntityType, completion: EKEventStoreRequestAccessCompletionHandler) {
         didRequestAccess = true
         authorizationStatus = requestedAuthorizationStatus
-        completion(ObjCBool(accessAllowed), nil)
+        completion(accessAllowed, nil)
     }
 }
 

--- a/OperationsTests/ReachableOperationTests.swift
+++ b/OperationsTests/ReachableOperationTests.swift
@@ -14,7 +14,7 @@ class TestableSystemReachability: SystemReachability {
     var observers = Array<Reachability.ObserverBlockType>()
     var status: Reachability.NetworkStatus {
         didSet {
-            observers.map { $0(self.status) }
+            for o in observers { o(self.status) }
         }
     }
 


### PR DESCRIPTION
I've modified 'unused map result' warnings to use foreach syntax in order to improve efficiency a bit. Other option was to silence the warning by adding '_ =' prefix, but I thought that was worse.