### PR TITLE
Investigate BuildKite auto generated build pipelines...

### DIFF
--- a/.buildkite/pipeline.sh
+++ b/.buildkite/pipeline.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+set -eu
+
+# Makes sure all the steps run on this same agent
+sed "s/\$BUILDKITE_AGENT_META_DATA_NAME/$BUILDKITE_AGENT_META_DATA_NAME/" pipeline.template.yml

--- a/.buildkite/pipeline.sh
+++ b/.buildkite/pipeline.sh
@@ -3,4 +3,4 @@
 set -eu
 
 # Makes sure all the steps run on this same agent
-sed "s/\$BUILDKITE_AGENT_META_DATA_NAME/$BUILDKITE_AGENT_META_DATA_NAME/" pipeline.template.yml
+sed "s/\$BUILDKITE_AGENT_META_DATA_NAME/$BUILDKITE_AGENT_META_DATA_NAME/" .buildkite/pipeline.template.yml

--- a/.buildkite/pipeline.template.yml
+++ b/.buildkite/pipeline.template.yml
@@ -1,0 +1,26 @@
+steps:
+  -
+    name: ":fastlane: Verify Xcode"
+    command: .scripts/verify-xcode.sh
+    agents:
+      name: "$BUILDKITE_AGENT_META_DATA_NAME"
+  -
+    name: ":fastlane: Test iOS Extension Only"
+    command: .scripts/test-extension.sh
+    agents:
+      name: "$BUILDKITE_AGENT_META_DATA_NAME"
+  -
+    name: ":fastlane: Test Mac OS X"
+    command: .scripts/test-osx.sh
+    agents:
+      name: "$BUILDKITE_AGENT_META_DATA_NAME"
+  -
+    name: ":fastlane: Test iOS"
+    command: .scripts/test-ios.sh
+    agents:
+      name: "$BUILDKITE_AGENT_META_DATA_NAME"
+  -
+    name: "Send Coverage"
+    command: .scripts/send-coverage.sh
+    agents:
+      name: "$BUILDKITE_AGENT_META_DATA_NAME"

--- a/.buildkite/pipeline.template.yml
+++ b/.buildkite/pipeline.template.yml
@@ -20,6 +20,8 @@ steps:
     agents:
       name: "$BUILDKITE_AGENT_META_DATA_NAME"
   -
+    type: "waiter"
+  -
     name: "Send Coverage"
     command: .scripts/send-coverage.sh
     agents:


### PR DESCRIPTION
BuildKite supports a pretty powerful feature for [uploading build pipelines](https://buildkite.com/docs/agent/uploading-pipelines). Which is essentially a way to store the build pipeline (i.e. what happens on a build) inside a file within source control, and have them uploaded to the agent / checked out at runtime.

The aim of this ticket is to re-create the current build which does

```
Verify Xcode -> Test iOS Extension -> Test OS X -> Test iOS App -> Send Test Coverage
```

but in a way that each step is executed on the same agent, but support multiple agents in BuildKite. The trick to getting this to work, will be to define a common key, with unique values for each agent (essentially their name). When uploading a pipeline, from a build template - need to replace this agent config flag at runtime.

This will allow us to have multiple agents, but will always use the same agent for all steps of a single build - but it would support multiple builds simultaneously.