### PR TITLE
Audit public interfaces

### DIFF
--- a/Operations.xcodeproj/project.pbxproj
+++ b/Operations.xcodeproj/project.pbxproj
@@ -201,13 +201,6 @@
 			name = Permissions;
 			sourceTree = "<group>";
 		};
-		656F21CD1B7E238000849E9F /* Extras */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			name = Extras;
-			sourceTree = "<group>";
-		};
 		657729531B3D9E0E00B5D153 = {
 			isa = PBXGroup;
 			children = (
@@ -234,7 +227,6 @@
 				657729841B3DAAA400B5D153 /* Support.swift */,
 				65E4E14E1B8B9B5F00A8F5DD /* AddressBook */,
 				6577297D1B3DAA0400B5D153 /* Conditions */,
-				656F21CD1B7E238000849E9F /* Extras */,
 				65CB76F61B3F284A00791E18 /* Observers */,
 				65D6F5731B5AC453003D35AD /* Operations */,
 				65CB76FA1B3F284A00791E18 /* Queue */,

--- a/Operations/AddressBook/AddressBookConditions.swift
+++ b/Operations/AddressBook/AddressBookConditions.swift
@@ -21,8 +21,12 @@ public struct AddressBookCondition: OperationCondition {
     public let isMutuallyExclusive = false
     private let registrar: AddressBookPermissionRegistrar
 
-    public init(registrar: AddressBookPermissionRegistrar? = .None) {
-        self.registrar = registrar ?? SystemAddressBookRegistrar()
+    public init() {
+        registrar = SystemAddressBookRegistrar()
+    }
+
+    init(registrar: AddressBookPermissionRegistrar) {
+        self.registrar = registrar
     }
 
     public func dependencyForOperation(operation: Operation) -> NSOperation? {

--- a/Operations/AddressBook/AddressBookOperations.swift
+++ b/Operations/AddressBook/AddressBookOperations.swift
@@ -17,8 +17,13 @@ public class AddressBookOperation: Operation {
     internal var registrar: AddressBookPermissionRegistrar
     public var addressBook: AddressBook
 
-    public init(registrar r: AddressBookPermissionRegistrar? = .None) {
-        registrar = r ?? SystemAddressBookRegistrar()
+    public override init() {
+        registrar = SystemAddressBookRegistrar()
+        addressBook = AddressBook(registrar: registrar)
+    }
+
+    init(registrar r: AddressBookPermissionRegistrar) {
+        registrar = r
         addressBook = AddressBook(registrar: registrar)
     }
 
@@ -197,8 +202,13 @@ public class AddressBookGetResource: AddressBookOperation {
 
 public class AddressBookGetGroup: AddressBookGetResource {
 
-    public init(registrar r: AddressBookPermissionRegistrar? = .None, name: String) {
-        super.init(registrar: r)
+    public init(name: String) {
+        super.init()
+        groupQuery = .Name(name)
+    }
+
+    init(registrar: AddressBookPermissionRegistrar, name: String) {
+        super.init(registrar: registrar)
         groupQuery = .Name(name)
     }
 }
@@ -258,7 +268,13 @@ public class AddressBookRemoveGroup: AddressBookGetGroup {
 
 public class AddressBookAddPersonToGroup: AddressBookGetResource {
 
-    public init(registrar: AddressBookPermissionRegistrar? = .None, group: String, personID: ABRecordID) {
+    public init(group: String, personID: ABRecordID) {
+        super.init()
+        groupQuery = .Name(group)
+        personQuery = .ID(personID)
+    }
+
+    init(registrar: AddressBookPermissionRegistrar, group: String, personID: ABRecordID) {
         super.init(registrar: registrar)
         groupQuery = .Name(group)
         personQuery = .ID(personID)
@@ -289,7 +305,13 @@ public class AddressBookAddPersonToGroup: AddressBookGetResource {
 
 public class AddressBookRemovePersonFromGroup: AddressBookGetResource {
 
-    public init(registrar: AddressBookPermissionRegistrar? = .None, group: String, personID: ABRecordID) {
+    public init(group: String, personID: ABRecordID) {
+        super.init()
+        groupQuery = .Name(group)
+        personQuery = .ID(personID)
+    }
+
+    init(registrar: AddressBookPermissionRegistrar, group: String, personID: ABRecordID) {
         super.init(registrar: registrar)
         groupQuery = .Name(group)
         personQuery = .ID(personID)
@@ -330,7 +352,15 @@ public class AddressBookMapPeople<T>: AddressBookGetResource {
     let transform: (AddressBookPerson) -> T?
     var results = Array<T>()
 
-    public init(registrar: AddressBookPermissionRegistrar? = .None, inGroupNamed groupName: String? = .None, transform: (AddressBookPerson) -> T?) {
+    public init(inGroupNamed groupName: String? = .None, transform: (AddressBookPerson) -> T?) {
+        self.transform = transform
+        super.init()
+        if let groupName = groupName {
+            groupQuery = .Name(groupName)
+        }
+    }
+
+    init(registrar: AddressBookPermissionRegistrar, inGroupNamed groupName: String? = .None, transform: (AddressBookPerson) -> T?) {
         self.transform = transform
         super.init(registrar: registrar)
         if let groupName = groupName {
@@ -388,7 +418,11 @@ public class AddressBookDisplayPersonViewController<F: PresentingViewController>
     let ui: UIOperation<ABPersonViewController, F>
     let get: AddressBookGetResource
 
-    public init(registrar: AddressBookPermissionRegistrar? = .None, personViewController: ABPersonViewController? = .None, personWithID id: ABRecordID, displayControllerFrom from: ViewControllerDisplayStyle<F>, delegate: ABPersonViewControllerDelegate, sender: AnyObject? = .None) {
+    public convenience init(personViewController: ABPersonViewController? = .None, personWithID id: ABRecordID, displayControllerFrom from: ViewControllerDisplayStyle<F>, delegate: ABPersonViewControllerDelegate, sender: AnyObject? = .None) {
+        self.init(registrar: SystemAddressBookRegistrar(), personViewController: personViewController, personWithID: id, displayControllerFrom: from, delegate: delegate, sender: sender)
+    }
+
+    init(registrar: AddressBookPermissionRegistrar, personViewController: ABPersonViewController? = .None, personWithID id: ABRecordID, displayControllerFrom from: ViewControllerDisplayStyle<F>, delegate: ABPersonViewControllerDelegate, sender: AnyObject? = .None) {
 
         self.ui = UIOperation(controller: personViewController ?? ABPersonViewController(), displayControllerFrom: from, sender: sender)
         self.delegate = delegate
@@ -414,7 +448,11 @@ public class AddressBookDisplayNewPersonViewController<F: PresentingViewControll
     let ui: UIOperation<ABNewPersonViewController, F>
     let get: AddressBookGetResource
 
-    public init(registrar: AddressBookPermissionRegistrar? = .None, displayControllerFrom from: ViewControllerDisplayStyle<F>, delegate: ABNewPersonViewControllerDelegate, sender: AnyObject? = .None, addToGroupWithName groupName: String? = .None) {
+    public convenience init(displayControllerFrom from: ViewControllerDisplayStyle<F>, delegate: ABNewPersonViewControllerDelegate, sender: AnyObject? = .None, addToGroupWithName groupName: String? = .None) {
+        self.init(registrar: SystemAddressBookRegistrar(), displayControllerFrom: from, delegate: delegate, sender: sender, addToGroupWithName: groupName)
+    }
+
+    init(registrar: AddressBookPermissionRegistrar, displayControllerFrom from: ViewControllerDisplayStyle<F>, delegate: ABNewPersonViewControllerDelegate, sender: AnyObject? = .None, addToGroupWithName groupName: String? = .None) {
 
         self.ui = UIOperation(controller: ABNewPersonViewController(), displayControllerFrom: from, sender: sender)
         self.delegate = delegate
@@ -497,6 +535,7 @@ public class AddressBookObserver: GroupOperation {
 
         init(_ block: AddressBookDidChange) {
             addressBookDidChange = block
+            super.init()
         }
 
         deinit {

--- a/Operations/Conditions/OperationCondition.swift
+++ b/Operations/Conditions/OperationCondition.swift
@@ -19,7 +19,7 @@ public protocol OperationCondition {
 
     var name: String { get }
 
-     var isMutuallyExclusive: Bool { get }
+    var isMutuallyExclusive: Bool { get }
 
     /**
     Some conditions may have the ability to satisfy the condition

--- a/Operations/Conditions/Permissions/CalendarCondition.swift
+++ b/Operations/Conditions/Permissions/CalendarCondition.swift
@@ -47,7 +47,7 @@ public struct CalendarCondition: OperationCondition {
         Instead use
             init(type: EKEntityType)
     */
-    public init(type: EKEntityType, authorizationManager: EventKitAuthorizationManagerType) {
+    init(type: EKEntityType, authorizationManager: EventKitAuthorizationManagerType) {
         entityType = type
         manager = authorizationManager
     }

--- a/Operations/Conditions/Permissions/CloudCondition.swift
+++ b/Operations/Conditions/Permissions/CloudCondition.swift
@@ -61,7 +61,7 @@ public struct CloudContainerCondition: OperationCondition {
         self.permissions = permissions
     }
 
-    public init(container: CloudContainer, permissions: CKApplicationPermissions = []) {
+    init(container: CloudContainer, permissions: CKApplicationPermissions = []) {
         self.container = container
         self.permissions = permissions
     }

--- a/Operations/Conditions/Permissions/HealthCondition.swift
+++ b/Operations/Conditions/Permissions/HealthCondition.swift
@@ -52,7 +52,7 @@ public struct HealthCondition: OperationCondition {
         self.init(manager: HKHealthStore(), typesToRead: typesToRead, typesToWrite: typesToWrite)
     }
 
-    public init(manager: HealthManagerType, typesToRead: Set<HKSampleType> = Set(), typesToWrite: Set<HKSampleType> = Set()) {
+    init(manager: HealthManagerType, typesToRead: Set<HKSampleType> = Set(), typesToWrite: Set<HKSampleType> = Set()) {
         self.manager = manager
         self.readTypes = typesToRead
         self.shareTypes = typesToWrite

--- a/Operations/Conditions/Permissions/LocationCondition.swift
+++ b/Operations/Conditions/Permissions/LocationCondition.swift
@@ -83,17 +83,12 @@ public struct LocationCondition: OperationCondition {
         interface, and will not be public in Swift 2.0, Operations 2.0
     */
     public init(usage: Usage = .WhenInUse) {
-        self.usage = usage
-        self.manager = CLLocationManager()
+        self.init(usage: usage, manager: CLLocationManager())
     }
 
-    /**
-        This is a testing interface, and will not be public in Swift 2.0, Operations 2.0.
-        Instead use init(:Usage)
-    */
-    public init(usage: Usage, manager: LocationManager? = .None) {
+    init(usage: Usage, manager: LocationManager) {
         self.usage = usage
-        self.manager = manager ?? CLLocationManager()
+        self.manager = manager
     }
 
     public func dependencyForOperation(operation: Operation) -> NSOperation? {

--- a/Operations/Conditions/Permissions/PassbookCondition.swift
+++ b/Operations/Conditions/Permissions/PassbookCondition.swift
@@ -37,12 +37,7 @@ public struct PassbookCondition: OperationCondition {
         self.init(library: PassLibrary())
     }
 
-    /**
-        Testing Interface only, use
-
-            init()
-    */
-    public init(library: PassLibraryType) {
+    init(library: PassLibraryType) {
         self.library = library
     }
 

--- a/Operations/Conditions/Permissions/PhotosCondition.swift
+++ b/Operations/Conditions/Permissions/PhotosCondition.swift
@@ -42,7 +42,7 @@ public struct PhotosCondition: OperationCondition {
         self.init(manager: SystemPhotoLibraryAuthenticationManager())
     }
 
-    public init(manager: PhotosManagerType) {
+    init(manager: PhotosManagerType) {
         self.manager = manager
     }
 

--- a/Operations/Conditions/ReachabilityCondition.swift
+++ b/Operations/Conditions/ReachabilityCondition.swift
@@ -31,7 +31,7 @@ public class ReachabilityCondition: OperationCondition {
         self.init(url: url, connectivity: connectivity, reachability: Reachability.sharedInstance)
     }
 
-    public init(url: NSURL, connectivity: Reachability.Connectivity = .AnyConnectionKind, reachability: HostReachability) {
+    init(url: NSURL, connectivity: Reachability.Connectivity = .AnyConnectionKind, reachability: HostReachability) {
         self.url = url
         self.connectivity = connectivity
         self.reachability = reachability

--- a/Operations/Conditions/RemoteNotificationCondition.swift
+++ b/Operations/Conditions/RemoteNotificationCondition.swift
@@ -51,7 +51,7 @@ public struct RemoteNotificationCondition: OperationCondition {
         self.init(registrar: UIApplication.sharedApplication())
     }
 
-    public init(registrar: RemoteNotificationRegistrarType) {
+    init(registrar: RemoteNotificationRegistrarType) {
         self.registrar = registrar
     }
 

--- a/Operations/Conditions/UserNotificationCondition.swift
+++ b/Operations/Conditions/UserNotificationCondition.swift
@@ -76,7 +76,7 @@ public struct UserNotificationCondition: OperationCondition {
         self.init(settings: settings, behavior: behavior, registrar: UIApplication.sharedApplication())
     }
 
-    public init(settings: UIUserNotificationSettings, behavior: Behavior = .Merge, registrar: UserNotificationRegistrarType) {
+    init(settings: UIUserNotificationSettings, behavior: Behavior = .Merge, registrar: UserNotificationRegistrarType) {
         self.settings = settings
         self.behavior = behavior
         self.registrar = registrar
@@ -125,7 +125,7 @@ public class UserNotificationPermissionOperation: Operation {
         self.init(settings: settings, behavior: behavior, registrar: UIApplication.sharedApplication())
     }
 
-    public init(settings: UIUserNotificationSettings, behavior: UserNotificationCondition.Behavior = .Merge, registrar: UserNotificationRegistrarType) {
+    init(settings: UIUserNotificationSettings, behavior: UserNotificationCondition.Behavior = .Merge, registrar: UserNotificationRegistrarType) {
         self.settings = settings
         self.behavior = behavior
         self.registrar = registrar

--- a/Operations/Observers/BackgroundObserver.swift
+++ b/Operations/Observers/BackgroundObserver.swift
@@ -31,7 +31,7 @@ public class BackgroundObserver: NSObject {
         self.init(app: UIApplication.sharedApplication())
     }
 
-    public init(app: BackgroundTaskApplicationInterface) {
+    init(app: BackgroundTaskApplicationInterface) {
         application = app
 
         super.init()

--- a/Operations/Observers/NetworkObserver.swift
+++ b/Operations/Observers/NetworkObserver.swift
@@ -22,7 +22,7 @@ public class NetworkObserver: OperationObserver {
         self.init(indicator: UIApplication.sharedApplication())
     }
 
-    public init(indicator: NetworkActivityIndicatorInterface) {
+    init(indicator: NetworkActivityIndicatorInterface) {
         networkActivityIndicator = indicator
     }
 

--- a/Operations/Operations/LocationOperations.swift
+++ b/Operations/Operations/LocationOperations.swift
@@ -34,14 +34,14 @@ public class UserLocationOperation: Operation {
         interface, and will not be public in Swift 2.0, Operations 2.0
     */
     public convenience init(accuracy: CLLocationAccuracy = kCLLocationAccuracyThreeKilometers, handler: LocationResponseHandler) {
-        self.init(accuracy: accuracy, manager: .None, handler: handler)
+        self.init(accuracy: accuracy, manager: CLLocationManager(), handler: handler)
     }
 
     /**
         This is the Swift 1.2 testing interface, and will not be public in Swift 2.0, Operations 2.0.
         Instead use init(:CLLocationAccuracy, handler: LocationResponseHandler)
     */
-    public init(accuracy: CLLocationAccuracy, manager: LocationManager? = .None, handler: LocationResponseHandler) {
+    init(accuracy: CLLocationAccuracy, manager: LocationManager, handler: LocationResponseHandler) {
         self.accuracy = accuracy
         self.manager = manager
         self.handler = handler
@@ -146,14 +146,10 @@ public class ReverseGeocodeOperation: Operation {
         interface, and will not be public in Swift 2.0, Operations 2.0
     */
     public convenience init(location: CLLocation, completion: ReverseGeocodeCompletionHandler? = .None) {
-        self.init(location: location, geocoder: CLGeocoder())
+        self.init(location: location, geocoder: CLGeocoder(), completion: completion)
     }
 
-    /**
-        This is the Swift 1.2 testing interface, and will not be public in Swift 2.0, Operations 2.0.
-        Instead use init(:CLLocationAccuracy, handler: LocationResponseHandler)
-    */
-    public init(location: CLLocation, geocoder: ReverseGeocoderType, completion: ReverseGeocodeCompletionHandler? = .None) {
+    init(location: CLLocation, geocoder: ReverseGeocoderType, completion: ReverseGeocodeCompletionHandler? = .None) {
         self.location = location
         self.geocoder = geocoder
         self.completion = completion
@@ -202,14 +198,10 @@ public class ReverseGeocodeUserLocationOperation: GroupOperation {
         interface, and will not be public in Swift 2.0, Operations 2.0
     */
     public convenience init(accuracy: CLLocationAccuracy = kCLLocationAccuracyThreeKilometers, completion: ReverseGeocodeUserLocationCompletionHandler? = .None) {
-        self.init(accuracy: accuracy, manager: .None, geocoder: CLGeocoder(), completion: completion)
+        self.init(accuracy: accuracy, manager: CLLocationManager(), geocoder: CLGeocoder(), completion: completion)
     }
 
-    /**
-        This is the Swift 1.2 testing interface, and will not be public in Swift 2.0, Operations 2.0.
-        Instead use init(:CLLocationAccuracy, handler: LocationResponseHandler)
-    */
-    public init(accuracy: CLLocationAccuracy, manager: LocationManager? = .None, geocoder: ReverseGeocoderType, completion: ReverseGeocodeUserLocationCompletionHandler? = .None) {
+    init(accuracy: CLLocationAccuracy, manager: LocationManager, geocoder: ReverseGeocoderType, completion: ReverseGeocodeUserLocationCompletionHandler? = .None) {
         self.geocoder = geocoder
         self.completion = completion
         self.userLocationOperation = UserLocationOperation(accuracy: accuracy, manager: manager) { location in

--- a/Operations/Operations/ReachableOperation.swift
+++ b/Operations/Operations/ReachableOperation.swift
@@ -29,8 +29,7 @@ public class ReachableOperation<O: NSOperation>: GroupOperation {
         self.init(operation: operation, connectivity: connectivity, reachability: Reachability.sharedInstance)
     }
 
-    // Testing interface
-    public init(operation: O, connectivity: Reachability.Connectivity = .AnyConnectionKind, reachability: SystemReachability) {
+    init(operation: O, connectivity: Reachability.Connectivity = .AnyConnectionKind, reachability: SystemReachability) {
         self.operation = operation
         self.connectivity = connectivity
         self.reachability = reachability

--- a/Operations/Operations/UIOperation.swift
+++ b/Operations/Operations/UIOperation.swift
@@ -29,7 +29,18 @@ public enum ViewControllerDisplayStyle<ViewController: PresentingViewController>
     case ShowDetail(ViewController)
     case Present(ViewController)
 
-    func displayController<C where C: UIViewController>(controller: C, sender: AnyObject?, completion: (() -> Void)?) {
+    public var controller: ViewController {
+        switch self {
+        case .Show(let controller):
+            return controller
+        case .ShowDetail(let controller):
+            return controller
+        case .Present(let controller):
+            return controller
+        }
+    }
+
+    public func displayController<C where C: UIViewController>(controller: C, sender: AnyObject?, completion: (() -> Void)?) {
         switch self {
 
         case .Present(let from):
@@ -57,9 +68,9 @@ public enum UIOperationError: ErrorType {
 
 public class UIOperation<C, From where C: UIViewController, From: PresentingViewController>: Operation {
 
-    let controller: C
-    let from: ViewControllerDisplayStyle<From>
-    let sender: AnyObject?
+    public let controller: C
+    public let from: ViewControllerDisplayStyle<From>
+    public let sender: AnyObject?
     let completion: (() -> Void)?
 
     public init(controller: C, displayControllerFrom from: ViewControllerDisplayStyle<From>, sender: AnyObject? = .None, completion: (() -> Void)? = .None) {

--- a/Operations/Queue/ExclusivityManager.swift
+++ b/Operations/Queue/ExclusivityManager.swift
@@ -64,7 +64,7 @@ extension ExclusivityManager {
 
     /// This should only be used as part of the unit testing
     /// and in v2+ will not be publically accessible
-    public func __tearDownForUnitTesting() {
+    private func __tearDownForUnitTesting() {
         dispatch_sync(queue) {
             for (category, operations) in self.operations {
                 for operation in operations {

--- a/Operations/Queue/ExclusivityManager.swift
+++ b/Operations/Queue/ExclusivityManager.swift
@@ -64,7 +64,7 @@ extension ExclusivityManager {
 
     /// This should only be used as part of the unit testing
     /// and in v2+ will not be publically accessible
-    private func __tearDownForUnitTesting() {
+    internal func __tearDownForUnitTesting() {
         dispatch_sync(queue) {
             for (category, operations) in self.operations {
                 for operation in operations {

--- a/Operations/Queue/OperationQueue.swift
+++ b/Operations/Queue/OperationQueue.swift
@@ -77,11 +77,8 @@ public class OperationQueue: NSOperationQueue {
 
     public override func addOperations(ops: [NSOperation], waitUntilFinished wait: Bool) {
         ops.forEach(addOperation)
-
         if wait {
-            for operation in operations {
-                operation.waitUntilFinished()
-            }
+            ops.forEach { $0.waitUntilFinished() }
         }
     }
 }

--- a/OperationsTests/AddressBookConditionTests.swift
+++ b/OperationsTests/AddressBookConditionTests.swift
@@ -8,7 +8,8 @@
 
 import XCTest
 import AddressBook
-import Operations
+
+@testable import Operations
 
 class TestableAddressBookRegistrar: AddressBookPermissionRegistrar {
 

--- a/OperationsTests/AddressBookTests.swift
+++ b/OperationsTests/AddressBookTests.swift
@@ -7,7 +7,7 @@
 //
 
 import XCTest
-import Operations
+@testable import Operations
 import AddressBook
 import AddressBookUI
 

--- a/OperationsTests/AlertOperationTests.swift
+++ b/OperationsTests/AlertOperationTests.swift
@@ -7,7 +7,7 @@
 //
 
 import XCTest
-import Operations
+@testable import Operations
 
 class TestablePresentingController: PresentingViewController {
     typealias CheckBlockType = (received: UIViewController) -> Void

--- a/OperationsTests/BackgroundObserverTests.swift
+++ b/OperationsTests/BackgroundObserverTests.swift
@@ -7,7 +7,7 @@
 //
 
 import XCTest
-import Operations
+@testable import Operations
 
 class TestableUIApplication: BackgroundTaskApplicationInterface {
 

--- a/OperationsTests/BlockConditionTests.swift
+++ b/OperationsTests/BlockConditionTests.swift
@@ -7,7 +7,7 @@
 //
 
 import XCTest
-import Operations
+@testable import Operations
 
 class BlockConditionTests: OperationTests {
 

--- a/OperationsTests/CalendarConditionTests.swift
+++ b/OperationsTests/CalendarConditionTests.swift
@@ -8,7 +8,7 @@
 
 import XCTest
 import EventKit
-import Operations
+@testable import Operations
 
 class TestableEventKitAuthorizationManager: EventKitAuthorizationManagerType {
 

--- a/OperationsTests/CloudConditionTests.swift
+++ b/OperationsTests/CloudConditionTests.swift
@@ -8,7 +8,7 @@
 
 import XCTest
 import CloudKit
-import Operations
+@testable import Operations
 
 class TestableCloudContainer: CloudContainer {
 

--- a/OperationsTests/ComposedOperationTests.swift
+++ b/OperationsTests/ComposedOperationTests.swift
@@ -7,7 +7,7 @@
 //
 
 import XCTest
-import Operations
+@testable import Operations
 
 class ComposedOperationTests: OperationTests {
 

--- a/OperationsTests/GatedOperationTests.swift
+++ b/OperationsTests/GatedOperationTests.swift
@@ -7,7 +7,7 @@
 //
 
 import XCTest
-import Operations
+@testable import Operations
 
 class GatedOperationTests: OperationTests {
 

--- a/OperationsTests/GroupOperationTests.swift
+++ b/OperationsTests/GroupOperationTests.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 import XCTest
-import Operations
+@testable import Operations
 
 class GroupOperationTests: OperationTests {
 

--- a/OperationsTests/HealthConditionTests.swift
+++ b/OperationsTests/HealthConditionTests.swift
@@ -10,7 +10,7 @@
 
 import XCTest
 import HealthKit
-import Operations
+@testable import Operations
 
 class TestableHealthManager: HealthManagerType {
 

--- a/OperationsTests/LocationConditionTests.swift
+++ b/OperationsTests/LocationConditionTests.swift
@@ -8,7 +8,7 @@
 
 import XCTest
 import CoreLocation
-import Operations
+@testable import Operations
 
 class TestableLocationManager: NSObject, LocationManager {
     let fakeLocationManager = CLLocationManager()

--- a/OperationsTests/LocationOperationsTests.swift
+++ b/OperationsTests/LocationOperationsTests.swift
@@ -9,7 +9,7 @@
 import XCTest
 import CoreLocation
 import MapKit
-import Operations
+@testable import Operations
 
 class LocationOperationTests: OperationTests {
 

--- a/OperationsTests/LoggingObserverTests.swift
+++ b/OperationsTests/LoggingObserverTests.swift
@@ -7,7 +7,7 @@
 //
 
 import XCTest
-import Operations
+@testable import Operations
 
 class LoggingObserverTests: OperationTests {
 

--- a/OperationsTests/MutualExclusiveTests.swift
+++ b/OperationsTests/MutualExclusiveTests.swift
@@ -7,7 +7,7 @@
 //
 
 import XCTest
-import Operations
+@testable import Operations
 
 class MutualExclusiveTests: XCTestCase {
 

--- a/OperationsTests/NegatedConditionTests.swift
+++ b/OperationsTests/NegatedConditionTests.swift
@@ -7,7 +7,7 @@
 //
 
 import XCTest
-import Operations
+@testable import Operations
 
 class NegatedConditionTests: OperationTests {
 

--- a/OperationsTests/NetworkObserverTests.swift
+++ b/OperationsTests/NetworkObserverTests.swift
@@ -7,7 +7,7 @@
 //
 
 import XCTest
-import Operations
+@testable import Operations
 
 class TestableNetworkActivityIndicator: NetworkActivityIndicatorInterface {
     typealias IndicatorVisibilityDidChange = (visibility: Bool) -> Void

--- a/OperationsTests/NoFailedDependenciesConditionTests.swift
+++ b/OperationsTests/NoFailedDependenciesConditionTests.swift
@@ -7,7 +7,7 @@
 //
 
 import XCTest
-import Operations
+@testable import Operations
 
 class NoFailedDependenciesConditionTests: OperationTests {
 

--- a/OperationsTests/OperationTests.swift
+++ b/OperationsTests/OperationTests.swift
@@ -8,7 +8,7 @@
 
 import UIKit
 import XCTest
-import Operations
+@testable import Operations
 
 class TestOperation: Operation {
 

--- a/OperationsTests/PassbookConditionTests.swift
+++ b/OperationsTests/PassbookConditionTests.swift
@@ -9,7 +9,7 @@
 #if os(iOS)
 
 import XCTest
-import Operations
+@testable import Operations
 
 class TestablePassLibrary: PassLibraryType {
     let enabled: Bool

--- a/OperationsTests/PhotosConditionTests.swift
+++ b/OperationsTests/PhotosConditionTests.swift
@@ -10,7 +10,7 @@
 
 import XCTest
 import Photos
-import Operations
+@testable import Operations
 
 class TestablePhotoLibrary: PhotosManagerType {
 

--- a/OperationsTests/ReachabilityConditionTests.swift
+++ b/OperationsTests/ReachabilityConditionTests.swift
@@ -7,7 +7,7 @@
 //
 
 import XCTest
-import Operations
+@testable import Operations
 
 class TestableReachability: HostReachability {
 

--- a/OperationsTests/ReachableOperationTests.swift
+++ b/OperationsTests/ReachableOperationTests.swift
@@ -7,7 +7,7 @@
 //
 
 import XCTest
-import Operations
+@testable import Operations
 
 class TestableSystemReachability: SystemReachability {
 

--- a/OperationsTests/RemoteNotificationConditionTests.swift
+++ b/OperationsTests/RemoteNotificationConditionTests.swift
@@ -7,7 +7,7 @@
 //
 
 import XCTest
-import Operations
+@testable import Operations
 
 class TestableRemoteNotificationRegistrar: RemoteNotificationRegistrarType {
 

--- a/OperationsTests/SilentConditionTests.swift
+++ b/OperationsTests/SilentConditionTests.swift
@@ -7,7 +7,7 @@
 //
 
 import XCTest
-import Operations
+@testable import Operations
 
 class SilentConditionTests: XCTestCase {
     

--- a/OperationsTests/TimeoutObserverTests.swift
+++ b/OperationsTests/TimeoutObserverTests.swift
@@ -7,7 +7,7 @@
 //
 
 import XCTest
-import Operations
+@testable import Operations
 
 class TimeoutObserverTests: OperationTests {
 

--- a/OperationsTests/UserNotificationConditionTests.swift
+++ b/OperationsTests/UserNotificationConditionTests.swift
@@ -7,7 +7,7 @@
 //
 
 import XCTest
-import Operations
+@testable import Operations
 
 class TestableUserNotificationRegistrar: UserNotificationRegistrarType {
 


### PR DESCRIPTION
There are a number of initializers which are necessarily public for Swift 1.2 testing. For Swift 2.0 these need to be audited and made private.