### PR TITLE
Contacts #1

### DIFF
--- a/Operations.podspec
+++ b/Operations.podspec
@@ -34,9 +34,16 @@ session Advanced NSOperations: https://developer.apple.com/videos/wwdc/2015/?id=
   end
 
   s.subspec '+AddressBook' do |ss|
-    ss.platform = :ios, "8.0"
     ss.dependency 'Operations/App'
-    ss.source_files   = 'Operations/Extras/AddressBook/iOS'
+    ss.source_files = [
+      'Operations/Extras/AddressBook/iOS',
+      'Operations/Extras/Contacts/Shared',
+      'Operations/Extras/Contacts/iOS'
+    ]
+    ss.osx.exclude_files = [
+      'Operations/Extras/AddressBook/iOS',
+      'Operations/Extras/Contacts/iOS'
+    ]
   end
 
   # Creates a framework suitable for an (iOS or watchOS) Extension

--- a/Operations.xcodeproj/project.pbxproj
+++ b/Operations.xcodeproj/project.pbxproj
@@ -7,6 +7,19 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		651E394C1BB454310013ADE6 /* ContactsOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 651E394B1BB454310013ADE6 /* ContactsOperation.swift */; settings = {ASSET_TAGS = (); }; };
+		651E394D1BB454310013ADE6 /* ContactsOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 651E394B1BB454310013ADE6 /* ContactsOperation.swift */; settings = {ASSET_TAGS = (); }; };
+		651E394E1BB454310013ADE6 /* ContactsOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 651E394B1BB454310013ADE6 /* ContactsOperation.swift */; settings = {ASSET_TAGS = (); }; };
+		651E394F1BB454310013ADE6 /* ContactsOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 651E394B1BB454310013ADE6 /* ContactsOperation.swift */; settings = {ASSET_TAGS = (); }; };
+		651E39501BB454310013ADE6 /* ContactsOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 651E394B1BB454310013ADE6 /* ContactsOperation.swift */; settings = {ASSET_TAGS = (); }; };
+		651E39531BB454BF0013ADE6 /* ContactsCondition.swift in Sources */ = {isa = PBXBuildFile; fileRef = 651E39521BB454BF0013ADE6 /* ContactsCondition.swift */; settings = {ASSET_TAGS = (); }; };
+		651E39541BB454BF0013ADE6 /* ContactsCondition.swift in Sources */ = {isa = PBXBuildFile; fileRef = 651E39521BB454BF0013ADE6 /* ContactsCondition.swift */; settings = {ASSET_TAGS = (); }; };
+		651E39551BB454BF0013ADE6 /* ContactsCondition.swift in Sources */ = {isa = PBXBuildFile; fileRef = 651E39521BB454BF0013ADE6 /* ContactsCondition.swift */; settings = {ASSET_TAGS = (); }; };
+		651E39561BB454BF0013ADE6 /* ContactsCondition.swift in Sources */ = {isa = PBXBuildFile; fileRef = 651E39521BB454BF0013ADE6 /* ContactsCondition.swift */; settings = {ASSET_TAGS = (); }; };
+		651E39571BB454BF0013ADE6 /* ContactsCondition.swift in Sources */ = {isa = PBXBuildFile; fileRef = 651E39521BB454BF0013ADE6 /* ContactsCondition.swift */; settings = {ASSET_TAGS = (); }; };
+		651E395A1BB45E370013ADE6 /* ContactsOperationsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 651E39591BB45E370013ADE6 /* ContactsOperationsTests.swift */; settings = {ASSET_TAGS = (); }; };
+		651E395B1BB45E370013ADE6 /* ContactsOperationsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 651E39591BB45E370013ADE6 /* ContactsOperationsTests.swift */; settings = {ASSET_TAGS = (); }; };
+		651E395C1BB45E370013ADE6 /* ContactsOperationsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 651E39591BB45E370013ADE6 /* ContactsOperationsTests.swift */; settings = {ASSET_TAGS = (); }; };
 		652F5A601BAF7A2800BB5F71 /* ExclusivityManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65EEC1731BAF44E80020A9BD /* ExclusivityManager.swift */; };
 		652F5A611BAF7A2800BB5F71 /* Operation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65EEC17A1BAF44E80020A9BD /* Operation.swift */; };
 		652F5A621BAF7A2800BB5F71 /* OperationCondition.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65EEC17B1BAF44E80020A9BD /* OperationCondition.swift */; };
@@ -247,6 +260,9 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		651E394B1BB454310013ADE6 /* ContactsOperation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ContactsOperation.swift; path = Contacts/Shared/ContactsOperation.swift; sourceTree = "<group>"; };
+		651E39521BB454BF0013ADE6 /* ContactsCondition.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ContactsCondition.swift; path = Contacts/Shared/ContactsCondition.swift; sourceTree = "<group>"; };
+		651E39591BB45E370013ADE6 /* ContactsOperationsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ContactsOperationsTests.swift; path = Contacts/ContactsOperationsTests.swift; sourceTree = "<group>"; };
 		652F5A491BAF79BA00BB5F71 /* Operations.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Operations.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		65882E801BAF5B00003F74B6 /* Operations.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Operations.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		65882EB01BAF6052003F74B6 /* AlertOperationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AlertOperationTests.swift; sourceTree = "<group>"; };
@@ -392,6 +408,23 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		651E39511BB454380013ADE6 /* Contacts */ = {
+			isa = PBXGroup;
+			children = (
+				651E394B1BB454310013ADE6 /* ContactsOperation.swift */,
+				651E39521BB454BF0013ADE6 /* ContactsCondition.swift */,
+			);
+			name = Contacts;
+			sourceTree = "<group>";
+		};
+		651E39581BB45E0C0013ADE6 /* Contacts */ = {
+			isa = PBXGroup;
+			children = (
+				651E39591BB45E370013ADE6 /* ContactsOperationsTests.swift */,
+			);
+			name = Contacts;
+			sourceTree = "<group>";
+		};
 		65882E6C1BAF578E003F74B6 /* Conditions */ = {
 			isa = PBXGroup;
 			children = (
@@ -458,6 +491,7 @@
 			isa = PBXGroup;
 			children = (
 				65882EBF1BAF6052003F74B6 /* AddressBook */,
+				651E39581BB45E0C0013ADE6 /* Contacts */,
 			);
 			path = Extras;
 			sourceTree = "<group>";
@@ -594,6 +628,7 @@
 			isa = PBXGroup;
 			children = (
 				65EEC20D1BAF4F230020A9BD /* AddressBook */,
+				651E39511BB454380013ADE6 /* Contacts */,
 			);
 			name = Extras;
 			path = Operations/Extras;
@@ -977,9 +1012,11 @@
 				652F5A761BAF7A2800BB5F71 /* UIOperation.swift in Sources */,
 				652F5A681BAF7A2800BB5F71 /* NegatedCondition.swift in Sources */,
 				652F5A651BAF7A2800BB5F71 /* Support.swift in Sources */,
+				651E39571BB454BF0013ADE6 /* ContactsCondition.swift in Sources */,
 				652F5A7C1BAF7A2800BB5F71 /* UserConfirmationCondition.swift in Sources */,
 				652F5A751BAF7A2800BB5F71 /* LoggingObserver.swift in Sources */,
 				652F5A671BAF7A2800BB5F71 /* MutuallyExclusive.swift in Sources */,
+				651E39501BB454310013ADE6 /* ContactsOperation.swift in Sources */,
 				652F5A711BAF7A2800BB5F71 /* ComposedOperation.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -996,7 +1033,9 @@
 				65882E9C1BAF5BEB003F74B6 /* GroupOperation.swift in Sources */,
 				65882E951BAF5BEB003F74B6 /* BlockObserver.swift in Sources */,
 				65882E961BAF5BEB003F74B6 /* TimeoutObserver.swift in Sources */,
+				651E39561BB454BF0013ADE6 /* ContactsCondition.swift in Sources */,
 				65882E8E1BAF5BEB003F74B6 /* BlockCondition.swift in Sources */,
+				651E394F1BB454310013ADE6 /* ContactsOperation.swift in Sources */,
 				65882E921BAF5BEB003F74B6 /* SlientCondition.swift in Sources */,
 				65882E911BAF5BEB003F74B6 /* NoFailedDependenciesCondition.swift in Sources */,
 				65882E891BAF5BEB003F74B6 /* Operation.swift in Sources */,
@@ -1027,9 +1066,11 @@
 				65EEC1971BAF44E80020A9BD /* TimeoutObserver.swift in Sources */,
 				65EEC18A1BAF44E80020A9BD /* ExclusivityManager.swift in Sources */,
 				65EEC1951BAF44E80020A9BD /* SlientCondition.swift in Sources */,
+				651E394D1BB454310013ADE6 /* ContactsOperation.swift in Sources */,
 				65EEC1821BAF44E80020A9BD /* BackgroundObserver.swift in Sources */,
 				65EEC2301BAF4F230020A9BD /* RemoteNotificationCondition.swift in Sources */,
 				65EEC1841BAF44E80020A9BD /* UIOperation.swift in Sources */,
+				651E39541BB454BF0013ADE6 /* ContactsCondition.swift in Sources */,
 				65EEC2351BAF4F230020A9BD /* CloudCondition.swift in Sources */,
 				65EEC1851BAF44E80020A9BD /* BlockCondition.swift in Sources */,
 				65EEC2271BAF4F230020A9BD /* AddressBookConditions.swift in Sources */,
@@ -1069,6 +1110,7 @@
 				65882F251BAF6083003F74B6 /* HealthConditionTests.swift in Sources */,
 				65882F031BAF6074003F74B6 /* NegatedConditionTests.swift in Sources */,
 				65882EFF1BAF6074003F74B6 /* GatedOperationTests.swift in Sources */,
+				651E395B1BB45E370013ADE6 /* ContactsOperationsTests.swift in Sources */,
 				65882F3B1BAF608A003F74B6 /* AddressBookConditionTests.swift in Sources */,
 				65882F3C1BAF608A003F74B6 /* AddressBookTests.swift in Sources */,
 				65882F231BAF6083003F74B6 /* CalendarConditionTests.swift in Sources */,
@@ -1105,6 +1147,7 @@
 				65EEC1CC1BAF468D0020A9BD /* GatedOperation.swift in Sources */,
 				65EEC1CB1BAF468D0020A9BD /* DelayOperation.swift in Sources */,
 				65EEC1C91BAF468D0020A9BD /* BlockOperation.swift in Sources */,
+				651E39551BB454BF0013ADE6 /* ContactsCondition.swift in Sources */,
 				65EEC23D1BAF4F610020A9BD /* Reachability.swift in Sources */,
 				65EEC1CD1BAF468D0020A9BD /* GroupOperation.swift in Sources */,
 				65EEC1C61BAF468D0020A9BD /* BlockObserver.swift in Sources */,
@@ -1124,6 +1167,7 @@
 				65EEC23F1BAF4F610020A9BD /* ReachableOperation.swift in Sources */,
 				65EEC1CE1BAF468D0020A9BD /* LoggingObserver.swift in Sources */,
 				65EEC1C01BAF468D0020A9BD /* MutuallyExclusive.swift in Sources */,
+				651E394E1BB454310013ADE6 /* ContactsOperation.swift in Sources */,
 				65EEC1CA1BAF468D0020A9BD /* ComposedOperation.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1132,6 +1176,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				651E395C1BB45E370013ADE6 /* ContactsOperationsTests.swift in Sources */,
 				65882F101BAF6078003F74B6 /* MutualExclusiveTests.swift in Sources */,
 				65882F111BAF6078003F74B6 /* NegatedConditionTests.swift in Sources */,
 				65882F0D1BAF6078003F74B6 /* GatedOperationTests.swift in Sources */,
@@ -1179,9 +1224,11 @@
 				65EEC1FD1BAF4C6F0020A9BD /* NegatedCondition.swift in Sources */,
 				65EEC1FA1BAF4C6F0020A9BD /* Support.swift in Sources */,
 				65EEC20A1BAF4C6F0020A9BD /* LoggingObserver.swift in Sources */,
+				651E39531BB454BF0013ADE6 /* ContactsCondition.swift in Sources */,
 				65EEC1FC1BAF4C6F0020A9BD /* MutuallyExclusive.swift in Sources */,
 				65EEC2431BAF4F780020A9BD /* Reachability.swift in Sources */,
 				65EEC2061BAF4C6F0020A9BD /* ComposedOperation.swift in Sources */,
+				651E394C1BB454310013ADE6 /* ContactsOperation.swift in Sources */,
 				65EEC24C1BAF4FD40020A9BD /* UserConfirmationCondition.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1190,6 +1237,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				651E395A1BB45E370013ADE6 /* ContactsOperationsTests.swift in Sources */,
 				65882EF41BAF606F003F74B6 /* MutualExclusiveTests.swift in Sources */,
 				65882EF51BAF606F003F74B6 /* NegatedConditionTests.swift in Sources */,
 				65882EF11BAF606F003F74B6 /* GatedOperationTests.swift in Sources */,

--- a/Operations.xcodeproj/project.pbxproj
+++ b/Operations.xcodeproj/project.pbxproj
@@ -20,6 +20,14 @@
 		651E395A1BB45E370013ADE6 /* ContactsOperationsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 651E39591BB45E370013ADE6 /* ContactsOperationsTests.swift */; settings = {ASSET_TAGS = (); }; };
 		651E395B1BB45E370013ADE6 /* ContactsOperationsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 651E39591BB45E370013ADE6 /* ContactsOperationsTests.swift */; settings = {ASSET_TAGS = (); }; };
 		651E395C1BB45E370013ADE6 /* ContactsOperationsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 651E39591BB45E370013ADE6 /* ContactsOperationsTests.swift */; settings = {ASSET_TAGS = (); }; };
