### PR TITLE
Update Swift 1.2 with recent changes in Swift 2.0

### DIFF
--- a/Operations.xcodeproj/project.pbxproj
+++ b/Operations.xcodeproj/project.pbxproj
@@ -47,8 +47,8 @@
 		6597EAD61B659D7500129294 /* LocationConditionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6597EAD51B659D7500129294 /* LocationConditionTests.swift */; };
 		6597EAD81B65A8B100129294 /* LocationOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6597EAD71B65A8B100129294 /* LocationOperation.swift */; };
 		6597EADA1B65B3A100129294 /* LocationOperationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6597EAD91B65B3A100129294 /* LocationOperationTests.swift */; };
-		6597EADC1B66373500129294 /* NoCancelledCondition.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6597EADB1B66373500129294 /* NoCancelledCondition.swift */; };
-		6597EADE1B66399700129294 /* NoCancelledConditionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6597EADD1B66399700129294 /* NoCancelledConditionTests.swift */; };
+		6597EADC1B66373500129294 /* NoFailedDependenciesCondition.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6597EADB1B66373500129294 /* NoFailedDependenciesCondition.swift */; };
+		6597EADE1B66399700129294 /* NoFailedDependenciesConditionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6597EADD1B66399700129294 /* NoFailedDependenciesConditionTests.swift */; };
 		65B551DC1B626FAA003B0C58 /* LoggingObserverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65B551DB1B626FAA003B0C58 /* LoggingObserverTests.swift */; };
 		65C00C2A1B6836D800599903 /* UserNotificationCondition.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65C00C291B6836D800599903 /* UserNotificationCondition.swift */; };
 		65CB76FC1B3F284A00791E18 /* BlockObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65CB76F71B3F284A00791E18 /* BlockObserver.swift */; };
@@ -131,8 +131,8 @@
 		6597EAD51B659D7500129294 /* LocationConditionTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LocationConditionTests.swift; sourceTree = "<group>"; };
 		6597EAD71B65A8B100129294 /* LocationOperation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LocationOperation.swift; sourceTree = "<group>"; };
 		6597EAD91B65B3A100129294 /* LocationOperationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LocationOperationTests.swift; sourceTree = "<group>"; };
-		6597EADB1B66373500129294 /* NoCancelledCondition.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NoCancelledCondition.swift; sourceTree = "<group>"; };
-		6597EADD1B66399700129294 /* NoCancelledConditionTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NoCancelledConditionTests.swift; sourceTree = "<group>"; };
+		6597EADB1B66373500129294 /* NoFailedDependenciesCondition.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NoFailedDependenciesCondition.swift; sourceTree = "<group>"; };
+		6597EADD1B66399700129294 /* NoFailedDependenciesConditionTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NoFailedDependenciesConditionTests.swift; sourceTree = "<group>"; };
 		65B551DB1B626FAA003B0C58 /* LoggingObserverTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LoggingObserverTests.swift; sourceTree = "<group>"; };
 		65C00C291B6836D800599903 /* UserNotificationCondition.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserNotificationCondition.swift; sourceTree = "<group>"; };
 		65CB76F71B3F284A00791E18 /* BlockObserver.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BlockObserver.swift; sourceTree = "<group>"; };
@@ -263,7 +263,7 @@
 				652122D81B5C427F00E26052 /* MutualExclusiveTests.swift */,
 				654308451B648D090081C211 /* NegatedConditionTests.swift */,
 				65D6F58A1B5BF264003D35AD /* NetworkObserverTests.swift */,
-				6597EADD1B66399700129294 /* NoCancelledConditionTests.swift */,
+				6597EADD1B66399700129294 /* NoFailedDependenciesConditionTests.swift */,
 				6577296F1B3D9E0E00B5D153 /* OperationsTests.swift */,
 				657A4A361B77DAD2006B3D7A /* PassbookConditionTests.swift */,
 				652803601B78FA9900717334 /* PhotosConditionTests.swift */,
@@ -291,7 +291,7 @@
 				65FABD5F1B600DA40072B599 /* BlockCondition.swift */,
 				652122D61B5C407100E26052 /* MutuallyExclusive.swift */,
 				653E59FF1B64899F00AAAA98 /* NegatedCondition.swift */,
