### PR TITLE
Bug with ReachableOperation

### DIFF
--- a/Operations/Features/Shared/ReachableOperation.swift
+++ b/Operations/Features/Shared/ReachableOperation.swift
@@ -33,10 +33,10 @@ public class ReachableOperation<O: NSOperation>: GroupOperation {
     Composes an operation to ensure that is will definitely be executed as soon as
     the required kind of connectivity is achieved.
     
-    :param: operation, any `NSOperation` type.
-    :param: connectivity, a `Reachability.Connectivity` value, defaults to `.AnyConnectionKind`.
+    - parameter [unlabeled] operation: any `NSOperation` type.
+    - parameter connectivity: a `Reachability.Connectivity` value, defaults to `.AnyConnectionKind`.
     */
-    public convenience init(operation: O, connectivity: Reachability.Connectivity = .AnyConnectionKind) {
+    public convenience init(_ operation: O, connectivity: Reachability.Connectivity = .AnyConnectionKind) {
         self.init(operation: operation, connectivity: connectivity, reachability: Reachability.sharedInstance)
     }
 


### PR DESCRIPTION
There is a subtle bug with `ReachableOperation`, which can result in the composed operation not executing even though the network is reachable.

The scenario is simply that the first time a `ReachableOperation` is executed, it will setup it's fire mechanism with no reachable flags. Therefore - there is a change, and all observers are notified.

However, if you then create another `ReachableOperation` - the system reachability object begin executing again (as there is a new observer) - however the flags are known - so if there isn't any change, they won't fire, and the new observer will not be notified.