### PR TITLE
Tests take too long to finish

### DIFF
--- a/Operations.xcodeproj/project.pbxproj
+++ b/Operations.xcodeproj/project.pbxproj
@@ -34,7 +34,7 @@
 		65719F6F1B70FE090012A775 /* UserNotificationConditionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65719F6E1B70FE090012A775 /* UserNotificationConditionTests.swift */; };
 		657729631B3D9E0E00B5D153 /* Operations.h in Headers */ = {isa = PBXBuildFile; fileRef = 657729621B3D9E0E00B5D153 /* Operations.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		657729691B3D9E0E00B5D153 /* Operations.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6577295D1B3D9E0E00B5D153 /* Operations.framework */; };
-		657729701B3D9E0E00B5D153 /* OperationsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6577296F1B3D9E0E00B5D153 /* OperationsTests.swift */; };
+		657729701B3D9E0E00B5D153 /* OperationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6577296F1B3D9E0E00B5D153 /* OperationTests.swift */; };
 		657729801B3DAA0400B5D153 /* OperationCondition.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6577297E1B3DAA0400B5D153 /* OperationCondition.swift */; };
 		657729851B3DAAA400B5D153 /* Support.swift in Sources */ = {isa = PBXBuildFile; fileRef = 657729841B3DAAA400B5D153 /* Support.swift */; };
 		65779C061B8C97AA00BE6C9D /* AddressBookOperations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65779C051B8C97AA00BE6C9D /* AddressBookOperations.swift */; };
@@ -119,7 +119,7 @@
 		657729621B3D9E0E00B5D153 /* Operations.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Operations.h; sourceTree = "<group>"; };
 		657729681B3D9E0E00B5D153 /* OperationsTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = OperationsTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		6577296E1B3D9E0E00B5D153 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		6577296F1B3D9E0E00B5D153 /* OperationsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OperationsTests.swift; sourceTree = "<group>"; };
+		6577296F1B3D9E0E00B5D153 /* OperationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OperationTests.swift; sourceTree = "<group>"; };
 		6577297E1B3DAA0400B5D153 /* OperationCondition.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OperationCondition.swift; sourceTree = "<group>"; };
 		657729841B3DAAA400B5D153 /* Support.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Support.swift; sourceTree = "<group>"; };
 		65779C051B8C97AA00BE6C9D /* AddressBookOperations.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = AddressBookOperations.swift; path = AddressBook/AddressBookOperations.swift; sourceTree = "<group>"; };
@@ -266,7 +266,7 @@
 				654308451B648D090081C211 /* NegatedConditionTests.swift */,
 				65D6F58A1B5BF264003D35AD /* NetworkObserverTests.swift */,
 				6597EADD1B66399700129294 /* NoFailedDependenciesConditionTests.swift */,
-				6577296F1B3D9E0E00B5D153 /* OperationsTests.swift */,
+				6577296F1B3D9E0E00B5D153 /* OperationTests.swift */,
 				657A4A361B77DAD2006B3D7A /* PassbookConditionTests.swift */,
 				652803601B78FA9900717334 /* PhotosConditionTests.swift */,
 				652122D11B5C2F4700E26052 /* ReachabilityConditionTests.swift */,
