### PR TITLE
Documentation Blitz

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ DerivedData
 Carthage/Build
 .fastlane/report.xml
 .fastlane/xcodebuild-data
+
+# Jazzy
+docs

--- a/Operations.xcodeproj/project.pbxproj
+++ b/Operations.xcodeproj/project.pbxproj
@@ -656,7 +656,6 @@
 				65EEC1721BAF44E80020A9BD /* DelayOperation.swift */,
 				65EEC1741BAF44E80020A9BD /* GatedOperation.swift */,
 				65EEC1751BAF44E80020A9BD /* GroupOperation.swift */,
-				65EEC1761BAF44E80020A9BD /* LoggingObserver.swift */,
 				65EEC16C1BAF44E80020A9BD /* UIOperation.swift */,
 			);
 			name = Operations;
@@ -692,6 +691,7 @@
 			children = (
 				65EEC16A1BAF44E80020A9BD /* BackgroundObserver.swift */,
 				65EEC16F1BAF44E80020A9BD /* BlockObserver.swift */,
+				65EEC1761BAF44E80020A9BD /* LoggingObserver.swift */,
 				65EEC16B1BAF44E80020A9BD /* NetworkObserver.swift */,
 				65EEC1801BAF44E80020A9BD /* TimeoutObserver.swift */,
 			);