+		651E39731BB48C790013ADE6 /* AddressBook.swift in Sources */ = {isa = PBXBuildFile; fileRef = 651E39701BB48C790013ADE6 /* AddressBook.swift */; settings = {ASSET_TAGS = (); }; };
+		651E39741BB48C790013ADE6 /* AddressBookConditions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 651E39711BB48C790013ADE6 /* AddressBookConditions.swift */; settings = {ASSET_TAGS = (); }; };
+		651E39751BB48C790013ADE6 /* AddressBookOperations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 651E39721BB48C790013ADE6 /* AddressBookOperations.swift */; settings = {ASSET_TAGS = (); }; };
+		651E39771BB48C8F0013ADE6 /* AddressBookUIOperations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 651E39761BB48C8F0013ADE6 /* AddressBookUIOperations.swift */; settings = {ASSET_TAGS = (); }; };
+		651E39781BB48CDB0013ADE6 /* AddressBook.swift in Sources */ = {isa = PBXBuildFile; fileRef = 651E39701BB48C790013ADE6 /* AddressBook.swift */; settings = {ASSET_TAGS = (); }; };
+		651E39791BB48CDB0013ADE6 /* AddressBookConditions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 651E39711BB48C790013ADE6 /* AddressBookConditions.swift */; settings = {ASSET_TAGS = (); }; };
+		651E397A1BB48CDB0013ADE6 /* AddressBookOperations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 651E39721BB48C790013ADE6 /* AddressBookOperations.swift */; settings = {ASSET_TAGS = (); }; };
+		651E397E1BB48D970013ADE6 /* ContactsUIOperations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 651E397D1BB48D970013ADE6 /* ContactsUIOperations.swift */; settings = {ASSET_TAGS = (); }; };
 		652F5A601BAF7A2800BB5F71 /* ExclusivityManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65EEC1731BAF44E80020A9BD /* ExclusivityManager.swift */; };
 		652F5A611BAF7A2800BB5F71 /* Operation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65EEC17A1BAF44E80020A9BD /* Operation.swift */; };
 		652F5A621BAF7A2800BB5F71 /* OperationCondition.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65EEC17B1BAF44E80020A9BD /* OperationCondition.swift */; };
@@ -201,9 +209,6 @@
 		65EEC2091BAF4C6F0020A9BD /* GroupOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65EEC1751BAF44E80020A9BD /* GroupOperation.swift */; };
 		65EEC20A1BAF4C6F0020A9BD /* LoggingObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65EEC1761BAF44E80020A9BD /* LoggingObserver.swift */; };
 		65EEC20B1BAF4C6F0020A9BD /* UIOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65EEC16C1BAF44E80020A9BD /* UIOperation.swift */; };
-		65EEC2261BAF4F230020A9BD /* AddressBook.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65EEC20F1BAF4F230020A9BD /* AddressBook.swift */; };
-		65EEC2271BAF4F230020A9BD /* AddressBookConditions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65EEC2101BAF4F230020A9BD /* AddressBookConditions.swift */; };
-		65EEC2281BAF4F230020A9BD /* AddressBookOperations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65EEC2111BAF4F230020A9BD /* AddressBookOperations.swift */; };
 		65EEC22B1BAF4F230020A9BD /* HealthCondition.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65EEC2161BAF4F230020A9BD /* HealthCondition.swift */; };
 		65EEC22C1BAF4F230020A9BD /* LocationCondition.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65EEC2171BAF4F230020A9BD /* LocationCondition.swift */; };
 		65EEC22D1BAF4F230020A9BD /* LocationOperations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65EEC2181BAF4F230020A9BD /* LocationOperations.swift */; };
@@ -263,6 +268,11 @@
 		651E394B1BB454310013ADE6 /* ContactsOperation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ContactsOperation.swift; path = Contacts/Shared/ContactsOperation.swift; sourceTree = "<group>"; };
 		651E39521BB454BF0013ADE6 /* ContactsCondition.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ContactsCondition.swift; path = Contacts/Shared/ContactsCondition.swift; sourceTree = "<group>"; };
 		651E39591BB45E370013ADE6 /* ContactsOperationsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ContactsOperationsTests.swift; path = Contacts/ContactsOperationsTests.swift; sourceTree = "<group>"; };
+		651E39701BB48C790013ADE6 /* AddressBook.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AddressBook.swift; sourceTree = "<group>"; };
+		651E39711BB48C790013ADE6 /* AddressBookConditions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AddressBookConditions.swift; sourceTree = "<group>"; };
+		651E39721BB48C790013ADE6 /* AddressBookOperations.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AddressBookOperations.swift; sourceTree = "<group>"; };
+		651E39761BB48C8F0013ADE6 /* AddressBookUIOperations.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AddressBookUIOperations.swift; sourceTree = "<group>"; };
+		651E397D1BB48D970013ADE6 /* ContactsUIOperations.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ContactsUIOperations.swift; path = Contacts/iOS/ContactsUIOperations.swift; sourceTree = "<group>"; };
 		652F5A491BAF79BA00BB5F71 /* Operations.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Operations.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		65882E801BAF5B00003F74B6 /* Operations.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Operations.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		65882EB01BAF6052003F74B6 /* AlertOperationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AlertOperationTests.swift; sourceTree = "<group>"; };
@@ -325,9 +335,6 @@
 		65EEC1AB1BAF46210020A9BD /* Operations-OSXTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Operations-OSXTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		65EEC1DE1BAF4B230020A9BD /* Operations.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Operations.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		65EEC1E71BAF4B230020A9BD /* Operations-iOS-ExtensionTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Operations-iOS-ExtensionTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
-		65EEC20F1BAF4F230020A9BD /* AddressBook.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AddressBook.swift; sourceTree = "<group>"; };
-		65EEC2101BAF4F230020A9BD /* AddressBookConditions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AddressBookConditions.swift; sourceTree = "<group>"; };
-		65EEC2111BAF4F230020A9BD /* AddressBookOperations.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AddressBookOperations.swift; sourceTree = "<group>"; };
 		65EEC2161BAF4F230020A9BD /* HealthCondition.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HealthCondition.swift; sourceTree = "<group>"; };
 		65EEC2171BAF4F230020A9BD /* LocationCondition.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LocationCondition.swift; sourceTree = "<group>"; };
 		65EEC2181BAF4F230020A9BD /* LocationOperations.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LocationOperations.swift; sourceTree = "<group>"; };
@@ -411,8 +418,8 @@
 		651E39511BB454380013ADE6 /* Contacts */ = {
 			isa = PBXGroup;
 			children = (
-				651E394B1BB454310013ADE6 /* ContactsOperation.swift */,
-				651E39521BB454BF0013ADE6 /* ContactsCondition.swift */,
+				651E397C1BB48D7D0013ADE6 /* iOS */,
+				651E397B1BB48D6F0013ADE6 /* Shared */,
 			);
 			name = Contacts;
 			sourceTree = "<group>";
@@ -423,6 +430,34 @@
 				651E39591BB45E370013ADE6 /* ContactsOperationsTests.swift */,
 			);
 			name = Contacts;
