### PR TITLE
Proper cancellation?

### DIFF
--- a/Operations/Core/Shared/Operation.swift
+++ b/Operations/Core/Shared/Operation.swift
@@ -76,10 +76,6 @@ public class Operation: NSOperation {
         return ["state"]
     }
 
-    class func keyPathsForValuesAffectingIsCancelled() -> Set<NSObject> {
-        return ["state"]
-    }
-
     private var _state = State.Initialized
     private let stateLock = NSLock()
 
@@ -291,12 +287,12 @@ public class Operation: NSOperation {
 
     /**
     Finish method which must be called eventually after an operation has
-    begun executing.
+    begun executing, unless it is cancelled.
 
     - parameter errors: an array of `ErrorType`, which defaults to empty.
     */
     final public func finish(errors: [ErrorType] = []) {
-        if !hasFinishedAlready && !cancelled {
+        if !hasFinishedAlready {
             hasFinishedAlready = true
             state = .Finishing
 

--- a/Operations/Core/Shared/Operation.swift
+++ b/Operations/Core/Shared/Operation.swift
@@ -296,7 +296,7 @@ public class Operation: NSOperation {
     - parameter errors: an array of `ErrorType`, which defaults to empty.
     */
     final public func finish(errors: [ErrorType] = []) {
-        if !hasFinishedAlready {
+        if !hasFinishedAlready && !cancelled {
             hasFinishedAlready = true
             state = .Finishing
 

--- a/OperationsTests/Core/OperationTests.swift
+++ b/OperationsTests/Core/OperationTests.swift
@@ -138,6 +138,14 @@ class BasicTests: OperationTests {
         XCTAssertNotEqual(OperationError.ConditionFailed, OperationError.OperationTimedOut(1.0))
         XCTAssertNotEqual(OperationError.OperationTimedOut(2.0), OperationError.OperationTimedOut(1.0))
     }
+
+    func test__finishing_cancelled_operation() {
+        let operation = TestOperation(delay: 1)
+        operation.cancel()
+        operation.finish()
+        XCTAssertTrue(operation.cancelled)
+        XCTAssertFalse(operation.finished)
+    }
 }
 
 class BlockOperationTests: OperationTests {

--- a/OperationsTests/Core/OperationTests.swift
+++ b/OperationsTests/Core/OperationTests.swift
@@ -138,14 +138,6 @@ class BasicTests: OperationTests {
         XCTAssertNotEqual(OperationError.ConditionFailed, OperationError.OperationTimedOut(1.0))
         XCTAssertNotEqual(OperationError.OperationTimedOut(2.0), OperationError.OperationTimedOut(1.0))
     }
-
-    func test__finishing_cancelled_operation() {
-        let operation = TestOperation(delay: 1)
-        operation.cancel()
-        operation.finish()
-        XCTAssertTrue(operation.cancelled)
-        XCTAssertFalse(operation.finished)
-    }
 }
 
 class BlockOperationTests: OperationTests {


### PR DESCRIPTION
In the process of implementing a logout handler for a special operation queue I use for all of my network operations, I've become confused as to what the proper cancellation behavior should be for `Operation` subclasses. For context, this is my `NetworkOperation` that wraps an Alamofire `Request`:
```swift
class NetworkOperation<T: Decodable where T == T.DecodedType> : Operation {
    let request: Request
    var completionHandler: ((T?, APIError?) -> Void)? = nil
    
    init(request: Request) {
        self.request = request
        
        super.init()
        
        request.responseObject { (responseObject: T?, error: APIError?) in
            if let error = error where error.isInvalidTokenError {
                self.finish(error)
            }
            else {
                self.completionHandler?(responseObject, error)
                self.finish(error)
            }
        }
        
        addObserver(NetworkObserver())
        addObserver(LoggingObserver())
    }
    
    override func execute() {
        request.resume()
    }
    
    override func cancel() {
        request.cancel()
        super.cancel()
    }
}
```
These operations are wrapped by a `GroupOperation` subclass that can be wrapped by yet another `GroupOperation` subclass or called directly on my `OperationQueue` subclass. Looking at your recently added `NetworkOperation` subclass, the implementation is largely the same regarding the execute and cancel implementations. However, as I've implemented a logout function that wraps my `OperationQueue`'s `cancelAllOperations()`, I've started seeing the following logged in the console:
`NetworkOperation went isFinished=YES without being started by the queue it is in` when canceling a `NetworkOperation` that was enqueued on an internal `GroupOperation` queue and the `GroupOperation` was subsequently cancelled.

In investigating this issue, I've noticed a discrepancy between the `NSOperation` docs regarding subclassing, and the implementation of `Operation`. `Operation` implements `start()` thusly:
```swift
/// Starts the operation, correctly managing the cancelled state. Cannot be over-ridden
public override final func start() {
    // NSOperation.start() has important logic which shouldn't be bypassed
    super.start()
    // If the operation has been cancelled, we still need to enter the finished state
    if cancelled {
        finish()
    }
}
```
Yet the `NSOperation` docs say: `At no time in your start method should you ever call super.` Are the docs wrong in this instance?

In general though, what can I do in my `Operation` subclass to avoid that cancellation warning? As far as I understand, I shouldn't have to check in my `execute()` whether or not the operation is cancelled, as the underlying `start()`  and `main()` implementations handle that already.