--- a/Operations/Core/Shared/BlockCondition.swift
+++ b/Operations/Core/Shared/BlockCondition.swift
@@ -13,25 +13,67 @@ An `OperationCondition` which will be satisfied if the block returns true.
 */
 public struct BlockCondition: OperationCondition {
 
+    /// The block type which returns a Bool.
     public typealias ConditionBlockType = () -> Bool
 
+    /// The error used to indicate failure.
     public enum Error: ErrorType {
+
+        /**
+        If the block returns false, the operation to
+        which it is attached will fail with this error.
+        */
         case BlockConditionFailed
     }
 
+    /**
+    The name of the condition.
+    
+    - parameter name: a constant String `Block Condition`.
+    */
     public let name = "Block Condition"
+
+    /**
+    The mutual exclusivity of the condition, which is false.
+
+    - parameter isMutuallyExclusive: a constant Bool, false.
+    */
     public let isMutuallyExclusive = false
 
     let condition: ConditionBlockType
 
+    /**
+    Creates a `BlockCondition` with the supplied block. 
+    
+    Example like this..
+    
+        operation.addCondition(BlockCondition { true })
+    
+    Alternatively
+    
+        func checkFlag() -> Bool {
+            return toDoSomethingOrNot
+        }
+    
+        operation.addCondition(BlockCondition(block: checkFlag))
+
+    - parameter block: a `ConditionBlockType`.
+    */
     public init(block: ConditionBlockType) {
         condition = block
     }
 
+    /// Conforms to `OperationCondition`, but there are no dependencies, so it returns .None.
     public func dependencyForOperation(operation: Operation) -> NSOperation? {
         return .None
     }
 
+    /**
+    Evaluates the condition, it will execute the block.
+    
+    - parameter operation: the attached `Operation`
+    - parameter completion: the evaulation completion block, it is given the result.
+    */
     public func evaluateForOperation(operation: Operation, completion: OperationConditionResult -> Void) {
         completion(condition() ? .Satisfied : .Failed(Error.BlockConditionFailed))
     }

--- a/Operations/Core/Shared/BlockObserver.swift
+++ b/Operations/Core/Shared/BlockObserver.swift
@@ -9,10 +9,11 @@
 import Foundation
 
 /**
-A `BlockObserver` which accepts three different blocks for start, 
+A `OperationObserver` which accepts three different blocks for start,
 produce and finish.
 */
 public struct BlockObserver: OperationObserver {
+
     public typealias StartHandler = Operation -> Void
     public typealias ProduceHandler = (Operation, NSOperation) -> Void
     public typealias FinishHandler = (Operation, [ErrorType]) -> Void
@@ -22,20 +23,20 @@ public struct BlockObserver: OperationObserver {
     let finishHandler: FinishHandler?
 
     /**
-    A `BlockObserver` which accepts three different blocks for start,
+    A `OperationObserver` which accepts three different blocks for start,
     produce and finish.
 
     The arguments all default to `.None` which means that the most
     typical use case for observing when the operation finishes. e.g.
 
-        operation.addObserver(BlockObserver { (_, errors) in
+        operation.addObserver(BlockObserver { _, errors in
             // The operation finished, maybe with errors,
             // which you should handle.
         })
 
-    :param: startHandler, a optional block of type Operation -> Void
-    :param: produceHandler, a optional block of type (Operation, NSOperation) -> Void
-    :param: finishHandler, a optional block of type (Operation, [ErrorType]) -> Void
+    - parameter startHandler, a optional block of type Operation -> Void
+    - parameter produceHandler, a optional block of type (Operation, NSOperation) -> Void
+    - parameter finishHandler, a optional block of type (Operation, [ErrorType]) -> Void
     */
     public init(startHandler: StartHandler? = .None, produceHandler: ProduceHandler? = .None, finishHandler: FinishHandler? = .None) {
         self.startHandler = startHandler
@@ -43,14 +44,17 @@ public struct BlockObserver: OperationObserver {
         self.finishHandler = finishHandler
     }
 
+    /// Conforms to `OperationObserver`, executes the optional startHandler.
     public func operationDidStart(operation: Operation) {
         startHandler?(operation)
     }
 
+    /// Conforms to `OperationObserver`, executes the optional produceHandler.
     public func operation(operation: Operation, didProduceOperation newOperation: NSOperation) {
         produceHandler?(operation, newOperation)
     }
 
+    /// Conforms to `OperationObserver`, executes the optional finishHandler.
     public func operationDidFinish(operation: Operation, errors: [ErrorType]) {
         finishHandler?(operation, errors)
     }

--- a/Operations/Core/Shared/BlockOperation.swift
+++ b/Operations/Core/Shared/BlockOperation.swift
@@ -25,7 +25,7 @@ public class BlockOperation: Operation {
     /**
     Designated initializer.
     
-    :param: block The closure to run when the operation executes.
+    - parameter block: The closure to run when the operation executes.
     If this block is nil, the operation will immediately finish.
     */
     public init(block: BlockType = { (continueWithError) in continueWithError(error: nil) }) {
@@ -36,7 +36,7 @@ public class BlockOperation: Operation {
     /**
     Convenience initializer.
     
-    :param: block a dispatch block which is run on the main thread.
+    - parameter block: a dispatch block which is run on the main thread.
     */
     public convenience init(mainQueueBlock: dispatch_block_t) {
         self.init(block: { continuation in
@@ -47,6 +47,15 @@ public class BlockOperation: Operation {
         })
     }
 
+    /**
+    Executes the block. The block is passed another block which receives an optional
+    error which is passed to finish.
+    
+    In other words, the operation is initialized with a block which receives a 
+    "continuation" block. The consumer must call this continuation block to finish
+    the operation. Errors can be propagated from the block to the operation by passing
+    them to this continuation block.
+    */
     public override func execute() {
         block { error in self.finish(error) }
     }

--- a/Operations/Core/Shared/ComposedOperation.swift
+++ b/Operations/Core/Shared/ComposedOperation.swift
@@ -18,7 +18,7 @@ public class ComposedOperation<O: NSOperation>: GatedOperation<O> {
     /**
     Designated initializer.
     
-    :param: operation The operation to compose.
+    - parameter operation: The composed operation, must be a `NSOperation` subclass.
     */
     public init(operation: O) {
         super.init(operation: operation, gate: { true })

--- a/Operations/Core/Shared/DelayOperation.swift
+++ b/Operations/Core/Shared/DelayOperation.swift
@@ -9,20 +9,20 @@
 import Foundation
 
 /**
-    `DelayOperation` is an operation which waits until a given future
-    date, or a time interval. If the interval is negative, or the date
-    is in the past, the operation finishes.
+`DelayOperation` is an operation which waits until a given future
+date, or a time interval. If the interval is negative, or the date
+is in the past, the operation finishes.
 
-    Note that this operation efficiently uses `dispatch_after` so it 
-    does not block the thread on which it is called.
+Note that this operation efficiently uses `dispatch_after` so it 
+does not block the thread on which it is called.
 
-    Make an operation dependent on a `DelayOperation` in order to 
-    make it execute after a timeout, or in a repeated fashion with a
-    time-out.
+Make an operation dependent on a `DelayOperation` in order to 
+make it execute after a timeout, or in a repeated fashion with a
+time-out.
 */
 public class DelayOperation: Operation {
 
-    private enum Delay {
+    internal enum Delay {
         case Interval(NSTimeInterval)
         case Date(NSDate)
 
@@ -36,16 +36,31 @@ public class DelayOperation: Operation {
 
     private let delay: Delay
 
+    /**
+    Initialize the `DelayOperation` with a time interval.
+    
+    - parameter interval: a `NSTimeInterval`.
+    */
     public init(interval: NSTimeInterval) {
         delay = .Interval(interval)
         super.init()
     }
 
+    /**
+    Initialize the `DelayOperation` with a date.
+
+    - parameter interval: a `NSDate`.
+    */
     public init(date: NSDate) {
         delay = .Date(date)
         super.init()
     }
 
+    /**
+    Executes the operation by using dispatch_after to finish the
+    operation in the future, but only if the time interval is 
+    greater than zero.
+    */
     public override func execute() {
 
         switch delay.interval {

--- a/Operations/Core/Shared/ExclusivityManager.swift
+++ b/Operations/Core/Shared/ExclusivityManager.swift
@@ -8,9 +8,9 @@
 
 import Foundation
 
-public class ExclusivityManager {
+internal class ExclusivityManager {
 
-    public static let sharedInstance = ExclusivityManager()
+    static let sharedInstance = ExclusivityManager()
 
     private let queue = Queue.Initiated.serial("me.danthorpe.Operations.Exclusivity")
     private var operations: [String: [Operation]] = [:]

--- a/Operations/Core/Shared/GatedOperation.swift
+++ b/Operations/Core/Shared/GatedOperation.swift
@@ -16,6 +16,7 @@ public class GatedOperation<O: NSOperation>: GroupOperation {
 
     public typealias GateBlockType = () -> Bool
 
+    /// The composed generic operation
     public let operation: O
     let gate: GateBlockType
 
@@ -24,8 +25,8 @@ public class GatedOperation<O: NSOperation>: GroupOperation {
     be executed, return false and the operation will not
     be executed.
     
-    :param: operation, any subclass of `NSOperation`.
-    :param: gate, a block which returns a Bool.
+    - parameter operation: any subclass of `NSOperation`.
+    - parameter gate: a block which returns a Bool.
     */
     public init(operation: O, gate: GateBlockType) {
         self.operation = operation
@@ -33,6 +34,12 @@ public class GatedOperation<O: NSOperation>: GroupOperation {
         super.init(operations: [])
     }
 
+    /**
+    Executes the block. If the result of executing the gate is
+    true, the operation is added. Then we call super.execute()
+    which will start the group's queue, meaning that the composed
+    operation will start.
+    */
     public override func execute() {
         if gate() {
             addOperation(operation)

--- a/Operations/Core/Shared/LoggingObserver.swift
+++ b/Operations/Core/Shared/LoggingObserver.swift
@@ -10,15 +10,10 @@ import Foundation
 
 /**
 Attach a `LoggingObserver to an operation to log when the operation
-start, produces new operation and finsihed. It doesn't yet report
-detailed error infomation.
+start, produces new operation and finsihed.
 
 Any produced `Operation` instances will automatically get their
 own logger attached.
-    
-:param: queue, Provide a queue, by detault it uses it's own serial queue.
-:param: logger, Provide a logging block. By detault the logger uses `println`
-however, for custom loggers provide a block which receives a `String`.
 */
 public struct LoggingObserver: OperationObserver {
     public typealias LoggerBlockType = (message: String) -> Void
@@ -26,15 +21,47 @@ public struct LoggingObserver: OperationObserver {
     let logger: LoggerBlockType
     let queue: dispatch_queue_t
 
+    /**
+    Create a logging observer. Accepts as the final argument a block which receives a
+    `String` message to be logged. By default this just uses `print()`, but construct 
+    with a custom block to send logs to other systems. The block is executed on a 
+    dispatch queue.
+
+    - parameter queue: a queue, by detault it uses it's own serial queue.
+    - parameter logger: a logging block. By detault the logger uses `println`
+    however, for custom loggers provide a block which receives a `String`.
+    */
     public init(queue: dispatch_queue_t = Queue.Initiated.serial("me.danthorpe.Operations.Logger"), logger: LoggerBlockType = { print($0) }) {
         self.queue = queue
         self.logger = logger
     }
 
+    /**
+    Conforms to `OperationObserver`. The logger is sent a string which uses the
+    `name` parameter of the operation if provived.
+    
+       "My Operation: did start."
+    
+    - parameter operation: the `Operation` which has started.
+    */
     public func operationDidStart(operation: Operation) {
         log("\(operationName(operation)): did start.")
     }
 
+    /**
+    Conforms to `OperationObserver`. The logger is sent a string which uses the
+    `name` parameter of the operation if provived.
+
+        "My Operation: did produce operation: My Other Operation."
+
+    If the produced operation is an `Operation`, then a new `LoggingObserver` with 
+    same queue and logger will be attached to it as an observer. Meaning that when
+    the produced operation starts/produces/finishes, it will also generate log 
+    output.
+
+    - parameter operation: the `Operation` producer.
+    - parameter newOperation: the `Operation` which has been produced.
+    */
     public func operation(operation: Operation, didProduceOperation newOperation: NSOperation) {
         var detail = "\(newOperation)"
 
@@ -46,6 +73,20 @@ public struct LoggingObserver: OperationObserver {
         log("\(operationName(operation)): did produce operation: \(detail).")
     }
 
+    /**
+    Conforms to `OperationObserver`. The logger is sent a string which uses the
+    `name` parameter of the operation if provived. If there were errors, output
+    looks like
+
+        "My Operation: finsihed with error(s): [My Operation Error]."
+    
+    or if no errors:
+    
+        "My Operation: finsihed with no errors."
+
+    - parameter operation: the `Operation` that finished.
+    - parameter errors: an array of `ErrorType`, not that these will be printed out.
+    */
     public func operationDidFinish(operation: Operation, errors: [ErrorType]) {
         let detail = errors.count > 0 ? "error(s): \(errors)" : "no errors"
         log("\(operationName(operation)): finished with \(detail).")

--- a/Operations/Core/Shared/MutuallyExclusive.swift
+++ b/Operations/Core/Shared/MutuallyExclusive.swift
@@ -14,18 +14,32 @@ cannot be allowed to execute concurrently.
 */
 public struct MutuallyExclusive<T>: OperationCondition {
 
+    /**
+    The name of the condition wraps the name of the generic
+    OperationCondition.
+
+    - parameter name: a String
+    */
     public var name: String {
         return "MutuallyExclusive<\(T.self)>"
     }
 
-    public var isMutuallyExclusive = true
+    /**
+    The mututally exclusivity parameter which is always true.
 
+    - parameter isMutuallyExclusive: a constant Bool, true.
+    */
+    public let isMutuallyExclusive = true
+
+    /// Public constructor
     public init() { }
 
+    /// Conforms to `OperationCondition`, but there are no dependencies, so it returns .None.
     public func dependencyForOperation(operation: Operation) -> NSOperation? {
         return .None
     }
 
+    /// Conforms to `OperationCondition`, but there is no evaluation, so it just completes with `.Satisfied`.
     public func evaluateForOperation(operation: Operation, completion: OperationConditionResult -> Void) {
         completion(.Satisfied)
     }

--- a/Operations/Core/Shared/NegatedCondition.swift
+++ b/Operations/Core/Shared/NegatedCondition.swift
@@ -27,14 +27,14 @@ a composed condition.
 public struct NegatedCondition<Condition: OperationCondition>: OperationCondition {
 
     /**
-    The nested condition.
+    The composed condition.
 
     - parameter condition: a type which conforms to `OperationCondition`
     */
     public let condition: Condition
 
     /**
-    The name of the condition wraps the name of the nested
+    The name of the condition wraps the name of the composed
     OperationCondition.
 
     - parameter name: a String
@@ -45,7 +45,7 @@ public struct NegatedCondition<Condition: OperationCondition>: OperationConditio
 
     /**
     The mututally exclusivity parameter which wraps the
-    nested condition's isMutuallyExclusive property.
+    composed condition's isMutuallyExclusive property.
 
     - parameter isMutuallyExclusive: a constant Bool, true.
     */
@@ -64,7 +64,7 @@ public struct NegatedCondition<Condition: OperationCondition>: OperationConditio
 
     /**
     The dependencies for a negated condition are the same as those of the
-    nested condition.
+    composed condition.
 
     - parameter operation: the `Operation` which is getting evaluated.
     */
@@ -73,7 +73,7 @@ public struct NegatedCondition<Condition: OperationCondition>: OperationConditio
     }
 
     /**
-    The evaluation results are inverted.
+    The evaluation results are those of the composed condition but inverted.
 
     - parameter operation: the `Operation` which is getting evaluated.
     - parameter completion: a block which receives the `OperationConditionResult`.
@@ -90,6 +90,7 @@ public struct NegatedCondition<Condition: OperationCondition>: OperationConditio
     }
 }
 
+/// Equatable conformance for `NegatedConditionError`
 public func ==(a: NegatedConditionError, b: NegatedConditionError) -> Bool {
     switch (a, b) {
     case let (.ConditionSatisfied(aString), .ConditionSatisfied(bString)):

--- a/Operations/Core/Shared/NegatedCondition.swift
+++ b/Operations/Core/Shared/NegatedCondition.swift
@@ -8,7 +8,15 @@
 
 import Foundation
 
+/**
+The error type used to indicate failure.
+*/
 public enum NegatedConditionError: ErrorType, Equatable {
+
+    /**
+    When the nested condition succeeds, the negated condition fails. 
+    The associated string is the name of the nested conditon.
+    */
     case ConditionSatisfied(String)
 }
 
@@ -17,25 +25,59 @@ A simple condition with negates the evaluation of
 a composed condition.
 */
 public struct NegatedCondition<Condition: OperationCondition>: OperationCondition {
-    
+
+    /**
+    The nested condition.
+
+    - parameter condition: a type which conforms to `OperationCondition`
+    */
     public let condition: Condition
-    
+
+    /**
+    The name of the condition wraps the name of the nested
+    OperationCondition.
+
+    - parameter name: a String
+    */
     public var name: String {
         return "Not<\(condition.name)>"
     }
-    
+
+    /**
+    The mututally exclusivity parameter which wraps the
+    nested condition's isMutuallyExclusive property.
+
+    - parameter isMutuallyExclusive: a constant Bool, true.
+    */
     public var isMutuallyExclusive: Bool {
         return condition.isMutuallyExclusive
     }
-    
+
+    /**
+    Initializer which receives a conditon which is to be negated.
+
+    - parameter [unnamed]: a nested `Condition` type.
+    */
     public init(_ c: Condition) {
         condition = c
     }
-    
+
+    /**
+    The dependencies for a negated condition are the same as those of the
+    nested condition.
+
+    - parameter operation: the `Operation` which is getting evaluated.
+    */
     public func dependencyForOperation(operation: Operation) -> NSOperation? {
         return condition.dependencyForOperation(operation)
     }
-    
+
+    /**
+    The evaluation results are inverted.
+
+    - parameter operation: the `Operation` which is getting evaluated.
+    - parameter completion: a block which receives the `OperationConditionResult`.
+    */
     public func evaluateForOperation(operation: Operation, completion: OperationConditionResult -> Void) {
         condition.evaluateForOperation(operation) { [conditionName = condition.name] result in
             switch result {

--- a/Operations/Core/Shared/NoFailedDependenciesCondition.swift
+++ b/Operations/Core/Shared/NoFailedDependenciesCondition.swift
@@ -15,20 +15,43 @@ the target operation will be fail.
 */
 public struct NoFailedDependenciesCondition: OperationCondition {
 
+    /// The `ErrorType` returned to indicate the condition failed.
     public enum Error: ErrorType, Equatable {
+
+        /// When some dependencies were cancelled
         case CancelledDependencies
+
+        /// When some dependencies failed with errors
         case FailedDependencies
     }
 
+    /// A constant name for the condition.
     public let name = "No Cancelled Condition"
+
+    /// A constant flag indicating this condition is not mutually exclusive
     public let isMutuallyExclusive = false
 
+    /// Initializer which takes no parameters.
     public init() { }
 
+    /// Conforms to `OperationCondition` but there are no dependent operations.
     public func dependencyForOperation(operation: Operation) -> NSOperation? {
         return .None
     }
 
+    /**
+    Evaluates the operation with respect to the finished status of its dependencies.
+    
+    The condition first checks if any dependencies were cancelled, in which case it 
+    fails with an `NoFailedDependenciesCondition.Error.CancelledDependencies`. Then
+    it checks to see if any dependencies failed due to errors, in which case it
+    fails with an `NoFailedDependenciesCondition.Error.FailedDependencies`.
+    
+    The cancelled or failed operations are no associated with the error.
+
+    - parameter operation: the `Operation` which the condition is attached to.
+    - parameter completion: the completion block which receives a `OperationConditionResult`.
+    */
     public func evaluateForOperation(operation: Operation, completion: OperationConditionResult -> Void) {
         let dependencies = operation.dependencies
 
@@ -52,6 +75,7 @@ public struct NoFailedDependenciesCondition: OperationCondition {
     }
 }
 
+/// Equatable conformance for `NoFailedDependenciesCondition.Error`
 public func ==(a: NoFailedDependenciesCondition.Error, b: NoFailedDependenciesCondition.Error) -> Bool {
     switch (a, b) {
     case (.CancelledDependencies, .CancelledDependencies), (.FailedDependencies, .FailedDependencies):

--- a/Operations/Core/Shared/OperationCondition.swift
+++ b/Operations/Core/Shared/OperationCondition.swift
@@ -8,17 +8,44 @@
 
 import Foundation
 
-public let OperationConditionKey = "OperationCondition"
-
+/**
+The result of an OperationCondition. Either the condition is
+satisfied, indicated by `.Satisfied` or it has failed. In the
+failure case, an `ErrorType` must be associated with the result.
+*/
 public enum OperationConditionResult {
     case Satisfied
     case Failed(ErrorType)
 }
 
+/**
+Types which conform to `OperationCondition` can be added to `Operation` 
+subclasses before they are added to an `OperationQueue`. If the condition
+returns an `NSOperation` dependency, the dependency relationship will be
+set and it is added to the queue automatically.
+
+Evaluation of the condition only occurs once the dependency has executed.
+
+It is possible to support asynchronous evaluation of the condition, as the
+results, an `OperationConditionResult` is returned in a completion block.
+*/
 public protocol OperationCondition {
 
+    /**
+    The name of the condition.
+
+    - parameter name: a String
+    */
     var name: String { get }
 
+    /**
+    A flag to indicate whether this condition is mutually exclusive. Meaning
+    that only one condition can be evaluated at a time. Other `Operation` 
+    instances which have this condition will wait in a `.Pending` state - i.e.
+    not get executed.
+
+    - parameter isMutuallyExclusive: a Bool
+    */
     var isMutuallyExclusive: Bool { get }
 
     /**
@@ -27,14 +54,19 @@ public protocol OperationCondition {
     an operation that (for example) asks for permission to perform 
     the operation.
 
-    - paramter operation: The `Operation` to which the condition has been added.
+    - parameter operation: The `Operation` to which the condition has been added.
     - returns: An `NSOperation`, if a dependency should be automatically added.
     - note: Only a single operation may be returned.
 
     */
     func dependencyForOperation(operation: Operation) -> NSOperation?
 
-    /// Evaluate the condition, to see if it has been satisfied.
+    /**
+    Evaluate the condition, to see if it has been satisfied.
+    
+    - parameter operation: the `Operation` which this condition is attached to.
+    - parameter completion: a closure which receives an `OperationConditionResult`.
+    */
     func evaluateForOperation(operation: Operation, completion: OperationConditionResult -> Void)
 }
 

--- a/Operations/Core/Shared/OperationObserver.swift
+++ b/Operations/Core/Shared/OperationObserver.swift
@@ -8,12 +8,35 @@
 
 import Foundation
 
-/// A protocol which operation observers must conform to.
+/**
+Types which conform to this protocol, can be attached to `Operation` subclasses before
+they are added to a queue. They will receive callbacks when the operation starts, 
+produces a new operation, and finishes.
+*/
 public protocol OperationObserver {
+
+    /**
+    The operation started.
     
+    - parameter operaton: the observed `Operation`.
+    */
     func operationDidStart(operation: Operation)
+
+    /**
+    The operation produced a new `NSOperation` instance which has been added to the 
+    queue. Note that this isn't necessarily an `Operation`, so be careful, if you 
+    intend to automatically start observing it.
     
+    - parameter operaton: the observed `Operation`.
+    - parameter newOperation: the produced `NSOperation`
+    */
     func operation(operation: Operation, didProduceOperation newOperation: NSOperation)
+
+    /**
+    The operation did finish. Any errors that were encountered are collected here.
     
+    - parameter operaton: the observed `Operation`.
+    - parameter errors: an array of `ErrorType`s.
+    */
     func operationDidFinish(operation: Operation, errors: [ErrorType])
 }

--- a/Operations/Core/Shared/OperationQueue.swift
+++ b/Operations/Core/Shared/OperationQueue.swift
@@ -8,15 +8,51 @@
 
 import Foundation
 
+/**
+A protocol which the `OperationQueue`'s delegate must conform to. The delegate is informed
+when the queue is about to add an operation, and when operations finish. Because it is a 
+delegate protocol, conforming types must be classes, as the queue weakly owns it.
+*/
 public protocol OperationQueueDelegate: class {
+
+    /**
+    The operation queue will add a new operation. This is for information only, the 
+    delegate cannot affect whether the operation is added, or other control flow.
+    
+    - paramter queue: the `OperationQueue`.
+    - paramter operation: the `NSOperation` instance about to be added.
+    */
     func operationQueue(queue: OperationQueue, willAddOperation operation: NSOperation)
+
+    /**
+    An operation has finished on the queue.
+    
+    - parameter queue: the `OperationQueue`.
+    - parameter operation: the `NSOperation` instance which finished.
+    - parameter errors: an array of `ErrorType`s.
+    */
     func operationQueue(queue: OperationQueue, operationDidFinish operation: NSOperation, withErrors errors: [ErrorType])
 }
 
+/**
+An `NSOperationQueue` subclass which supports the features of Operations. All functionality
+is achieved via the overridden functionality of `addOperation`.
+*/
 public class OperationQueue: NSOperationQueue {
 
+    /**
+    The queue's delegate, helpful for reporting activity.
+    
+    - parameter delegate: a weak `OperationQueueDelegate?`
+    */
     public weak var delegate: OperationQueueDelegate? = .None
 
+    /**
+    Adds the operation to the queue. Subclasses which override this method must call this
+    implementation as it is critical to how Operations function.
+    
+    - parameter op: an `NSOperation` instance.
+    */
     public override func addOperation(op: NSOperation) {
         if let operation = op as? Operation {
 
@@ -75,6 +111,12 @@ public class OperationQueue: NSOperationQueue {
         super.addOperation(op)
     }
 
+    /**
+    Adds the operations to the queue.
+
+    - parameter ops: an array of `NSOperation` instances.
+    - parameter wait: a Bool flag which is ignored.
+    */
     public override func addOperations(ops: [NSOperation], waitUntilFinished wait: Bool) {
         ops.forEach(addOperation)
     }

--- a/Operations/Core/Shared/SlientCondition.swift
+++ b/Operations/Core/Shared/SlientCondition.swift
@@ -9,31 +9,64 @@
 import Foundation
 
 /**
-A simple condition which suppresses it's contained condition to not
+A simple condition which suppresses its contained condition to not
 enqueue its dependency. This is useful for verifying access to
 a resoource without prompting for permission.
 */
 public struct SilentCondition<Condition: OperationCondition>: OperationCondition {
 
+    /**
+    The composed condition.
+
+    - parameter condition: a type which conforms to `OperationCondition`
+    */
     public let condition: Condition
 
+    /**
+    The name of the condition wraps the name of the composed
+    OperationCondition.
+
+    - parameter name: a String
+    */
     public var name: String {
-        return "Silent \(condition.name)"
+        return "Silent<\(condition.name)>"
     }
 
+    /**
+    The mututally exclusivity parameter which wraps the
+    composed condition's isMutuallyExclusive property.
+
+    - parameter isMutuallyExclusive: a constant Bool, true.
+    */
     public var isMutuallyExclusive: Bool {
         return condition.isMutuallyExclusive
     }
 
+    /**
+    Initializer which receives a conditon which is to be negated.
+
+    - parameter [unnamed]: a nested `Condition` type.
+    */
     public init(_ c: Condition) {
         condition = c
     }
 
+    /**
+    The dependencies for a silent condition are nil. This is because the "active
+    impact" of the nested condition is to be removed.
+
+    - parameter operation: the `Operation` which is getting evaluated.
+    */
     public func dependencyForOperation(operation: Operation) -> NSOperation? {
-        // Returning nil here supresses the enqueing of another operation.
         return .None
     }
 
+    /**
+    The evaluation results just those of its composed condition.
+
+    - parameter operation: the `Operation` which is getting evaluated.
+    - parameter completion: a block which receives the `OperationConditionResult`.
+    */
     public func evaluateForOperation(operation: Operation, completion: OperationConditionResult -> Void) {
         condition.evaluateForOperation(operation, completion: completion)
     }

--- a/Operations/Core/Shared/Support.swift
+++ b/Operations/Core/Shared/Support.swift
@@ -10,13 +10,33 @@ import Foundation
 
 // MARK: - Queues
 
+/**
+A nice Swift wrapper around `dispatch_queue_create`. The cases
+correspond to GCD's quality of service classes. To get the
+main queue use like this:
+
+    dispatch_async(Queue.Main.queue) {
+       print("I'm on the main queue!")
+    }
+*/
 public enum Queue {
 
+    /// The main queue
     case Main
+
+    /// The default QOS
     case Default
+
+    /// Use for user initiated tasks which do not impact the UI. Such as data processing.
     case Initiated
+
+    /// Use for user initiated tasks which do impact the UI - e.g. a rendering pipeline.
     case Interactive
+
+    /// Use for non-user initiated task.
     case Utility
+
+    /// Backgound QOS is a severly limited class, should not be used for anything when the app is active.
     case Background
 
     private var qos_class: qos_class_t {
@@ -30,6 +50,13 @@ public enum Queue {
         }
     }
 
+    /**
+    Access the appropriate global `dispatch_queue_t`. For `.Main` this
+    is the main queue, for other cases, it is the global queue for the
+    appropriate `qos_class_t`.
+
+    - parameter queue: the corresponding global dispatch_queue_t
+    */
     public var queue: dispatch_queue_t {
         switch self {
         case .Main: return dispatch_get_main_queue()
@@ -37,10 +64,30 @@ public enum Queue {
         }
     }
 
+    /**
+    Creates a named serial queue with the correct QOS class.
+
+    Use like this:
+
+        let queue = Queue.Utility.serial("me.danthorpe.Operation.eg")
+            dispatch_async(queue) {
+            print("I'm on a utility serial queue.")
+        }
+    */
     public func serial(named: String) -> dispatch_queue_t {
         return dispatch_queue_create(named, dispatch_queue_attr_make_with_qos_class(DISPATCH_QUEUE_SERIAL, qos_class, QOS_MIN_RELATIVE_PRIORITY))
     }
 
+    /**
+    Creates a named concurrent queue with the correct QOS class.
+
+    Use like this:
+
+        let queue = Queue.Initiated.concurrent("me.danthorpe.Operation.eg")
+        dispatch_barrier_async(queue) {
+            print("I'm on a initiated concurrent queue.")
+        }
+    */
     public func concurrent(named: String) -> dispatch_queue_t {
         return dispatch_queue_create(named, dispatch_queue_attr_make_with_qos_class(DISPATCH_QUEUE_CONCURRENT, qos_class, QOS_MIN_RELATIVE_PRIORITY))
     }

--- a/Operations/Core/Shared/TimeoutObserver.swift
+++ b/Operations/Core/Shared/TimeoutObserver.swift
@@ -16,10 +16,24 @@ public struct TimeoutObserver: OperationObserver {
 
     private let timeout: NSTimeInterval
 
+    /**
+    Initialize the operation observer with a timeout, which will start when 
+    the operation to which it is attached starts.
+
+    - parameter timeout: a `NSTimeInterval` value.
+    */
     public init(timeout: NSTimeInterval) {
         self.timeout = timeout
     }
 
+    /**
+    Conforms to `OperationObserver`, when the operation starts, it triggers
+    a block using dispatch_after and the time interval. When the block runs,
+    if the operation has not finished and is not cancelled, then it will
+    cancel it with an error of `OperationError.OperationTimedOut`
+    
+    - parameter operation: the `Operation` which will be cancelled if the timeout is reached.
+    */
     public func operationDidStart(operation: Operation) {
         let when = dispatch_time(DISPATCH_TIME_NOW, Int64(timeout * Double(NSEC_PER_SEC)))
 
@@ -31,13 +45,11 @@ public struct TimeoutObserver: OperationObserver {
         }
     }
 
-    public func operation(operation: Operation, didProduceOperation newOperation: NSOperation) {
-        // no-op
-    }
+    /// Conforms to `OperationObserver`, has no opertion for when another operation is produced.
+    public func operation(operation: Operation, didProduceOperation newOperation: NSOperation) {}
 
-    public func operationDidFinish(operation: Operation, errors: [ErrorType]) {
-        // no-op
-    }
+    /// Conforms to `OperationObserver`, has no opertion for when the operation finishes
+    public func operationDidFinish(operation: Operation, errors: [ErrorType]) {}
 }
 
 

--- a/Operations/Core/iOS/AlertOperation.swift
+++ b/Operations/Core/iOS/AlertOperation.swift
@@ -60,6 +60,13 @@ public class AlertOperation<From: PresentingViewController>: Operation {
         }
     }
 
+    /**
+    Creates an `AlertOperation`. It must be constructed with the view
+    controller which the alert will be presented from.
+    
+    - parameter from: a generic type conforming to `PresentingViewController`, 
+    such as an `UIViewController`
+    */
     public init(presentAlertFrom from: From) {
         ui = UIOperation(controller: UIAlertController(title: .None, message: .None, preferredStyle: .Alert), displayControllerFrom: .Present(from))
         super.init()
@@ -73,9 +80,9 @@ public class AlertOperation<From: PresentingViewController>: Operation {
     Do not add actions directly to the `UIAlertController`, as
     this will prevent the `AlertOperation` from correctly finishing.
     
-    :param: title, a required String.
-    :param: style, a `UIAlertActionStyle` which defaults to `.Default`.
-    :param: handler, a block which receives the operation, and returns Void.
+    - parameter title, a required String.
+    - parameter style, a `UIAlertActionStyle` which defaults to `.Default`.
+    - parameter handler, a block which receives the operation, and returns Void.
     */
     public func addActionWithTitle(title: String, style: UIAlertActionStyle = .Default, handler: AlertOperation -> Void = { _ in }) {
         let action = UIAlertAction(title: title, style: style) { [weak self] _ in
@@ -87,6 +94,11 @@ public class AlertOperation<From: PresentingViewController>: Operation {
         alert.addAction(action)
     }
 
+    /**
+    Will add a default "Okay" action (`NSLocalizedString("Okay", comment: "Okay")`)
+    if the alert has no actions. Will then produce the UI operation which presents
+    the alert controller.
+    */
     public override func execute() {
         if alert.actions.isEmpty {
             addActionWithTitle(NSLocalizedString("Okay", comment: "Okay"))

--- a/Operations/Core/iOS/AlertOperation.swift
+++ b/Operations/Core/iOS/AlertOperation.swift
@@ -80,9 +80,9 @@ public class AlertOperation<From: PresentingViewController>: Operation {
     Do not add actions directly to the `UIAlertController`, as
     this will prevent the `AlertOperation` from correctly finishing.
     
-    - parameter title, a required String.
-    - parameter style, a `UIAlertActionStyle` which defaults to `.Default`.
-    - parameter handler, a block which receives the operation, and returns Void.
+    - parameter title: a required String.
+    - parameter style: a `UIAlertActionStyle` which defaults to `.Default`.
+    - parameter handler: a block which receives the operation, and returns Void.
     */
     public func addActionWithTitle(title: String, style: UIAlertActionStyle = .Default, handler: AlertOperation -> Void = { _ in }) {
         let action = UIAlertAction(title: title, style: style) { [weak self] _ in

--- a/Operations/Core/iOS/BackgroundObserver.swift
+++ b/Operations/Core/iOS/BackgroundObserver.swift
@@ -25,7 +25,7 @@ if the app goes in the background.
 */
 public class BackgroundObserver: NSObject {
 
-    public static let backgroundTaskName = "Background Operation Observer"
+    static let backgroundTaskName = "Background Operation Observer"
 
     private var identifier: UIBackgroundTaskIdentifier? = .None
     private let application: BackgroundTaskApplicationInterface
@@ -34,6 +34,7 @@ public class BackgroundObserver: NSObject {
         return application.applicationState == .Background
     }
 
+    /// Initialize a `BackgroundObserver`, takes no parameters.
     public override convenience init() {
         self.init(app: UIApplication.sharedApplication())
     }
@@ -86,14 +87,13 @@ public class BackgroundObserver: NSObject {
 
 extension BackgroundObserver: OperationObserver {
 
-    public func operationDidStart(operation: Operation) {
-        // no-op
-    }
+    /// Conforms to `OperationObserver`, has no opertion for when the operation finishes
+    public func operationDidStart(operation: Operation) {}
 
-    public func operation(operation: Operation, didProduceOperation newOperation: NSOperation) {
-        // no-op
-    }
+    /// Conforms to `OperationObserver`, has no opertion for when another operation is produced.
+    public func operation(operation: Operation, didProduceOperation newOperation: NSOperation) {}
 
+    /// Conforms to `OperationObserver`, will end any background task that has been started.
     public func operationDidFinish(operation: Operation, errors: [ErrorType]) {
         endBackgroundTask()
     }

--- a/Operations/Core/iOS/NetworkObserver.swift
+++ b/Operations/Core/iOS/NetworkObserver.swift
@@ -8,7 +8,7 @@
 
 import UIKit
 
-public protocol NetworkActivityIndicatorInterface {
+protocol NetworkActivityIndicatorInterface {
     var networkActivityIndicatorVisible: Bool { get set }
 }
 
@@ -23,6 +23,7 @@ public class NetworkObserver: OperationObserver {
 
     let networkActivityIndicator: NetworkActivityIndicatorInterface
 
+    /// Initializer takes no parameters.
     public convenience init() {
         self.init(indicator: UIApplication.sharedApplication())
     }
@@ -31,6 +32,7 @@ public class NetworkObserver: OperationObserver {
         networkActivityIndicator = indicator
     }
 
+    /// Conforms to `OperationObserver`, will start the network activity indicator.
     public func operationDidStart(operation: Operation) {
         dispatch_async(Queue.Main.queue) {
             NetworkIndicatorController.sharedInstance.networkActivityIndicator = self.networkActivityIndicator
@@ -38,10 +40,12 @@ public class NetworkObserver: OperationObserver {
         }
     }
 
+    /// Conforms to `OperationObserver`, has no opertion for when another operation is produced.
     public func operation(operation: Operation, didProduceOperation newOperation: NSOperation) {
         // no-op
     }
 
+    /// Conforms to `OperationObserver`, will stop the network activity indicator.
     public func operationDidFinish(operation: Operation, errors: [ErrorType]) {
         dispatch_async(Queue.Main.queue) {
             NetworkIndicatorController.sharedInstance.networkActivityIndicator = self.networkActivityIndicator

--- a/Operations/Core/iOS/UIOperation.swift
+++ b/Operations/Core/iOS/UIOperation.swift
@@ -10,24 +10,61 @@ import UIKit
 
 // MARK: - UI
 
+/**
+A protocol which defines the presentation API used for `UIOperation`. This is mostly to provide testability.
+*/
 public protocol PresentingViewController: class {
+
+    /**
+    Presents the view controller.
+
+    - parameter viewController: the `UIViewController` being presented.
+    - parameter animated: a `Bool` flag to indicate whether the presentation should be animated.
+    - parameter completion: a completion block which may be nil.
+    */
     func presentViewController(viewController: UIViewController, animated: Bool, completion: (() -> Void)?)
 
+
     @available(iOS 8.0, *)
+    /**
+    Shows the view controller.
+
+    - parameter vc: the `UIViewController` being presented.
+    - parameter sender: an optional `AnyObject`, usually this is a `UIControl`.
+    */
     func showViewController(vc: UIViewController, sender: AnyObject?)
 
     @available(iOS 8.0, *)
+    /**
+    Shows the view controller as a detail controller in a split view controller.
+
+    - parameter vc: the `UIViewController` being presented.
+    - parameter sender: an optional `AnyObject`, usually this is a `UIControl`.
+    */
     func showDetailViewController(vc: UIViewController, sender: AnyObject?)
 }
 
 extension UIViewController: PresentingViewController { }
 
+/**
+A simple enum to convey how a view controller should be presented. The view controller
+which performs the presentation is stored as an associated type, and is generic. So, 
+to present a detail view controller from a master view controller say, it would be
+used like this
+
+    let from: ViewControllerDisplayStyle = .ShowDetail(masterViewController)
+    from.displayController(detailViewController, sender: .None, completion: .None)
+
+This enum is used as an argument for the `UIOperation` class which usually is 
+responsible for creating the view controller which is to be presented.
+*/
 public enum ViewControllerDisplayStyle<ViewController: PresentingViewController> {
 
     case Show(ViewController)
     case ShowDetail(ViewController)
     case Present(ViewController)
 
+    /// Access the associated view controller.
     public var controller: ViewController {
         switch self {
         case .Show(let controller):
@@ -39,6 +76,16 @@ public enum ViewControllerDisplayStyle<ViewController: PresentingViewController>
         }
     }
 
+    /**
+    A function which will present the view controller from the associated view controller property.
+    
+    When the style is `.Present`, and the controller is not a `UIAlertController`, it is automatically
+    placed as the root controller of a `UINavigationController` which is then presented.
+
+    - parameter controller: a `UIViewController` subclass which will be presented.
+    - parameter sender: an optional `AnyObject` used as the sender when showing the view controller
+    - parameter completion: an optional completio block.
+    */
     public func displayController<C where C: UIViewController>(controller: C, sender: AnyObject?, completion: (() -> Void)?) {
         switch self {
 
@@ -60,17 +107,44 @@ public enum ViewControllerDisplayStyle<ViewController: PresentingViewController>
     }
 }
 
-public enum UIOperationError: ErrorType {
-    case PresentationViewControllerNotSet
-}
+/**
+`UIOperation` is an `Operation` subclass which is responsible for presenting one view controller
+from another view controller. The operation is generic over both of these types. It uses
+standard `UIViewController` presentation APIs. These APIs have been condensed into the 
+`PresentingViewController` protocol, meaning that the *presenting* generic type is just something
+conforming to this protocol. This is for testing purposes, don't let it confuse you, the From 
+generic type is your view controller.
 
+However, note that the presenting view controller is associated into a `ViewControllerDisplayStyle`.
+This enum lets you define how the view controller should be presented. Either, "show", "show detail" or
+"present".
+*/
 public class UIOperation<C, From where C: UIViewController, From: PresentingViewController>: Operation {
 
+    /// The controller which will be presented.
     public let controller: C
+
+    /// The presenting `ViewControllerDisplayStyle`
     public let from: ViewControllerDisplayStyle<From>
+
+    /// The `AnyObject` sender.
     public let sender: AnyObject?
     let completion: (() -> Void)?
 
+    /**
+    Construct a `UIOperation` with the presented view controller, the presenting view controller display 
+    style, and optional sender and completion blocks. For example...
+    
+        let ui = UIOperation(
+            controller: detailViewController, 
+            displayControllerFrom: .ShowDetail(myViewController)
+        )
+    
+    - parameter controller: the generic `UIViewController` subclass.
+    - parameter displayControllerFrom: a ViewControllerDisplayStyle<From> value.
+    - parameter sender: an optional `AnyObject` see docs for UIViewController.
+    - parameter completion: an optional void block, see docs for UIViewController.
+    */
     public init(controller: C, displayControllerFrom from: ViewControllerDisplayStyle<From>, sender: AnyObject? = .None, completion: (() -> Void)? = .None) {
         self.controller = controller
         self.from = from
@@ -78,6 +152,11 @@ public class UIOperation<C, From where C: UIViewController, From: PresentingView
         self.completion = completion
     }
 
+    /**
+    When the operation executes, on the main queue, it calls `displayController` on the
+    ViewControllerDisplayStyle, which in turn will execute either `presentViewController`, 
+    `showViewController`, or `showDetailViewController`.
+    */
     public override func execute() {
         dispatch_async(Queue.Main.queue) {
             self.from.displayController(self.controller, sender: self.sender, completion: self.completion)

--- a/OperationsTests/Core/SilentConditionTests.swift
+++ b/OperationsTests/Core/SilentConditionTests.swift
@@ -14,6 +14,6 @@ class SilentConditionTests: XCTestCase {
     func test__silent_condition_composes_name_correctly() {
         let condition = BlockCondition { false }
         let silent = SilentCondition(condition)
-        XCTAssertEqual(silent.name, "Silent Block Condition")
+        XCTAssertEqual(silent.name, "Silent<Block Condition>")
     }
 }


### PR DESCRIPTION
Documentation in the source code is pretty dismal - less than 10%. So, will aim to fix that in a number of tickets for 2.3 release.

In this ticket...
- [x] Core / Foundation (up to 12% documentation coverage)
- [x] Core / Conditions (up to 15% documentation coverage)
- [x] Core / Observers (up to 18% documentation coverage)
- [x] Core / Operations (up to 22% documentation coverage)

In future tickets...
- [ ] Features / Capability
- [ ] Features / Conditions
- [ ] Features / Operations
- [ ] Features / Support
- [ ] Extras / AddressBook