### PR TITLE
RemoteNotificationName conflicts DidRegisterSettingsNotificationName

### DIFF
--- a/Sources/Features/iOS/RemoteNotificationCondition.swift
+++ b/Sources/Features/iOS/RemoteNotificationCondition.swift
@@ -127,7 +127,7 @@ public class RemoteNotificationsRegistration: Operation {
     }
 }
 
-private let RemoteNotificationName = "DidRegisterSettingsNotificationName"
+private let RemoteNotificationName = "RemoteNotificationName"
 private let RemoteNotificationTokenKey = "RemoteNotificationTokenKey"
 private let RemoteNotificationErrorKey = "RemoteNotificationErrorKey"
 


### PR DESCRIPTION
The two notification names conflict, which cause unexpected notification handling when RemoteNotificationsRegistration and UserNotificationPermissionOperation are used simultaneously.