-				6597EADB1B66373500129294 /* NoCancelledCondition.swift */,
+				6597EADB1B66373500129294 /* NoFailedDependenciesCondition.swift */,
 				6577297E1B3DAA0400B5D153 /* OperationCondition.swift */,
 				65D6F58C1B5BFE59003D35AD /* ReachabilityCondition.swift */,
 				657A4A3C1B77F10F006B3D7A /* RemoteNotificationCondition.swift */,
@@ -464,7 +464,7 @@
 				653E5A001B64899F00AAAA98 /* NegatedCondition.swift in Sources */,
 				65D6F57D1B5B009D003D35AD /* DelayOperation.swift in Sources */,
 				65D6F5771B5ADEF6003D35AD /* BlockOperation.swift in Sources */,
-				6597EADC1B66373500129294 /* NoCancelledCondition.swift in Sources */,
+				6597EADC1B66373500129294 /* NoFailedDependenciesCondition.swift in Sources */,
 				657A4A391B77E162006B3D7A /* CalendarCondition.swift in Sources */,
 				65E3BDB71B91153700600CFB /* ComposedOperation.swift in Sources */,
 				6514BE5A1B65993F0020A39D /* LocationCondition.swift in Sources */,
@@ -519,7 +519,7 @@
 				655E43FF1B3F43D60013A3E1 /* TimeoutObserverTests.swift in Sources */,
 				652122D21B5C2F4700E26052 /* ReachabilityConditionTests.swift in Sources */,
 				65D6F57B1B5AF091003D35AD /* GroupOperationTests.swift in Sources */,
-				6597EADE1B66399700129294 /* NoCancelledConditionTests.swift in Sources */,
+				6597EADE1B66399700129294 /* NoFailedDependenciesConditionTests.swift in Sources */,
 				657A4A3B1B77E7CA006B3D7A /* CalendarConditionTests.swift in Sources */,
 				6597EADA1B65B3A100129294 /* LocationOperationTests.swift in Sources */,
 				65DADF651B62D75400EAD25B /* ReachableOperationTests.swift in Sources */,

--- a/Operations/Support.swift
+++ b/Operations/Support.swift
@@ -61,3 +61,54 @@ extension Dictionary {
     }
 }
 
+
+// MARK: - Thread Safety
+
+protocol ReadWriteLock {
+    func read<T>(block: () -> T) -> T
+    mutating func write(block: dispatch_block_t)
+    mutating func write(block: dispatch_block_t, completion: dispatch_block_t?)
+}
+
+struct Lock: ReadWriteLock {
+    let queue = Queue.Default.concurrent("me.danthorpe.Operations.lock")
+
+    func read<T>(block: () -> T) -> T {
+        var result: T!
+        dispatch_sync(queue) {
+            result = block()
+        }
+        return result
+    }
+
+    mutating func write(block: dispatch_block_t) {
+        write(block, completion: .None)
+    }
+
+    func write(block: dispatch_block_t, completion: dispatch_block_t? = .None) {
+        dispatch_barrier_async(queue) {
+            block()
+            if let completion = completion {
+                dispatch_async(Queue.Main.queue, completion)
+            }
+        }
+    }
+}
+
+public class Protector<T> {
+    private var lock: ReadWriteLock = Lock()
+    private var ward: T
+
+    public init(_ ward: T) {
+        self.ward = ward
+    }
+
+    public func read<U>(block: T -> U) -> U {
+        return lock.read { [ward = self.ward] in block(ward) }
+    }
+
+    public func write(block: (inout T) -> Void) {
+        lock.write({ block(&self.ward) })
+    }
+}
+

--- a/OperationsTests/NoFailedDependenciesConditionTests.swift
+++ b/OperationsTests/NoFailedDependenciesConditionTests.swift
@@ -1,5 +1,5 @@
 //
-//  NoCancelledConditionTests.swift
+//  NoFailedDependenciesConditionTests.swift
 //  Operations
 //
 //  Created by Daniel Thorpe on 20/07/2015.
@@ -9,7 +9,7 @@
 import XCTest
 import Operations
 