+			sourceTree = "<group>";
+		};
+		651E396F1BB48C790013ADE6 /* iOS */ = {
+			isa = PBXGroup;
+			children = (
+				651E39701BB48C790013ADE6 /* AddressBook.swift */,
+				651E39711BB48C790013ADE6 /* AddressBookConditions.swift */,
+				651E39721BB48C790013ADE6 /* AddressBookOperations.swift */,
+				651E39761BB48C8F0013ADE6 /* AddressBookUIOperations.swift */,
+			);
+			path = iOS;
+			sourceTree = "<group>";
+		};
+		651E397B1BB48D6F0013ADE6 /* Shared */ = {
+			isa = PBXGroup;
+			children = (
+				651E39521BB454BF0013ADE6 /* ContactsCondition.swift */,
+				651E394B1BB454310013ADE6 /* ContactsOperation.swift */,
+			);
+			name = Shared;
+			sourceTree = "<group>";
+		};
+		651E397C1BB48D7D0013ADE6 /* iOS */ = {
+			isa = PBXGroup;
+			children = (
+				651E397D1BB48D970013ADE6 /* ContactsUIOperations.swift */,
+			);
+			name = iOS;
 			sourceTree = "<group>";
 		};
 		65882E6C1BAF578E003F74B6 /* Conditions */ = {
@@ -637,19 +672,9 @@
 		65EEC20D1BAF4F230020A9BD /* AddressBook */ = {
 			isa = PBXGroup;
 			children = (
-				65EEC20E1BAF4F230020A9BD /* iOS */,
+				651E396F1BB48C790013ADE6 /* iOS */,
 			);
 			path = AddressBook;
-			sourceTree = "<group>";
-		};
-		65EEC20E1BAF4F230020A9BD /* iOS */ = {
-			isa = PBXGroup;
-			children = (
-				65EEC20F1BAF4F230020A9BD /* AddressBook.swift */,
-				65EEC2101BAF4F230020A9BD /* AddressBookConditions.swift */,
-				65EEC2111BAF4F230020A9BD /* AddressBookOperations.swift */,
-			);
-			path = iOS;
 			sourceTree = "<group>";
 		};
 		65EEC2141BAF4F230020A9BD /* Features */ = {
@@ -1059,32 +1084,34 @@
 				65EEC22D1BAF4F230020A9BD /* LocationOperations.swift in Sources */,
 				65EEC1811BAF44E80020A9BD /* AlertOperation.swift in Sources */,
 				65EEC18E1BAF44E80020A9BD /* MutuallyExclusive.swift in Sources */,
+				651E39771BB48C8F0013ADE6 /* AddressBookUIOperations.swift in Sources */,
 				65EEC18C1BAF44E80020A9BD /* GroupOperation.swift in Sources */,
 				65EEC1831BAF44E80020A9BD /* NetworkObserver.swift in Sources */,
 				65EEC1891BAF44E80020A9BD /* DelayOperation.swift in Sources */,
 				65EEC22B1BAF4F230020A9BD /* HealthCondition.swift in Sources */,
+				651E397E1BB48D970013ADE6 /* ContactsUIOperations.swift in Sources */,
 				65EEC1971BAF44E80020A9BD /* TimeoutObserver.swift in Sources */,
 				65EEC18A1BAF44E80020A9BD /* ExclusivityManager.swift in Sources */,
 				65EEC1951BAF44E80020A9BD /* SlientCondition.swift in Sources */,
 				651E394D1BB454310013ADE6 /* ContactsOperation.swift in Sources */,
 				65EEC1821BAF44E80020A9BD /* BackgroundObserver.swift in Sources */,
 				65EEC2301BAF4F230020A9BD /* RemoteNotificationCondition.swift in Sources */,
+				651E39731BB48C790013ADE6 /* AddressBook.swift in Sources */,
 				65EEC1841BAF44E80020A9BD /* UIOperation.swift in Sources */,
 				651E39541BB454BF0013ADE6 /* ContactsCondition.swift in Sources */,
 				65EEC2351BAF4F230020A9BD /* CloudCondition.swift in Sources */,
 				65EEC1851BAF44E80020A9BD /* BlockCondition.swift in Sources */,
-				65EEC2271BAF4F230020A9BD /* AddressBookConditions.swift in Sources */,
 				65EEC1941BAF44E80020A9BD /* OperationQueue.swift in Sources */,
 				65EEC1961BAF44E80020A9BD /* Support.swift in Sources */,
 				65EEC2331BAF4F230020A9BD /* WebpageOperation.swift in Sources */,
 				65EEC18F1BAF44E80020A9BD /* NegatedCondition.swift in Sources */,
 				65EEC22E1BAF4F230020A9BD /* PassbookCondition.swift in Sources */,
+				651E39751BB48C790013ADE6 /* AddressBookOperations.swift in Sources */,
 				65EEC2321BAF4F230020A9BD /* UserNotificationCondition.swift in Sources */,
 				65EEC1881BAF44E80020A9BD /* ComposedOperation.swift in Sources */,
 				65EEC22F1BAF4F230020A9BD /* PhotosCondition.swift in Sources */,
 				65EEC18B1BAF44E80020A9BD /* GatedOperation.swift in Sources */,
 				65EEC2361BAF4F230020A9BD /* CloudKitOperation.swift in Sources */,
-				65EEC2281BAF4F230020A9BD /* AddressBookOperations.swift in Sources */,
 				65EEC1861BAF44E80020A9BD /* BlockObserver.swift in Sources */,
 				65EEC2391BAF4F230020A9BD /* ReachableOperation.swift in Sources */,
 				65EEC2381BAF4F230020A9BD /* ReachabilityCondition.swift in Sources */,
@@ -1094,7 +1121,7 @@
 				65EEC2341BAF4F230020A9BD /* CalendarCondition.swift in Sources */,
 				65EEC1871BAF44E80020A9BD /* BlockOperation.swift in Sources */,
 				65EEC1901BAF44E80020A9BD /* NoFailedDependenciesCondition.swift in Sources */,
-				65EEC2261BAF4F230020A9BD /* AddressBook.swift in Sources */,
+				651E39741BB48C790013ADE6 /* AddressBookConditions.swift in Sources */,
 				65EEC18D1BAF44E80020A9BD /* LoggingObserver.swift in Sources */,
 				65EEC1921BAF44E80020A9BD /* OperationCondition.swift in Sources */,
 				65EEC2371BAF4F230020A9BD /* Reachability.swift in Sources */,
@@ -1202,6 +1229,7 @@
 				65EEC1F51BAF4C6F0020A9BD /* ExclusivityManager.swift in Sources */,
 				65EEC2081BAF4C6F0020A9BD /* GatedOperation.swift in Sources */,
 				65EEC2421BAF4F780020A9BD /* CloudKitOperation.swift in Sources */,
+				651E397A1BB48CDB0013ADE6 /* AddressBookOperations.swift in Sources */,
 				65EEC2071BAF4C6F0020A9BD /* DelayOperation.swift in Sources */,
 				65EEC2441BAF4F780020A9BD /* ReachabilityCondition.swift in Sources */,
 				65EEC2051BAF4C6F0020A9BD /* BlockOperation.swift in Sources */,
@@ -1228,7 +1256,9 @@
 				65EEC1FC1BAF4C6F0020A9BD /* MutuallyExclusive.swift in Sources */,
 				65EEC2431BAF4F780020A9BD /* Reachability.swift in Sources */,
 				65EEC2061BAF4C6F0020A9BD /* ComposedOperation.swift in Sources */,
+				651E39781BB48CDB0013ADE6 /* AddressBook.swift in Sources */,
 				651E394C1BB454310013ADE6 /* ContactsOperation.swift in Sources */,
+				651E39791BB48CDB0013ADE6 /* AddressBookConditions.swift in Sources */,
 				65EEC24C1BAF4FD40020A9BD /* UserConfirmationCondition.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Operations/Core/Shared/LoggingObserver.swift
+++ b/Operations/Core/Shared/LoggingObserver.swift
@@ -47,7 +47,7 @@ public struct LoggingObserver: OperationObserver {
     }
 
     public func operationDidFinish(operation: Operation, errors: [ErrorType]) {
-        let detail = errors.count > 0 ? "\(errors.count) error(s)" : "no errors"
+        let detail = errors.count > 0 ? "error(s): \(errors)" : "no errors"
         log("\(operationName(operation)): finished with \(detail).")
     }
 

--- a/Operations/Extras/AddressBook/iOS/AddressBookOperations.swift
+++ b/Operations/Extras/AddressBook/iOS/AddressBookOperations.swift
@@ -8,7 +8,6 @@
 
 import Foundation
 import AddressBook
-import AddressBookUI
 
 // MARK: - Address Book Operation
 
@@ -383,102 +382,6 @@ public class AddressBookMapPeople<T>: AddressBookGetResource {
     func mapPeople() -> ErrorType? {
         results = addressBookPeople().flatMap { self.transform($0) }
         return .None
-    }
-}
-
-/**
-Displays an `ABPersonViewController`. To enable actions or editing, create
-an `ABPersonViewController` instance and configure these settings. Pass it
-to this operation as the first argument.
-
-The operation will locate the `ABRecordRef` for the person and set this
-on the controller in addition to the `ABAddressBookRef`.
-
-Select and appropriate `DisplayStyle` to configure how the controller should
-be displayed, either presented, show, show detail. For each style, associate
-the sending view controller. Therefore, to push a person controller:
-
-    let show = AddressBookDisplayPersonViewController(
-        personWithId: addressBookID,
-        displayFromControllerWithStyle: .Show(self),
-        delegate: self,
-        sender: self)
-    queue.addOperation(show)
-
-To configure the controller, you can do this:
-
-    let controller = ABPersonViewController()
-    controller.allowEditing = true
-    let show = AddressBookDisplayPersonViewController(
-        personViewController: controller,
-        personWithId: addressBookID,
-        displayFromControllerWithStyle: .Show(self),
-        delegate: self,
-        sender: self)
-    queue.addOperation(show)
-*/
-public class AddressBookDisplayPersonViewController<F: PresentingViewController>: GroupOperation {
-
-    let delegate: ABPersonViewControllerDelegate
-    let ui: UIOperation<ABPersonViewController, F>
-    let get: AddressBookGetResource
-
-    public convenience init(personViewController: ABPersonViewController? = .None, personWithID id: ABRecordID, displayControllerFrom from: ViewControllerDisplayStyle<F>, delegate: ABPersonViewControllerDelegate, sender: AnyObject? = .None) {
-        self.init(registrar: SystemAddressBookRegistrar(), personViewController: personViewController, personWithID: id, displayControllerFrom: from, delegate: delegate, sender: sender)
-    }
-
-    init(registrar: AddressBookPermissionRegistrar, personViewController: ABPersonViewController? = .None, personWithID id: ABRecordID, displayControllerFrom from: ViewControllerDisplayStyle<F>, delegate: ABPersonViewControllerDelegate, sender: AnyObject? = .None) {
-
-        self.ui = UIOperation(controller: personViewController ?? ABPersonViewController(), displayControllerFrom: from, sender: sender)
-        self.delegate = delegate
-        self.get = AddressBookGetResource(registrar: registrar)
-        self.get.personQuery = .ID(id)
-        super.init(operations: [ get ])
-    }
-
-    public override func operationDidFinish(operation: NSOperation, withErrors errors: [ErrorType]) {
-        if errors.isEmpty && get == operation, let person = get.addressBookPerson {
-            ui.controller.personViewDelegate = delegate
-            ui.controller.displayedPerson = person.storage
-            ui.controller.addressBook = get.addressBook.addressBook
-            addOperation(ui)
-        }
-    }
-}
-
-public class AddressBookDisplayNewPersonViewController<F: PresentingViewController>: GroupOperation {
-
-    let delegate: ABNewPersonViewControllerDelegate
-    let ui: UIOperation<ABNewPersonViewController, F>
-    let get: AddressBookGetResource
-
-    public convenience init(displayControllerFrom from: ViewControllerDisplayStyle<F>, delegate: ABNewPersonViewControllerDelegate, sender: AnyObject? = .None, addToGroupWithName groupName: String? = .None) {
-        self.init(registrar: SystemAddressBookRegistrar(), displayControllerFrom: from, delegate: delegate, sender: sender, addToGroupWithName: groupName)
-    }
-
-    init(registrar: AddressBookPermissionRegistrar, displayControllerFrom from: ViewControllerDisplayStyle<F>, delegate: ABNewPersonViewControllerDelegate, sender: AnyObject? = .None, addToGroupWithName groupName: String? = .None) {
-
-        self.ui = UIOperation(controller: ABNewPersonViewController(), displayControllerFrom: from, sender: sender)
-        self.delegate = delegate
-        self.get = AddressBookGetResource(registrar: registrar)
-        if let groupName = groupName {
-            get.groupQuery = .Name(groupName)
-        }
-        super.init(operations: [ get ])
-    }
-
-    public override func operationDidFinish(operation: NSOperation, withErrors errors: [ErrorType]) {
-        if errors.isEmpty && get == operation {
-
-            ui.controller.newPersonViewDelegate = delegate
-            ui.controller.addressBook = get.addressBook.addressBook
-
-            if let group = get.addressBookGroup {
-                ui.controller.parentGroup = group.storage
-            }
-
-            addOperation(ui)
-        }
     }
 }
 

--- a/Operations/Extras/AddressBook/iOS/AddressBookUIOperations.swift
+++ b/Operations/Extras/AddressBook/iOS/AddressBookUIOperations.swift
@@ -1,0 +1,112 @@
+//
+//  AddressBookUIOperations.swift
+//  Operations
+//
+//  Created by Daniel Thorpe on 24/09/2015.
+//  Copyright © 2015 Dan Thorpe. All rights reserved.
+//
+
+import Foundation
+import AddressBook
+import AddressBookUI
+
+
+
+/**
+Displays an `ABPersonViewController`. To enable actions or editing, create
+an `ABPersonViewController` instance and configure these settings. Pass it
+to this operation as the first argument.
+
+The operation will locate the `ABRecordRef` for the person and set this
+on the controller in addition to the `ABAddressBookRef`.
+
+Select and appropriate `DisplayStyle` to configure how the controller should
+be displayed, either presented, show, show detail. For each style, associate
+the sending view controller. Therefore, to push a person controller:
+
+    let show = AddressBookDisplayPersonViewController(
+      personWithId: addressBookID,
+      displayFromControllerWithStyle: .Show(self),
+      delegate: self,
+      sender: self
+    )
+    queue.addOperation(show)
+
+To configure the controller, you can do this:
+
+    let controller = ABPersonViewController()
+    controller.allowEditing = true
+    let show = AddressBookDisplayPersonViewController(
+      personViewController: controller,
+      personWithId: addressBookID,
+      displayFromControllerWithStyle: .Show(self),
+      delegate: self,
+      sender: self
+    )
+    queue.addOperation(show)
+*/
+public class AddressBookDisplayPersonViewController<F: PresentingViewController>: GroupOperation {
+
+    let delegate: ABPersonViewControllerDelegate
+    let ui: UIOperation<ABPersonViewController, F>
+    let get: AddressBookGetResource
+
+    public convenience init(personViewController: ABPersonViewController? = .None, personWithID id: ABRecordID, displayControllerFrom from: ViewControllerDisplayStyle<F>, delegate: ABPersonViewControllerDelegate, sender: AnyObject? = .None) {
+        self.init(registrar: SystemAddressBookRegistrar(), personViewController: personViewController, personWithID: id, displayControllerFrom: from, delegate: delegate, sender: sender)
+    }
+
+    init(registrar: AddressBookPermissionRegistrar, personViewController: ABPersonViewController? = .None, personWithID id: ABRecordID, displayControllerFrom from: ViewControllerDisplayStyle<F>, delegate: ABPersonViewControllerDelegate, sender: AnyObject? = .None) {
+
+        self.ui = UIOperation(controller: personViewController ?? ABPersonViewController(), displayControllerFrom: from, sender: sender)
+        self.delegate = delegate
+        self.get = AddressBookGetResource(registrar: registrar)
+        self.get.personQuery = .ID(id)
+        super.init(operations: [ get ])
+    }
+
+    public override func operationDidFinish(operation: NSOperation, withErrors errors: [ErrorType]) {
+        if errors.isEmpty && get == operation, let person = get.addressBookPerson {
+            ui.controller.personViewDelegate = delegate
+            ui.controller.displayedPerson = person.storage
+            ui.controller.addressBook = get.addressBook.addressBook
+            addOperation(ui)
+        }
+    }
+}
+
+public class AddressBookDisplayNewPersonViewController<F: PresentingViewController>: GroupOperation {
+
+    let delegate: ABNewPersonViewControllerDelegate
+    let ui: UIOperation<ABNewPersonViewController, F>
+    let get: AddressBookGetResource
+
+    public convenience init(displayControllerFrom from: ViewControllerDisplayStyle<F>, delegate: ABNewPersonViewControllerDelegate, sender: AnyObject? = .None, addToGroupWithName groupName: String? = .None) {
+        self.init(registrar: SystemAddressBookRegistrar(), displayControllerFrom: from, delegate: delegate, sender: sender, addToGroupWithName: groupName)
+    }
+
+    init(registrar: AddressBookPermissionRegistrar, displayControllerFrom from: ViewControllerDisplayStyle<F>, delegate: ABNewPersonViewControllerDelegate, sender: AnyObject? = .None, addToGroupWithName groupName: String? = .None) {
+
+        self.ui = UIOperation(controller: ABNewPersonViewController(), displayControllerFrom: from, sender: sender)
+        self.delegate = delegate
+        self.get = AddressBookGetResource(registrar: registrar)
+        if let groupName = groupName {
+            get.groupQuery = .Name(groupName)
+        }
+        super.init(operations: [ get ])
+    }
+
+    public override func operationDidFinish(operation: NSOperation, withErrors errors: [ErrorType]) {
+        if errors.isEmpty && get == operation {
+
+            ui.controller.newPersonViewDelegate = delegate
+            ui.controller.addressBook = get.addressBook.addressBook
+
+            if let group = get.addressBookGroup {
+                ui.controller.parentGroup = group.storage
+            }
+            
+            addOperation(ui)
+        }
+    }
+}
+

--- a/Operations/Extras/Contacts/Shared/ContactsCondition.swift
+++ b/Operations/Extras/Contacts/Shared/ContactsCondition.swift
@@ -9,35 +9,35 @@
 import Contacts
 
 @available(iOS 9.0, OSX 10.11, *)
-public struct _ContactsCondition<Store: ContactsPermissionRegistrar>: OperationCondition {
+public struct _ContactsCondition<Store: ContactStoreType>: OperationCondition {
 
     public let name = "Contacts"
     public let isMutuallyExclusive = false
 
     let entityType: CNEntityType
-    let registrar: Store
+    let store: Store
 
     public init(entityType: CNEntityType = .Contacts) {
         self.entityType = entityType
-        registrar = Store()
+        store = Store()
     }
 
     init(entityType: CNEntityType = .Contacts, registrar: Store) {
         self.entityType = entityType
-        self.registrar = registrar
+        self.store = registrar
     }
 
     public func dependencyForOperation(operation: Operation) -> NSOperation? {
-        switch registrar.opr_authorizationStatusForEntityType(entityType) {
+        switch store.opr_authorizationStatusForEntityType(entityType) {
         case .NotDetermined:
-            return _ContactsAccess(entityType: entityType, contactStore: registrar)
+            return _ContactsAccess(entityType: entityType, contactStore: store)
         default:
             return .None
         }
     }
 
     public func evaluateForOperation(operation: Operation, completion: OperationConditionResult -> Void) {
-        switch registrar.opr_authorizationStatusForEntityType(entityType) {
+        switch store.opr_authorizationStatusForEntityType(entityType) {
         case .Authorized:
             completion(.Satisfied)
         case .Denied:
@@ -51,4 +51,4 @@ public struct _ContactsCondition<Store: ContactsPermissionRegistrar>: OperationC
 }
 
 @available(iOS 9.0, OSX 10.11, *)
-public typealias ContactsCondition = _ContactsCondition<CNContactStore>
+public typealias ContactsCondition = _ContactsCondition<SystemContactStore>

--- a/Operations/Extras/Contacts/Shared/ContactsCondition.swift
+++ b/Operations/Extras/Contacts/Shared/ContactsCondition.swift
@@ -1,0 +1,82 @@
+//
+//  ContactsCondition.swift
+//  Operations
+//
+//  Created by Daniel Thorpe on 24/09/2015.
+//  Copyright © 2015 Dan Thorpe. All rights reserved.
+//
+
+import Contacts
+
+@available(iOS 9.0, *)
+protocol ContactsPermissionRegistrar {
+    func opr_authorizationStatusForEntityType(entityType: CNEntityType) -> CNAuthorizationStatus
+    func opr_requestAccessForEntityType(entityType: CNEntityType, completion: (Bool, NSError?) -> Void)
+}
+
+public enum ContactsPermissionsError: ErrorType {
+    case ContactsUnknownErrorOccured
+    case ContactsErrorOccured(NSError)
+    case ContactsAccessDenied
+}
+
+@available(iOS 9.0, *)
+extension CNContactStore: ContactsPermissionRegistrar {
+    func opr_authorizationStatusForEntityType(entityType: CNEntityType) -> CNAuthorizationStatus {
+        return self.dynamicType.authorizationStatusForEntityType(entityType)
+    }
+    func opr_requestAccessForEntityType(entityType: CNEntityType, completion: (Bool, NSError?) -> Void) {
+        requestAccessForEntityType(entityType, completionHandler: completion)
+    }
+}
+
+@available(iOS 9.0, *)
+public struct ContactsCondition: OperationCondition {
+
+    public enum Error: ErrorType {
+        case AuthorizationDenied
+        case AuthorizationRestricted
+        case AuthorizationNotDetermined
+    }
+
+    public let name = "Address Book"
+    public let isMutuallyExclusive = false
+
+    let entityType: CNEntityType
+    let registrar: ContactsPermissionRegistrar
+
+    public init(entityType: CNEntityType = .Contacts) {
+        self.entityType = entityType
+        registrar = CNContactStore()
+    }
+
+    init(entityType: CNEntityType = .Contacts, registrar: ContactsPermissionRegistrar) {
+        self.entityType = entityType
+        self.registrar = registrar
+    }
+
+    public func dependencyForOperation(operation: Operation) -> NSOperation? {
+        switch registrar.opr_authorizationStatusForEntityType(entityType) {
+        case .NotDetermined:
+            return ContactsOperation(entityType: entityType, registrar: registrar)
+        default:
+            return .None
+        }
+    }
+
+    public func evaluateForOperation(operation: Operation, completion: OperationConditionResult -> Void) {
+        switch registrar.opr_authorizationStatusForEntityType(entityType) {
+        case .Authorized:
+            completion(.Satisfied)
+        case .Denied:
+            completion(.Failed(Error.AuthorizationDenied))
+        case .Restricted:
+            completion(.Failed(Error.AuthorizationRestricted))
+        case .NotDetermined:
+            completion(.Failed(Error.AuthorizationNotDetermined))
+        }
+    }
+}
+
+
+

--- a/Operations/Extras/Contacts/Shared/ContactsCondition.swift
+++ b/Operations/Extras/Contacts/Shared/ContactsCondition.swift
@@ -8,19 +8,20 @@
 
 import Contacts
 
-@available(iOS 9.0, *)
+@available(iOS 9.0, OSX 10.11, *)
 protocol ContactsPermissionRegistrar {
     func opr_authorizationStatusForEntityType(entityType: CNEntityType) -> CNAuthorizationStatus
     func opr_requestAccessForEntityType(entityType: CNEntityType, completion: (Bool, NSError?) -> Void)
 }
 
-public enum ContactsPermissionsError: ErrorType {
+@available(iOS 9.0, OSX 10.11, *)
+public enum ContactsPermissionError: ErrorType {
     case ContactsUnknownErrorOccured
     case ContactsErrorOccured(NSError)
     case ContactsAccessDenied
 }
 
-@available(iOS 9.0, *)
+@available(iOS 9.0, OSX 10.11, *)
 extension CNContactStore: ContactsPermissionRegistrar {
     func opr_authorizationStatusForEntityType(entityType: CNEntityType) -> CNAuthorizationStatus {
         return self.dynamicType.authorizationStatusForEntityType(entityType)
@@ -30,7 +31,7 @@ extension CNContactStore: ContactsPermissionRegistrar {
     }
 }
 
-@available(iOS 9.0, *)
+@available(iOS 9.0, OSX 10.11, *)
 public struct ContactsCondition: OperationCondition {
 
     public enum Error: ErrorType {
@@ -39,7 +40,7 @@ public struct ContactsCondition: OperationCondition {
         case AuthorizationNotDetermined
     }
 
-    public let name = "Address Book"
+    public let name = "Contacts"
     public let isMutuallyExclusive = false
 
     let entityType: CNEntityType

--- a/Operations/Extras/Contacts/Shared/ContactsOperation.swift
+++ b/Operations/Extras/Contacts/Shared/ContactsOperation.swift
@@ -115,7 +115,7 @@ public typealias ContactsGetGroup = _ContactsGetGroup<CNContactStore>
 
 // MARK: - Testable Class Interfaces
 
-// MARK: - ContactsOperation
+// MARK: - ContactsAccess
 
 @available(iOS 9.0, OSX 10.11, *)
 public class _ContactsAccess<Store: ContactsPermissionRegistrar>: Operation {
@@ -170,6 +170,8 @@ public class _ContactsAccess<Store: ContactsPermissionRegistrar>: Operation {
         // no-op
     }
 }
+
+// MARK: - ContactsOperation
 
 @available(iOS 9.0, OSX 10.11, *)
 public class _ContactsOperation<Store: ContactStoreType>: _ContactsAccess<Store> {
@@ -234,15 +236,11 @@ public class _ContactsGetContacts<Store: ContactStoreType>: _ContactsOperation<S
         return contacts.first
     }
 
-    public convenience init(identifier: String, keysToFetch: [CNKeyDescriptor], containerId: CNContainer.ID = .Default, entityType: CNEntityType = .Contacts) {
-        self.init(predicate: .WithIdentifiers([identifier]), keysToFetch: keysToFetch, containerId: containerId, entityType: entityType, contactStore: Store())
+    public convenience init(identifier: String, keysToFetch: [CNKeyDescriptor]) {
+        self.init(predicate: .WithIdentifiers([identifier]), keysToFetch: keysToFetch)
     }
 
-    public convenience init(predicate: CNContact.Predicate, keysToFetch: [CNKeyDescriptor], containerId: CNContainer.ID = .Default, entityType: CNEntityType = .Contacts) {
-        self.init(predicate: predicate, keysToFetch: keysToFetch, containerId: containerId, entityType: entityType, contactStore: Store())
-    }
-
-    init(predicate: CNContact.Predicate, keysToFetch: [CNKeyDescriptor], containerId: CNContainer.ID = .Default, entityType: CNEntityType = .Contacts, contactStore: Store) {
+    public init(predicate: CNContact.Predicate, keysToFetch: [CNKeyDescriptor], containerId: CNContainer.ID = .Default, entityType: CNEntityType = .Contacts, contactStore: Store = Store()) {
         self.predicate = predicate
         self.keysToFetch = keysToFetch
         super.init(containerId: containerId, entityType: entityType, contactStore: contactStore)
@@ -264,11 +262,7 @@ public class _ContactsCreateGroup<Store: ContactStoreType>: _ContactsOperation<S
 
     let groupName: String
 
-    public convenience init(groupName: String, containerId: CNContainer.ID = .Default, entityType: CNEntityType = .Contacts) {
-        self.init(groupName: groupName, containerId: containerId, entityType: entityType, contactStore: Store())
-    }
-
-    init(groupName: String, containerId: CNContainer.ID = .Default, entityType: CNEntityType = .Contacts, contactStore: Store) {
+    public init(groupName: String, containerId: CNContainer.ID = .Default, entityType: CNEntityType = .Contacts, contactStore: Store = Store()) {
         self.groupName = groupName
         super.init(containerId: containerId, entityType: entityType, contactStore: contactStore)
     }
@@ -291,12 +285,7 @@ public class _ContactsGetGroup<Store: ContactStoreType>: _ContactsOperation<Stor
 
     public var group: CNGroup? = .None
 
-    public init(groupName: String, containerId: CNContainer.ID = .Default, entityType: CNEntityType = .Contacts) {
-        self.groupName = groupName
-        super.init(entityType: entityType, containerId: containerId, contactStore: Store())
-    }
-
-    init(groupName: String, containerId: CNContainer.ID = .Default, entityType: CNEntityType = .Contacts, contactStore: Store) {
+    public init(groupName: String, containerId: CNContainer.ID = .Default, entityType: CNEntityType = .Contacts, contactStore: Store = Store()) {
         self.groupName = groupName
         super.init(containerId: containerId, entityType: entityType, contactStore: contactStore)
     }

--- a/Operations/Extras/Contacts/Shared/ContactsOperation.swift
+++ b/Operations/Extras/Contacts/Shared/ContactsOperation.swift
@@ -8,20 +8,41 @@
 
 import Contacts
 
-@available(iOS 9.0, *)
+@available(iOS 9.0, OSX 10.11, *)
 public class ContactsOperation: Operation {
 
-    let store = CNContactStore()
-    let entityType: CNEntityType
-    let registrar: ContactsPermissionRegistrar
-
-    public init(entityType: CNEntityType = .Contacts) {
-        self.entityType = entityType
-        registrar = store
+    public enum ContainerIdentifier {
+        case Default
+        case Identifier(String)
     }
 
-    init(entityType: CNEntityType = .Contacts, registrar: ContactsPermissionRegistrar) {
+    public let store = CNContactStore()
+    let registrar: ContactsPermissionRegistrar
+    let entityType: CNEntityType
+    let containerId: ContainerIdentifier
+
+    var allGroupsPredicate: NSPredicate {
+        return CNGroup.predicateForGroupsInContainerWithIdentifier(containerIdentifier)
+    }
+
+    public var containerIdentifier: String {
+        switch containerId {
+        case .Default:
+            return store.defaultContainerIdentifier()
+        case .Identifier(let id):
+            return id
+        }
+    }
+
+    public init(containerId: ContainerIdentifier = .Default, entityType: CNEntityType = .Contacts) {
         self.entityType = entityType
+        self.containerId = containerId
+        self.registrar = store
+    }
+
+    init(containerId: ContainerIdentifier = .Default, entityType: CNEntityType = .Contacts, registrar: ContactsPermissionRegistrar) {
+        self.entityType = entityType
+        self.containerId = containerId
         self.registrar = registrar
     }
 
@@ -33,25 +54,145 @@ public class ContactsOperation: Operation {
         switch registrar.opr_authorizationStatusForEntityType(entityType) {
         case .NotDetermined:
             registrar.opr_requestAccessForEntityType(entityType, completion: requestAccessDidComplete)
+        case .Authorized:
+            requestAccessDidComplete(true, error: .None)
         default:
-            finish(ContactsPermissionsError.ContactsAccessDenied)
+            finish(ContactsPermissionError.ContactsAccessDenied)
         }
     }
 
-    func requestAccessDidComplete(success: Bool, error: NSError?) {
+    final func requestAccessDidComplete(success: Bool, error: NSError?) {
         switch (success, error) {
+
         case (true, _):
-            finish(executeContactsTask())
+            do {
+                try executeContactsTask()
+                finish()
+            }
+            catch let error {
+                finish(error)
+            }
+
         case let (false, .Some(error)):
-            finish(ContactsPermissionsError.ContactsErrorOccured(error))
+            finish(ContactsPermissionError.ContactsErrorOccured(error))
+
         case (false, _):
-            finish(ContactsPermissionsError.ContactsUnknownErrorOccured)
+            finish(ContactsPermissionError.ContactsUnknownErrorOccured)
         }
     }
 
-    func executeContactsTask() -> ErrorType? {
-        return .None
+    public func executeContactsTask() throws {
+        // no-op
+    }
+
+    // Public API
+
+    public func allGroups() throws -> [CNGroup] {
+        return try store.groupsMatchingPredicate(allGroupsPredicate)
+    }
+
+    public func groupsNamed(groupName: String) throws -> [CNGroup] {
+        return try allGroups().filter { $0.name == groupName }
+    }
+
+    public func addContactsWithIdentifiers(contactIDs: [String], toGroupNamed groupName: String) throws {
+        guard contactIDs.count > 0 else { return }
+
+        let save = CNSaveRequest()
+
+        let group: CNGroup = try {
+            if let group = try self.groupsNamed(groupName).first {
+                return group
+            }
+            let group = CNMutableGroup()
+            group.name = groupName
+            save.addGroup(group, toContainerWithIdentifier: containerIdentifier)
+            return group
+        }()
+
+        let fetch = CNContactFetchRequest(keysToFetch: [CNContactIdentifierKey])
+        fetch.predicate = CNContact.predicateForContactsWithIdentifiers(contactIDs)
+        try store.enumerateContactsWithFetchRequest(fetch) { contact, _ in
+            save.addMember(contact, toGroup: group)
+        }
+        try store.executeSaveRequest(save)
     }
 }
+
+@available(iOS 9.0, OSX 10.11, *)
+public class ContactsCreateGroup: ContactsOperation {
+
+    let groupName: String
+
+    public init(groupName: String, containerId: ContainerIdentifier = .Default, entityType: CNEntityType = .Contacts) {
+        self.groupName = groupName
+        super.init(entityType: entityType, containerId: containerId)
+    }
+
+    init(groupName: String, containerId: ContainerIdentifier = .Default, entityType: CNEntityType = .Contacts, registrar: ContactsPermissionRegistrar) {
+        self.groupName = groupName
+        super.init(entityType: entityType, containerId: containerId, registrar: registrar)
+    }
+
+    public override func executeContactsTask() throws {
+        let group = CNMutableGroup()
+        group.name = groupName
+
+        let save = CNSaveRequest()
+        save.addGroup(group, toContainerWithIdentifier: containerIdentifier)
+
+        try store.executeSaveRequest(save)
+    }
+}
+
+@available(iOS 9.0, OSX 10.11, *)
+public class ContactsGetGroup: ContactsOperation {
+
+    let groupName: String
+
+    public var group: CNGroup? = .None
+
+    public init(groupName: String, containerId: ContainerIdentifier = .Default, entityType: CNEntityType = .Contacts) {
+        self.groupName = groupName
+        super.init(entityType: entityType, containerId: containerId)
+    }
+
+    init(groupName: String, containerId: ContainerIdentifier = .Default, entityType: CNEntityType = .Contacts, registrar: ContactsPermissionRegistrar) {
+        self.groupName = groupName
+        super.init(entityType: entityType, containerId: containerId, registrar: registrar)
+    }
+
+    public override func executeContactsTask() throws {
+        do {
+            group = try groupsNamed(groupName).first
+            finish()
+        }
+        catch let error {
+            finish(error)
+        }
+    }
+}
+
+
+@available(iOS 9.0, OSX 10.11, *)
+extension CNContactStore {
+
+    public func flatMapAllContactsWithFetchRequest<T>(fetchRequest: CNContactFetchRequest, transform: CNContact -> T?) throws -> [T] {
+        var result = [T]()
+        try enumerateContactsWithFetchRequest(fetchRequest) { contact, _ in
+            if let tmp = transform(contact) {
+                result.append(tmp)
+            }
+        }
+        return result
+    }
+}
+
+
+
+
+
+
+
 
 

--- a/Operations/Extras/Contacts/Shared/ContactsOperation.swift
+++ b/Operations/Extras/Contacts/Shared/ContactsOperation.swift
@@ -9,41 +9,126 @@
 import Contacts
 
 @available(iOS 9.0, OSX 10.11, *)
-public class ContactsOperation: Operation {
+public enum ContactsPermissionError: ErrorType {
+    case AuthorizationDenied
+    case AuthorizationRestricted
+    case AuthorizationNotDetermined
+    case UnknownErrorOccured
+    case ErrorOccured(NSError)
+}
 
-    public enum ContainerIdentifier {
+@available(iOS 9.0, OSX 10.11, *)
+public enum ContactsError: ErrorType {
+    case UnknownErrorOccured
+    case ErrorOccured(NSError)
+}
+
+@available(iOS 9.0, OSX 10.11, *)
+public protocol ContactsPermissionRegistrar {
+    init()    
+    func opr_authorizationStatusForEntityType(entityType: CNEntityType) -> CNAuthorizationStatus
+    func opr_requestAccessForEntityType(entityType: CNEntityType, completion: (Bool, NSError?) -> Void)
+}
+
+@available(iOS 9.0, OSX 10.11, *)
+public protocol ContactStoreType: ContactsPermissionRegistrar {
+    func opr_defaultContainerIdentifier() -> String
+    func opr_unifiedContactWithIdentifier(identifier: String, keysToFetch keys: [CNKeyDescriptor]) throws -> CNContact
+    func opr_unifiedContactsMatchingPredicate(predicate: NSPredicate, keysToFetch keys: [CNKeyDescriptor]) throws -> [CNContact]
+    func opr_groupsMatchingPredicate(predicate: NSPredicate?) throws -> [CNGroup]
+    func opr_enumerateContactsWithFetchRequest(fetchRequest: CNContactFetchRequest, usingBlock block: (CNContact, UnsafeMutablePointer<ObjCBool>) -> Void) throws
+    func opr_executeSaveRequest(saveRequest: CNSaveRequest) throws
+}
+
+@available(iOS 9.0, OSX 10.11, *)
+extension CNContainer {
+    public enum ID {
         case Default
         case Identifier(String)
-    }
 
-    public let store = CNContactStore()
-    let registrar: ContactsPermissionRegistrar
-    let entityType: CNEntityType
-    let containerId: ContainerIdentifier
-
-    var allGroupsPredicate: NSPredicate {
-        return CNGroup.predicateForGroupsInContainerWithIdentifier(containerIdentifier)
-    }
-
-    public var containerIdentifier: String {
-        switch containerId {
-        case .Default:
-            return store.defaultContainerIdentifier()
-        case .Identifier(let id):
-            return id
+        var identifier: String {
+            switch self {
+            case .Default:
+                return CNContactStore().defaultContainerIdentifier()
+            case .Identifier(let id):
+                return id
+            }
         }
     }
+}
 
-    public init(containerId: ContainerIdentifier = .Default, entityType: CNEntityType = .Contacts) {
-        self.entityType = entityType
-        self.containerId = containerId
-        self.registrar = store
+@available(iOS 9.0, OSX 10.11, *)
+extension CNContact {
+    public enum Predicate {
+        case MatchingName(String)
+        case WithIdentifiers([String])
+        case InGroupWithIdentifier(String)
+        case InContainerWithID(CNContainer.ID)
+
+        var predicate: NSPredicate {
+            switch self {
+            case .MatchingName(let name):
+                return CNContact.predicateForContactsMatchingName(name)
+            case .WithIdentifiers(let identifiers):
+                return CNContact.predicateForContactsWithIdentifiers(identifiers)
+            case .InGroupWithIdentifier(let identifier):
+                return CNContact.predicateForContactsInGroupWithIdentifier(identifier)
+            case .InContainerWithID(let id):
+                return CNContact.predicateForContactsInContainerWithIdentifier(id.identifier)
+            }
+        }
     }
+}
 
-    init(containerId: ContainerIdentifier = .Default, entityType: CNEntityType = .Contacts, registrar: ContactsPermissionRegistrar) {
+@available(iOS 9.0, OSX 10.11, *)
+extension CNGroup {
+
+    public enum Predicate {
+        case WithIdentifiers([String])
+        case InContainerWithID(CNContainer.ID)
+
+        var predicate: NSPredicate {
+            switch self {
+            case .WithIdentifiers(let identifiers):
+                return CNGroup.predicateForGroupsWithIdentifiers(identifiers)
+            case .InContainerWithID(let id):
+                return CNGroup.predicateForGroupsInContainerWithIdentifier(id.identifier)
+            }
+        }
+    }
+}
+
+// MARK: - Public Type Interfaces
+
+@available(iOS 9.0, OSX 10.11, *)
+public typealias ContactsOperation = _ContactsOperation<CNContactStore>
+
+@available(iOS 9.0, OSX 10.11, *)
+public typealias ContactsGetContacts = _ContactsGetContacts<CNContactStore>
+
+@available(iOS 9.0, OSX 10.11, *)
+public typealias ContactsCreateGroup = _ContactsCreateGroup<CNContactStore>
+
+@available(iOS 9.0, OSX 10.11, *)
+public typealias ContactsGetGroup = _ContactsGetGroup<CNContactStore>
+
+
+
+
+// MARK: - Testable Class Interfaces
+
+// MARK: - ContactsOperation
+
+@available(iOS 9.0, OSX 10.11, *)
+public class _ContactsAccess<Store: ContactsPermissionRegistrar>: Operation {
+    public let store: Store
+    let entityType: CNEntityType
+
+    init(entityType: CNEntityType = .Contacts, contactStore: Store) {
         self.entityType = entityType
-        self.containerId = containerId
-        self.registrar = registrar
+        self.store = contactStore
+        super.init()
+        name = "Contacts Access"
     }
 
     public override func execute() {
@@ -51,13 +136,15 @@ public class ContactsOperation: Operation {
     }
 
     final func requestAccess() {
-        switch registrar.opr_authorizationStatusForEntityType(entityType) {
+        switch store.opr_authorizationStatusForEntityType(entityType) {
         case .NotDetermined:
-            registrar.opr_requestAccessForEntityType(entityType, completion: requestAccessDidComplete)
+            store.opr_requestAccessForEntityType(entityType, completion: requestAccessDidComplete)
         case .Authorized:
             requestAccessDidComplete(true, error: .None)
-        default:
-            finish(ContactsPermissionError.ContactsAccessDenied)
+        case .Denied:
+            finish(ContactsPermissionError.AuthorizationDenied)
+        case .Restricted:
+            finish(ContactsPermissionError.AuthorizationRestricted)
         }
     }
 
@@ -74,21 +161,37 @@ public class ContactsOperation: Operation {
             }
 
         case let (false, .Some(error)):
-            finish(ContactsPermissionError.ContactsErrorOccured(error))
+            finish(ContactsPermissionError.ErrorOccured(error))
 
         case (false, _):
-            finish(ContactsPermissionError.ContactsUnknownErrorOccured)
+            finish(ContactsPermissionError.UnknownErrorOccured)
         }
     }
 
     public func executeContactsTask() throws {
         // no-op
     }
+}
+
+@available(iOS 9.0, OSX 10.11, *)
+public class _ContactsOperation<Store: ContactStoreType>: _ContactsAccess<Store> {
+
+    let containerId: CNContainer.ID
+
+    public var containerIdentifier: String {
+        return containerId.identifier
+    }
+
+    public init(containerId: CNContainer.ID = .Default, entityType: CNEntityType = .Contacts, contactStore: Store = Store()) {
+        self.containerId = containerId
+        super.init(entityType: entityType, contactStore: Store())
+        name = "Contacts Operation"
+    }
 
     // Public API
 
     public func allGroups() throws -> [CNGroup] {
-        return try store.groupsMatchingPredicate(allGroupsPredicate)
+        return try store.opr_groupsMatchingPredicate(.None)
     }
 
     public func groupsNamed(groupName: String) throws -> [CNGroup] {
@@ -112,26 +215,64 @@ public class ContactsOperation: Operation {
 
         let fetch = CNContactFetchRequest(keysToFetch: [CNContactIdentifierKey])
         fetch.predicate = CNContact.predicateForContactsWithIdentifiers(contactIDs)
-        try store.enumerateContactsWithFetchRequest(fetch) { contact, _ in
+        try store.opr_enumerateContactsWithFetchRequest(fetch) { contact, _ in
             save.addMember(contact, toGroup: group)
         }
-        try store.executeSaveRequest(save)
+        try store.opr_executeSaveRequest(save)
+    }
+}
+
+// MARK: - ContactsGetContacts
+
+@available(iOS 9.0, OSX 10.11, *)
+public class _ContactsGetContacts<Store: ContactStoreType>: _ContactsOperation<Store> {
+
+    let predicate: CNContact.Predicate
+    let keysToFetch: [CNKeyDescriptor]
+
+    public var contacts = [CNContact]()
+
+    public var contact: CNContact? {
+        return contacts.first
+    }
+
+    public convenience init(identifier: String, keysToFetch: [CNKeyDescriptor], containerId: CNContainer.ID = .Default, entityType: CNEntityType = .Contacts) {
+        self.init(predicate: .WithIdentifiers([identifier]), keysToFetch: keysToFetch, containerId: containerId, entityType: entityType, contactStore: Store())
+    }
+
+    public convenience init(predicate: CNContact.Predicate, keysToFetch: [CNKeyDescriptor], containerId: CNContainer.ID = .Default, entityType: CNEntityType = .Contacts) {
+        self.init(predicate: predicate, keysToFetch: keysToFetch, containerId: containerId, entityType: entityType, contactStore: Store())
+    }
+
+    init(predicate: CNContact.Predicate, keysToFetch: [CNKeyDescriptor], containerId: CNContainer.ID = .Default, entityType: CNEntityType = .Contacts, contactStore: Store) {
+        self.predicate = predicate
+        self.keysToFetch = keysToFetch
+        super.init(containerId: containerId, entityType: entityType, contactStore: contactStore)
+    }
+    
+    public override func executeContactsTask() throws {
+        switch predicate {
+        case .WithIdentifiers(let identifiers) where identifiers.count == 1:
+            let contact = try store.opr_unifiedContactWithIdentifier(identifiers.first!, keysToFetch: keysToFetch)
+            contacts = [contact]
+        default:
+            contacts = try store.opr_unifiedContactsMatchingPredicate(predicate.predicate, keysToFetch: keysToFetch)
+        }
     }
 }
 
 @available(iOS 9.0, OSX 10.11, *)
-public class ContactsCreateGroup: ContactsOperation {
+public class _ContactsCreateGroup<Store: ContactStoreType>: _ContactsOperation<Store> {
 
     let groupName: String
 
-    public init(groupName: String, containerId: ContainerIdentifier = .Default, entityType: CNEntityType = .Contacts) {
-        self.groupName = groupName
-        super.init(entityType: entityType, containerId: containerId)
+    public convenience init(groupName: String, containerId: CNContainer.ID = .Default, entityType: CNEntityType = .Contacts) {
+        self.init(groupName: groupName, containerId: containerId, entityType: entityType, contactStore: Store())
     }
 
-    init(groupName: String, containerId: ContainerIdentifier = .Default, entityType: CNEntityType = .Contacts, registrar: ContactsPermissionRegistrar) {
+    init(groupName: String, containerId: CNContainer.ID = .Default, entityType: CNEntityType = .Contacts, contactStore: Store) {
         self.groupName = groupName
-        super.init(entityType: entityType, containerId: containerId, registrar: registrar)
+        super.init(containerId: containerId, entityType: entityType, contactStore: contactStore)
     }
 
     public override func executeContactsTask() throws {
@@ -141,25 +282,25 @@ public class ContactsCreateGroup: ContactsOperation {
         let save = CNSaveRequest()
         save.addGroup(group, toContainerWithIdentifier: containerIdentifier)
 
-        try store.executeSaveRequest(save)
+        try store.opr_executeSaveRequest(save)
     }
 }
 
 @available(iOS 9.0, OSX 10.11, *)
-public class ContactsGetGroup: ContactsOperation {
+public class _ContactsGetGroup<Store: ContactStoreType>: _ContactsOperation<Store> {
 
     let groupName: String
 
     public var group: CNGroup? = .None
 
-    public init(groupName: String, containerId: ContainerIdentifier = .Default, entityType: CNEntityType = .Contacts) {
+    public init(groupName: String, containerId: CNContainer.ID = .Default, entityType: CNEntityType = .Contacts) {
         self.groupName = groupName
-        super.init(entityType: entityType, containerId: containerId)
+        super.init(entityType: entityType, containerId: containerId, contactStore: Store())
     }
 
-    init(groupName: String, containerId: ContainerIdentifier = .Default, entityType: CNEntityType = .Contacts, registrar: ContactsPermissionRegistrar) {
+    init(groupName: String, containerId: CNContainer.ID = .Default, entityType: CNEntityType = .Contacts, contactStore: Store) {
         self.groupName = groupName
-        super.init(entityType: entityType, containerId: containerId, registrar: registrar)
+        super.init(containerId: containerId, entityType: entityType, contactStore: contactStore)
     }
 
     public override func executeContactsTask() throws {
@@ -174,12 +315,23 @@ public class ContactsGetGroup: ContactsOperation {
 }
 
 
+
+
+
+
+
+
+
+
+
+// MARK: - Helpers
+
 @available(iOS 9.0, OSX 10.11, *)
-extension CNContactStore {
+extension ContactStoreType {
 
     public func flatMapAllContactsWithFetchRequest<T>(fetchRequest: CNContactFetchRequest, transform: CNContact -> T?) throws -> [T] {
         var result = [T]()
-        try enumerateContactsWithFetchRequest(fetchRequest) { contact, _ in
+        try opr_enumerateContactsWithFetchRequest(fetchRequest) { contact, _ in
             if let tmp = transform(contact) {
                 result.append(tmp)
             }
@@ -188,8 +340,43 @@ extension CNContactStore {
     }
 }
 
+// MARK: - Conformance
 
+@available(iOS 9.0, OSX 10.11, *)
+extension CNContactStore: ContactStoreType {
 
+    public func opr_authorizationStatusForEntityType(entityType: CNEntityType) -> CNAuthorizationStatus {
+        return self.dynamicType.authorizationStatusForEntityType(entityType)
+    }
+
+    public func opr_requestAccessForEntityType(entityType: CNEntityType, completion: (Bool, NSError?) -> Void) {
+        requestAccessForEntityType(entityType, completionHandler: completion)
+    }
+
+    public func opr_defaultContainerIdentifier() -> String {
+        return defaultContainerIdentifier()
+    }
+
+    public func opr_unifiedContactWithIdentifier(identifier: String, keysToFetch keys: [CNKeyDescriptor]) throws -> CNContact {
+        return try unifiedContactWithIdentifier(identifier, keysToFetch: keys)
+    }
+
+    public func opr_unifiedContactsMatchingPredicate(predicate: NSPredicate, keysToFetch keys: [CNKeyDescriptor]) throws -> [CNContact] {
+        return try unifiedContactsMatchingPredicate(predicate, keysToFetch: keys)
+    }
+
+    public func opr_groupsMatchingPredicate(predicate: NSPredicate?) throws -> [CNGroup] {
+        return try groupsMatchingPredicate(predicate)
+    }
+
+    public func opr_enumerateContactsWithFetchRequest(fetchRequest: CNContactFetchRequest, usingBlock block: (CNContact, UnsafeMutablePointer<ObjCBool>) -> Void) throws {
+        try enumerateContactsWithFetchRequest(fetchRequest, usingBlock: block)
+    }
+
+    public func opr_executeSaveRequest(saveRequest: CNSaveRequest) throws {
+        try executeSaveRequest(saveRequest)
+    }
+}
 
 
 

--- a/Operations/Extras/Contacts/Shared/ContactsOperation.swift
+++ b/Operations/Extras/Contacts/Shared/ContactsOperation.swift
@@ -1,0 +1,57 @@
+//
+//  ContactsOperation.swift
+//  Operations
+//
+//  Created by Daniel Thorpe on 24/09/2015.
+//  Copyright © 2015 Dan Thorpe. All rights reserved.
+//
+
+import Contacts
+
+@available(iOS 9.0, *)
+public class ContactsOperation: Operation {
+
+    let store = CNContactStore()
+    let entityType: CNEntityType
+    let registrar: ContactsPermissionRegistrar
+
+    public init(entityType: CNEntityType = .Contacts) {
+        self.entityType = entityType
+        registrar = store
+    }
+
+    init(entityType: CNEntityType = .Contacts, registrar: ContactsPermissionRegistrar) {
+        self.entityType = entityType
+        self.registrar = registrar
+    }
+
+    public override func execute() {
+        requestAccess()
+    }
+
+    final func requestAccess() {
+        switch registrar.opr_authorizationStatusForEntityType(entityType) {
+        case .NotDetermined:
+            registrar.opr_requestAccessForEntityType(entityType, completion: requestAccessDidComplete)
+        default:
+            finish(ContactsPermissionsError.ContactsAccessDenied)
+        }
+    }
+
+    func requestAccessDidComplete(success: Bool, error: NSError?) {
+        switch (success, error) {
+        case (true, _):
+            finish(executeContactsTask())
+        case let (false, .Some(error)):
+            finish(ContactsPermissionsError.ContactsErrorOccured(error))
+        case (false, _):
+            finish(ContactsPermissionsError.ContactsUnknownErrorOccured)
+        }
+    }
+
+    func executeContactsTask() -> ErrorType? {
+        return .None
+    }
+}
+
+

--- a/Operations/Extras/Contacts/Shared/ContactsOperation.swift
+++ b/Operations/Extras/Contacts/Shared/ContactsOperation.swift
@@ -13,8 +13,6 @@ public enum ContactsPermissionError: ErrorType {
     case AuthorizationDenied
     case AuthorizationRestricted
     case AuthorizationNotDetermined
-    case UnknownErrorOccured
-    case ErrorOccured(NSError)
 }
 
 @available(iOS 9.0, OSX 10.11, *)
@@ -161,10 +159,10 @@ public class _ContactsAccess<Store: ContactsPermissionRegistrar>: Operation {
             }
 
         case let (false, .Some(error)):
-            finish(ContactsPermissionError.ErrorOccured(error))
+            finish(ContactsError.ErrorOccured(error))
 
         case (false, _):
-            finish(ContactsPermissionError.UnknownErrorOccured)
+            finish(ContactsError.UnknownErrorOccured)
         }
     }
 

--- a/Operations/Extras/Contacts/Shared/ContactsOperation.swift
+++ b/Operations/Extras/Contacts/Shared/ContactsOperation.swift
@@ -102,13 +102,13 @@ extension CNGroup {
 public typealias ContactsOperation = _ContactsOperation<CNContactStore>
 
 @available(iOS 9.0, OSX 10.11, *)
-public typealias ContactsGetContacts = _ContactsGetContacts<CNContactStore>
+public typealias GetContacts = _GetContacts<CNContactStore>
 
 @available(iOS 9.0, OSX 10.11, *)
-public typealias ContactsCreateGroup = _ContactsCreateGroup<CNContactStore>
+public typealias CreateContactsGroup = _CreateContactsGroup<CNContactStore>
 
 @available(iOS 9.0, OSX 10.11, *)
-public typealias ContactsGetGroup = _ContactsGetGroup<CNContactStore>
+public typealias GetContactsGroup = _GetContactsGroup<CNContactStore>
 
 
 
@@ -222,10 +222,10 @@ public class _ContactsOperation<Store: ContactStoreType>: _ContactsAccess<Store>
     }
 }
 
-// MARK: - ContactsGetContacts
+// MARK: - GetContacts
 
 @available(iOS 9.0, OSX 10.11, *)
-public class _ContactsGetContacts<Store: ContactStoreType>: _ContactsOperation<Store> {
+public class _GetContacts<Store: ContactStoreType>: _ContactsOperation<Store> {
 
     let predicate: CNContact.Predicate
     let keysToFetch: [CNKeyDescriptor]
@@ -258,7 +258,7 @@ public class _ContactsGetContacts<Store: ContactStoreType>: _ContactsOperation<S
 }
 
 @available(iOS 9.0, OSX 10.11, *)
-public class _ContactsCreateGroup<Store: ContactStoreType>: _ContactsOperation<Store> {
+public class _CreateContactsGroup<Store: ContactStoreType>: _ContactsOperation<Store> {
 
     let groupName: String
 
@@ -279,7 +279,7 @@ public class _ContactsCreateGroup<Store: ContactStoreType>: _ContactsOperation<S
 }
 
 @available(iOS 9.0, OSX 10.11, *)
-public class _ContactsGetGroup<Store: ContactStoreType>: _ContactsOperation<Store> {
+public class _GetContactsGroup<Store: ContactStoreType>: _ContactsOperation<Store> {
 
     let groupName: String
 

--- a/Operations/Extras/Contacts/iOS/ContactsUIOperations.swift
+++ b/Operations/Extras/Contacts/iOS/ContactsUIOperations.swift
@@ -16,7 +16,7 @@ final public class DisplayContactViewController<F: PresentingViewController>: Gr
 
     let from: ViewControllerDisplayStyle<F>
     let sender: AnyObject?
-    let get: ContactsGetContacts
+    let get: GetContacts
     let configuration: ContactViewControllerConfigurationBlock?
 
     var ui: UIOperation<CNContactViewController, F>? = .None
@@ -28,7 +28,7 @@ final public class DisplayContactViewController<F: PresentingViewController>: Gr
     public init(identifier: String, displayControllerFrom from: ViewControllerDisplayStyle<F>, delegate: CNContactViewControllerDelegate, sender: AnyObject? = .None, configuration: ContactViewControllerConfigurationBlock? = .None) {
         self.from = from
         self.sender = sender
-        self.get = ContactsGetContacts(identifier: identifier, keysToFetch: [CNContactViewController.descriptorForRequiredKeys()])
+        self.get = GetContacts(identifier: identifier, keysToFetch: [CNContactViewController.descriptorForRequiredKeys()])
         self.configuration = configuration
         super.init(operations: [ get ])
         name = "Display Contact View Controller"
@@ -62,7 +62,7 @@ final public class DisplayCreateContactViewController<F: PresentingViewControlle
     public init(displayControllerFrom from: ViewControllerDisplayStyle<F>, delegate: CNContactViewControllerDelegate, sender: AnyObject? = .None, addToGroupWithName groupName: String? = .None) {
         self.delegate = delegate
         self.ui = UIOperation(controller: CNContactViewController(forNewContact: .None), displayControllerFrom: from, sender: sender)
-        let op = groupName.map { ContactsGetGroup(groupName: $0) } ?? ContactsOperation()
+        let op = groupName.map { GetContactsGroup(groupName: $0) } ?? ContactsOperation()
         super.init(operations: [op])
         name = "Display Create Contact View Controller"
     }
@@ -70,7 +70,7 @@ final public class DisplayCreateContactViewController<F: PresentingViewControlle
     public override func operationDidFinish(operation: NSOperation, withErrors errors: [ErrorType]) {
         if errors.isEmpty {
             contactViewController.delegate = delegate
-            if let getGroupOperation = operation as? ContactsGetGroup {
+            if let getGroupOperation = operation as? GetContactsGroup {
                 contactViewController.parentGroup = getGroupOperation.group
             }
             addOperation(ui)

--- a/Operations/Extras/Contacts/iOS/ContactsUIOperations.swift
+++ b/Operations/Extras/Contacts/iOS/ContactsUIOperations.swift
@@ -1,0 +1,86 @@
+//
+//  ContactsUIOperations.swift
+//  Operations
+//
+//  Created by Daniel Thorpe on 24/09/2015.
+//  Copyright © 2015 Dan Thorpe. All rights reserved.
+//
+
+import Contacts
+import ContactsUI
+
+
+
+@available(iOS 9.0, *)
+public enum DisplayContactWithIntent {
+
+    case Contact(CNContact)
+    case Unknown(CNContact)
+    case New(CNContact?)
+
+    var contactViewController: CNContactViewController {
+        switch self {
+        case .Contact(let contact):
+            return CNContactViewController(forContact: contact)
+        case .Unknown(let contact):
+            return CNContactViewController(forUnknownContact: contact)
+        case .New(let contact):
+            return CNContactViewController(forNewContact: contact)
+        }
+    }
+}
+
+@available(iOS 9.0, *)
+final public class ContactsDisplayContactViewController<F: PresentingViewController>: ContactsOperation {
+
+    let contact: DisplayContactWithIntent
+    let ui: UIOperation<CNContactViewController, F>
+
+    public var contactViewController: CNContactViewController {
+        return ui.controller
+    }
+
+    public init(contact: DisplayContactWithIntent, displayControllerFrom from: ViewControllerDisplayStyle<F>, delegate: CNContactViewControllerDelegate, sender: AnyObject? = .None) {
+        self.contact = contact
+        self.ui = UIOperation(controller: contact.contactViewController, displayControllerFrom: from, sender: sender)
+        super.init()
+        name = "Display Contact View Controller"
+        contactViewController.delegate = delegate
+    }
+
+    public override func executeContactsTask() throws {
+        contactViewController.contactStore = store
+        produceOperation(ui)
+    }
+}
+
+@available(iOS 9.0, *)
+final public class ContactsDisplayCreateContactViewController<F: PresentingViewController>: GroupOperation {
+
+    let store = CNContactStore()
+    let delegate: CNContactViewControllerDelegate
+    let ui: UIOperation<CNContactViewController, F>
+
+    public var contactViewController: CNContactViewController {
+        return ui.controller
+    }
+
+    public init(displayControllerFrom from: ViewControllerDisplayStyle<F>, delegate: CNContactViewControllerDelegate, sender: AnyObject? = .None, addToGroupWithName groupName: String? = .None) {
+        self.delegate = delegate
+        self.ui = UIOperation(controller: CNContactViewController(forNewContact: .None), displayControllerFrom: from, sender: sender)
+        let op = groupName.map { ContactsGetGroup(groupName: $0) } ?? ContactsOperation()
+        super.init(operations: [op])
+        name = "Display Create Contact View Controller"
+    }
+
+    public override func operationDidFinish(operation: NSOperation, withErrors errors: [ErrorType]) {
+        if errors.isEmpty {
+            contactViewController.delegate = delegate
+            if let getGroupOperation = operation as? ContactsGetGroup {
+                contactViewController.parentGroup = getGroupOperation.group
+            }
+            addOperation(ui)
+        }
+    }
+}
+

--- a/Operations/Extras/Contacts/iOS/ContactsUIOperations.swift
+++ b/Operations/Extras/Contacts/iOS/ContactsUIOperations.swift
@@ -25,10 +25,10 @@ final public class DisplayContactViewController<F: PresentingViewController>: Gr
         return ui?.controller
     }
 
-    public init(identifier: String, containerId: CNContainer.ID = .Default, displayControllerFrom from: ViewControllerDisplayStyle<F>, delegate: CNContactViewControllerDelegate, sender: AnyObject? = .None, configuration: ContactViewControllerConfigurationBlock? = .None) {
+    public init(identifier: String, displayControllerFrom from: ViewControllerDisplayStyle<F>, delegate: CNContactViewControllerDelegate, sender: AnyObject? = .None, configuration: ContactViewControllerConfigurationBlock? = .None) {
         self.from = from
         self.sender = sender
-        self.get = ContactsGetContacts(identifier: identifier, keysToFetch: [CNContactViewController.descriptorForRequiredKeys()], containerId: containerId)
+        self.get = ContactsGetContacts(identifier: identifier, keysToFetch: [CNContactViewController.descriptorForRequiredKeys()])
         self.configuration = configuration
         super.init(operations: [ get ])
         name = "Display Contact View Controller"

--- a/OperationsTests/Core/LoggingObserverTests.swift
+++ b/OperationsTests/Core/LoggingObserverTests.swift
@@ -46,7 +46,7 @@ class LoggingObserverTests: OperationTests {
         waitForExpectationsWithTimeout(3, handler: nil)
 
         XCTAssertEqual(receivedMessages.count, 2)
-        XCTAssertEqual(receivedMessages[1], "\(operation): finished with 1 error(s).")
+        XCTAssertEqual(receivedMessages[1], "\(operation): finished with error(s): [Operations.CloudContainerCondition.Error.NotAuthenticated].")
     }
 
     func test__logger_receives_messages_from_produced_operation() {
@@ -71,7 +71,7 @@ class LoggingObserverTests: OperationTests {
         XCTAssertEqual(receivedMessages[1], "Test Operation: did produce operation: Produced Operation.")
         XCTAssertEqual(receivedMessages[2], "Produced Operation: did start.")
         XCTAssertEqual(receivedMessages[3], "Produced Operation: finished with no errors.")
-        XCTAssertEqual(receivedMessages[4], "Test Operation: finished with 1 error(s).")
+        XCTAssertEqual(receivedMessages[4], "Test Operation: finished with error(s): [Operations.CloudContainerCondition.Error.NotAuthenticated].")
     }
 }
 

--- a/OperationsTests/Extras/Contacts/ContactsOperationsTests.swift
+++ b/OperationsTests/Extras/Contacts/ContactsOperationsTests.swift
@@ -1,0 +1,95 @@
+//
+//  ContactsOperationsTests.swift
+//  Operations
+//
+//  Created by Daniel Thorpe on 24/09/2015.
+//  Copyright © 2015 Dan Thorpe. All rights reserved.
+//
+
+import XCTest
+import Contacts
+
+@testable import Operations
+
+class TestableContactsRegistrar: ContactsPermissionRegistrar {
+
+    var didAccessStatus = false
+    var didRequestAccess = false
+    var requestedEntityType: CNEntityType? = .None
+    var accessError: NSError? = .None
+
+    var status: CNAuthorizationStatus
+    let accessRequestShouldSucceed: Bool
+
+    init(status: CNAuthorizationStatus, accessRequestShouldSucceed: Bool = true) {
+        self.status = status
+        self.accessRequestShouldSucceed = accessRequestShouldSucceed
+    }
+
+    func opr_authorizationStatusForEntityType(entityType: CNEntityType) -> CNAuthorizationStatus {
+        didAccessStatus = true
+        requestedEntityType = entityType
+        return status
+    }
+
+    func opr_requestAccessForEntityType(entityType: CNEntityType, completion: (Bool, NSError?) -> Void) {
+        didRequestAccess = true
+        requestedEntityType = entityType
+        if accessRequestShouldSucceed {
+            status = .Authorized
+            completion(true, .None)
+        }
+        else {
+            status = .Denied
+            completion(false, accessError)
+        }
+    }
+}
+
+class ContactsOperationsTests: OperationTests {
+
+    func test__given_authorization_granted__access_succeeds() {
+
+        let registrar = TestableContactsRegistrar(status: .NotDetermined)
+        let operation = TestOperation()
+        operation.addCondition(ContactsCondition(registrar: registrar))
+
+        addCompletionBlockToTestOperation(operation, withExpectation: expectationWithDescription("Test: \(__FUNCTION__)"))
+        runOperation(operation)
+        waitForExpectationsWithTimeout(3, handler: nil)
+
+        XCTAssertTrue(operation.didExecute)
+        XCTAssertTrue(registrar.didAccessStatus)
+        XCTAssertTrue(registrar.didRequestAccess)
+    }
+
+    func test__given_authorization_already_granted__access_succeeds() {
+
+        let registrar = TestableContactsRegistrar(status: .Authorized)
+        let operation = TestOperation()
+        operation.addCondition(ContactsCondition(registrar: registrar))
+
+        addCompletionBlockToTestOperation(operation, withExpectation: expectationWithDescription("Test: \(__FUNCTION__)"))
+        runOperation(operation)
+        waitForExpectationsWithTimeout(3, handler: nil)
+
+        XCTAssertTrue(operation.didExecute)
+        XCTAssertTrue(registrar.didAccessStatus)
+        XCTAssertFalse(registrar.didRequestAccess)
+    }
+
+    func test__given_authorization_denied__access_fails() {
+        let registrar = TestableContactsRegistrar(status: .NotDetermined, accessRequestShouldSucceed: false)
+        let operation = TestOperation()
+        operation.addCondition(ContactsCondition(registrar: registrar))
+
+        addCompletionBlockToTestOperation(operation, withExpectation: expectationWithDescription("Test: \(__FUNCTION__)"))
+        runOperation(operation)
+        waitForExpectationsWithTimeout(3, handler: nil)
+
+        XCTAssertFalse(operation.didExecute)
+        XCTAssertTrue(registrar.didAccessStatus)
+        XCTAssertTrue(registrar.didRequestAccess)
+    }
+
+}

--- a/OperationsTests/Extras/Contacts/ContactsOperationsTests.swift
+++ b/OperationsTests/Extras/Contacts/ContactsOperationsTests.swift
@@ -11,7 +11,11 @@ import Contacts
 
 @testable import Operations
 
-class TestableContactsRegistrar: ContactsPermissionRegistrar {
+class TestableContactsStore: ContactStoreType {
+
+    enum Error: ErrorType {
+        case NotImplemented
+    }
 
     var didAccessStatus = false
     var didRequestAccess = false
@@ -49,13 +53,41 @@ class TestableContactsRegistrar: ContactsPermissionRegistrar {
             completion(false, accessError)
         }
     }
+
+    func opr_defaultContainerIdentifier() -> String {
+        return "not implmented"
+    }
+
+    func opr_unifiedContactWithIdentifier(identifier: String, keysToFetch keys: [CNKeyDescriptor]) throws -> CNContact {
+        throw Error.NotImplemented
+    }
+
+    func opr_unifiedContactsMatchingPredicate(predicate: NSPredicate, keysToFetch keys: [CNKeyDescriptor]) throws -> [CNContact] {
+        throw Error.NotImplemented
+    }
+
+    func opr_groupsMatchingPredicate(predicate: NSPredicate?) throws -> [CNGroup] {
+        throw Error.NotImplemented
+    }
+
+    func opr_containersMatchingPredicate(predicate: NSPredicate?) throws -> [CNContainer] {
+        throw Error.NotImplemented
+    }
+
+    func opr_enumerateContactsWithFetchRequest(fetchRequest: CNContactFetchRequest, usingBlock block: (CNContact, UnsafeMutablePointer<ObjCBool>) -> Void) throws {
+        throw Error.NotImplemented
+    }
+
+    func opr_executeSaveRequest(saveRequest: CNSaveRequest) throws {
+        throw Error.NotImplemented
+    }
 }
 
 class ContactsOperationsTests: OperationTests {
 
     func test__given_authorization_granted__access_succeeds() {
 
-        let registrar = TestableContactsRegistrar(status: .NotDetermined)
+        let registrar = TestableContactsStore(status: .NotDetermined)
         let operation = TestOperation()
         operation.addCondition(_ContactsCondition(registrar: registrar))
 
@@ -70,7 +102,7 @@ class ContactsOperationsTests: OperationTests {
 
     func test__given_authorization_already_granted__access_succeeds() {
 
-        let registrar = TestableContactsRegistrar(status: .Authorized)
+        let registrar = TestableContactsStore(status: .Authorized)
         let operation = TestOperation()
         operation.addCondition(_ContactsCondition(registrar: registrar))
 
@@ -84,7 +116,7 @@ class ContactsOperationsTests: OperationTests {
     }
 
     func test__given_authorization_denied__access_fails() {
-        let registrar = TestableContactsRegistrar(status: .NotDetermined, accessRequestShouldSucceed: false)
+        let registrar = TestableContactsStore(status: .NotDetermined, accessRequestShouldSucceed: false)
         let operation = TestOperation()
         operation.addCondition(_ContactsCondition(registrar: registrar))
 

--- a/OperationsTests/Extras/Contacts/ContactsOperationsTests.swift
+++ b/OperationsTests/Extras/Contacts/ContactsOperationsTests.swift
@@ -21,6 +21,11 @@ class TestableContactsRegistrar: ContactsPermissionRegistrar {
     var status: CNAuthorizationStatus
     let accessRequestShouldSucceed: Bool
 
+    required init() {
+        self.status = .NotDetermined
+        self.accessRequestShouldSucceed = true
+    }
+
     init(status: CNAuthorizationStatus, accessRequestShouldSucceed: Bool = true) {
         self.status = status
         self.accessRequestShouldSucceed = accessRequestShouldSucceed
@@ -52,7 +57,7 @@ class ContactsOperationsTests: OperationTests {
 
         let registrar = TestableContactsRegistrar(status: .NotDetermined)
         let operation = TestOperation()
-        operation.addCondition(ContactsCondition(registrar: registrar))
+        operation.addCondition(_ContactsCondition(registrar: registrar))
 
         addCompletionBlockToTestOperation(operation, withExpectation: expectationWithDescription("Test: \(__FUNCTION__)"))
         runOperation(operation)
@@ -67,7 +72,7 @@ class ContactsOperationsTests: OperationTests {
 
         let registrar = TestableContactsRegistrar(status: .Authorized)
         let operation = TestOperation()
-        operation.addCondition(ContactsCondition(registrar: registrar))
+        operation.addCondition(_ContactsCondition(registrar: registrar))
 
         addCompletionBlockToTestOperation(operation, withExpectation: expectationWithDescription("Test: \(__FUNCTION__)"))
         runOperation(operation)
@@ -81,7 +86,7 @@ class ContactsOperationsTests: OperationTests {
     func test__given_authorization_denied__access_fails() {
         let registrar = TestableContactsRegistrar(status: .NotDetermined, accessRequestShouldSucceed: false)
         let operation = TestOperation()
-        operation.addCondition(ContactsCondition(registrar: registrar))
+        operation.addCondition(_ContactsCondition(registrar: registrar))
 
         addCompletionBlockToTestOperation(operation, withExpectation: expectationWithDescription("Test: \(__FUNCTION__)"))
         runOperation(operation)


### PR DESCRIPTION
Support use of Contacts framework (across all appropriate platforms)

- [x] `ContactsCondition` - a condition to require permissions to Contacts.framework
- [x] `ContactsOperation` - basic low level operation(s) which own the store, and provide "execute" method suitable for subclassing.
- [x] `GetContacts` - operation to get contacts based on predicate
- [x] `GetGroup` - operation to get a group with a name, create it if necessary.