@@ -514,7 +514,7 @@
 			files = (
 				652803611B78FA9900717334 /* PhotosConditionTests.swift in Sources */,
 				652E271F1B62C13400A53AA6 /* GatedOperationTests.swift in Sources */,
-				657729701B3D9E0E00B5D153 /* OperationsTests.swift in Sources */,
+				657729701B3D9E0E00B5D153 /* OperationTests.swift in Sources */,
 				65719F6F1B70FE090012A775 /* UserNotificationConditionTests.swift in Sources */,
 				652122D91B5C427F00E26052 /* MutualExclusiveTests.swift in Sources */,
 				6528035D1B78DB8F00717334 /* HealthConditionTests.swift in Sources */,

--- a/OperationsTests/OperationTests.swift
+++ b/OperationsTests/OperationTests.swift
@@ -172,7 +172,7 @@ class DelayOperationTests: OperationTests {
         let expectation = expectationWithDescription("Test: \(__FUNCTION__)")
         let operation = DelayOperation(interval: -9_000_000)
         runOperation(operation)
-        let after = dispatch_time(DISPATCH_TIME_NOW, Int64(0.5 * Double(NSEC_PER_SEC)))
+        let after = dispatch_time(DISPATCH_TIME_NOW, Int64(0.05 * Double(NSEC_PER_SEC)))
         dispatch_after(after, Queue.Main.queue) {
             expectation.fulfill()
         }
@@ -184,7 +184,7 @@ class DelayOperationTests: OperationTests {
         let expectation = expectationWithDescription("Test: \(__FUNCTION__)")
         let operation = DelayOperation(date: NSDate.distantPast() as! NSDate)
         runOperation(operation)
-        let after = dispatch_time(DISPATCH_TIME_NOW, Int64(0.5 * Double(NSEC_PER_SEC)))
+        let after = dispatch_time(DISPATCH_TIME_NOW, Int64(0.05 * Double(NSEC_PER_SEC)))
         dispatch_after(after, Queue.Main.queue) {
             expectation.fulfill()
         }
@@ -196,7 +196,7 @@ class DelayOperationTests: OperationTests {
         var started: NSDate!
         var ended: NSDate!
         let expectation = expectationWithDescription("Test: \(__FUNCTION__)")
-        let interval: NSTimeInterval = 1
+        let interval: NSTimeInterval = 0.5
         let operation = DelayOperation(interval: interval)
         operation.addCompletionBlock {
             ended = NSDate()
@@ -204,7 +204,7 @@ class DelayOperationTests: OperationTests {
         }
         started = NSDate()
         runOperation(operation)
-        waitForExpectationsWithTimeout(3, handler: nil)
+        waitForExpectationsWithTimeout(1, handler: nil)
         XCTAssertTrue(operation.finished)
         let timeTaken = ended.timeIntervalSinceDate(started)
         XCTAssertGreaterThanOrEqual(timeTaken, interval)

--- a/OperationsTests/OperationTests.swift
+++ b/OperationsTests/OperationTests.swift
@@ -1,6 +1,6 @@
 //
-//  OperationsTests.swift
-//  OperationsTests
+//  OperationTests.swift
+//  OperationTests
 //
 //  Created by Daniel Thorpe on 26/06/2015.
 //  Copyright (c) 2015 Daniel Thorpe. All rights reserved.
@@ -21,8 +21,8 @@ class TestOperation: Operation {
     let producedOperation: NSOperation?
     var didExecute: Bool = false
     
-    init(delay: Int = 1, error: ErrorType? = .None, produced: NSOperation? = .None) {
-        numberOfSeconds = Double(delay)
+    init(delay: Double = 0.001, error: ErrorType? = .None, produced: NSOperation? = .None) {
+        numberOfSeconds = delay
         simulatedError = error
         producedOperation = produced
         super.init()
@@ -31,7 +31,7 @@ class TestOperation: Operation {
     override func execute() {
 
         if let producedOperation = self.producedOperation {
-            let after = dispatch_time(DISPATCH_TIME_NOW, Int64(numberOfSeconds * Double(0.5) * Double(NSEC_PER_SEC)))
+            let after = dispatch_time(DISPATCH_TIME_NOW, Int64(numberOfSeconds * Double(0.001) * Double(NSEC_PER_SEC)))
             dispatch_after(after, Queue.Main.queue) {
                 self.produceOperation(producedOperation)
             }

--- a/OperationsTests/ReachableOperationTests.swift
+++ b/OperationsTests/ReachableOperationTests.swift
@@ -23,7 +23,7 @@ class TestableSystemReachability: SystemReachability {
     }
 
     func addObserver(observer: Reachability.ObserverBlockType) -> String {
-        let after = dispatch_time(DISPATCH_TIME_NOW, Int64(Double(0.3) * Double(NSEC_PER_SEC)))
+        let after = dispatch_time(DISPATCH_TIME_NOW, Int64(Double(0.03) * Double(NSEC_PER_SEC)))
         dispatch_after(after, Queue.Default.queue) {
             observer(self.status)
         }


### PR DESCRIPTION
Most test operations have execution times of a second. Taking that there are many tests, the whole suite as a whole takes too long to run.

I think it would be possible to make most of them instant (0-second delay), and for those that rely on timers make intervals very small (`0.01` second should be fine, I think).