-class NoCancelledConditionTests: OperationTests {
+class NoFailedDependenciesConditionTests: OperationTests {
 
     func createCancellingOperation(shouldCancel: Bool, expectation: XCTestExpectation) -> TestOperation {
 
@@ -30,7 +30,7 @@ class NoCancelledConditionTests: OperationTests {
 
     func test__operation_with_no_dependencies_still_succeeds() {
         let operation = TestOperation()
-        operation.addCondition(NoCancelledCondition())
+        operation.addCondition(NoFailedDependenciesCondition())
 
         addCompletionBlockToTestOperation(operation, withExpectation: expectationWithDescription("Test: \(__FUNCTION__)"))
         runOperation(operation)
@@ -45,7 +45,7 @@ class NoCancelledConditionTests: OperationTests {
         addCompletionBlockToTestOperation(operation, withExpectation: expectationWithDescription("Test: \(__FUNCTION__)"))
         let dependency = createCancellingOperation(false, expectation: expectationWithDescription("Dependency for Test: \(__FUNCTION__)"))
         operation.addDependency(dependency)
-        operation.addCondition(NoCancelledCondition())
+        operation.addCondition(NoFailedDependenciesCondition())
 
         runOperations(operation, dependency)
         waitForExpectationsWithTimeout(3, handler: nil)
@@ -58,7 +58,7 @@ class NoCancelledConditionTests: OperationTests {
         let operation = TestOperation()
         let dependency = createCancellingOperation(true, expectation: expectationWithDescription("Dependency for Test: \(__FUNCTION__)"))
         operation.addDependency(dependency)
-        operation.addCondition(NoCancelledCondition())
+        operation.addCondition(NoFailedDependenciesCondition())
 
         runOperations(operation, dependency)
         waitForExpectationsWithTimeout(3, handler: nil)
@@ -73,7 +73,7 @@ class NoCancelledConditionTests: OperationTests {
         operation.addDependency(dependency1)
         let dependency2 = createCancellingOperation(false, expectation: expectationWithDescription("Dependency 2 for Test: \(__FUNCTION__)"))
         operation.addDependency(dependency2)
-        operation.addCondition(NoCancelledCondition())
+        operation.addCondition(NoFailedDependenciesCondition())
 
         var receivedErrors = [ErrorType]()
         operation.addObserver(BlockObserver { (_ , errors) in
@@ -88,5 +88,44 @@ class NoCancelledConditionTests: OperationTests {
         XCTAssertEqual(receivedErrors.count, 1)
     }
 
+    func test__operation_with_errored_dependency_fails() {
+        let expectation = expectationWithDescription("Test: \(__FUNCTION__)")
+        let operation = TestOperation()
+        let dependency = TestOperation(delay: 0, error: TestOperation.Error.SimulatedError)
+        operation.addDependency(dependency)
+        operation.addCondition(NoFailedDependenciesCondition())
 
+        var receivedErrors = [ErrorType]()
+        operation.addObserver(BlockObserver { (_ , errors) in
+            receivedErrors = errors
+            expectation.fulfill()
+        })
+
+        runOperations(operation, dependency)
+        waitForExpectationsWithTimeout(3, handler: nil)
+
+        XCTAssertFalse(operation.didExecute)
+        XCTAssertEqual(receivedErrors.count, 1)
+    }
+
+    func test__operation_with_group_dependency_with_errored_child_fails() {
+        let expectation = expectationWithDescription("Test: \(__FUNCTION__)")
+        let operation = TestOperation()
+        let childOperation = TestOperation(delay: 0, error: TestOperation.Error.SimulatedError)
+        let dependency = GroupOperation(operations: [childOperation])
+        operation.addDependency(dependency)
+        operation.addCondition(NoFailedDependenciesCondition())
+
+        var receivedErrors = [ErrorType]()
+        operation.addObserver(BlockObserver { (_ , errors) in
+            receivedErrors = errors
+            expectation.fulfill()
+        })
+
+        runOperations(operation, dependency)
+        waitForExpectationsWithTimeout(3, handler: nil)
+        
+        XCTAssertFalse(operation.didExecute)
+        XCTAssertEqual(receivedErrors.count, 1)        
+    }
 }


### PR DESCRIPTION
Also there is a slight bug in how `Operation` evaluates readiness, which should be sorted. Also, I'm thinking that the internal `State` should be made thread safe... 