### PR TITLE
Cancel Operation when it finishes with an error.

### DIFF
--- a/Operations/Operations/GroupOperation.swift
+++ b/Operations/Operations/GroupOperation.swift
@@ -42,7 +42,9 @@ public class GroupOperation: Operation {
     }
 
     public override func cancel() {
-        _queue.cancelAllOperations()
+        if !self.cancelled {
+            _queue.cancelAllOperations()
+        }
         super.cancel()
     }
 

--- a/Operations/Operations/Operation.swift
+++ b/Operations/Operations/Operation.swift
@@ -212,6 +212,10 @@ public class Operation: NSOperation {
             state = .Finishing
             
             let combinedErrors = _internalErrors + errors
+            if !combinedErrors.isEmpty {
+                // Allow dependent tasks to be cancelled using NoCancelledCondition
+                cancel()
+            }
             finished(combinedErrors)
             
             observers.forEach { $0.operationDidFinish(self, errors: combinedErrors) }


### PR DESCRIPTION
I think the intention for NoCancelledCondition was to cancel the dependencies when an operation either cancels or finishes with an error. But current implementation works only for explicit cancellations.

If my reading of the NoCancelledCondition intent was incorrect, then I need to add NoFailedCondition, and somehow check that dependent operations finished without having any errors, but there's no way to check for that: the easiest way to solve this would be to add `var errors: [ErrorType] { get { _internalErrors }}` property.