### PR TITLE
Update README & Wiki

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,12 @@
 
 # Operations
 
-A Swift framework inspired by WWDC 2015 Advanced NSOperations session. See the session video [here](https://developer.apple.com/videos/wwdc/2015/?id=226). There is a programming guide available here: [operations.readme.io](https://operations.readme.io). Reference documentation is available here: [docs.danthorpe.me/operations](http://docs.danthorpe.me/operations/2.4.1/index.html).
+A Swift framework inspired by WWDC 2015 Advanced NSOperations session.
+
+---|---
+Session video | [developer.apple.com](https://developer.apple.com/videos/wwdc/2015/?id=226)
+Reference documentation | [docs.danthorpe.me/operations](http://docs.danthorpe.me/operations/2.4.1/index.html)
+Programming guide | [operations.readme.io](https://operations.readme.io)
 
 ## Usage
 
@@ -139,7 +144,7 @@ Recently it was discovered that it is not currently possible to install the API 
 
 I want to stress that this code is heavily influenced by Apple. In no way am I attempting to assume any sort of credit for this architecture - that goes to [Dave DeLong](https://twitter.com/davedelong) and his team. My motivations are that I want to adopt this code in my own projects, and so require a solid well tested framework which I can integrate with.
 
-### Other Advanced NSOperations
+### Other *Advanced NSOperations*
 Other developers have created projects based off Apple’a WWDC sample code. Check them out too.
 
 1. [PSOperations](https://github.com/pluralsight/PSOperations)

--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@
 
 A Swift framework inspired by WWDC 2015 Advanced NSOperations session.
 
----|---
+Resource | Where to find it
+-------|-------
 Session video | [developer.apple.com](https://developer.apple.com/videos/wwdc/2015/?id=226)
 Reference documentation | [docs.danthorpe.me/operations](http://docs.danthorpe.me/operations/2.4.1/index.html)
 Programming guide | [operations.readme.io](https://operations.readme.io)

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ class NumberCrunchingOperation: Operation {
 This is a contrived example, to show two key points:
 
 1. Always override `execute` (instead of `NSOperation`’s `main`)
-2. Always call `finish()`, or `finishWithError() when execution is complete.
+2. Always call `finish()`, or `finishWithError()` when execution is complete.
 
 But, if you are not familiar with `NSOperation` or haven’t yet watched the [WWDC video](https://developer.apple.com/videos/wwdc/2015/?id=226), you might be wondering why? After all, surely this is easier:
 
@@ -52,7 +52,7 @@ TODO: Explain the Operation State Machine
 
 ## Observers & Conditions
 
-Observers and Conditions are components which can be added to an `Operation` instances. There are the building blocks of the “advanced” features this framework provides.
+Observers and Conditions are components which can be added to `Operation` instances. There are the building blocks of the “advanced” features this framework provides.
 
 ### Observers
 

--- a/README.md
+++ b/README.md
@@ -53,19 +53,24 @@ Conditions are attached to an `Operation`. Before an operation is ready to execu
 
 ```swift
 operation.addCondition(BlockCondition { 
-    // operation will only be executed if this is true
+    // operation will finish with an error if this is false
     return trueOrFalse
 }
 ``` 
 
 Conditions can be mutually exclusive which is akin to a lock being held preventing other operations with the same exclusion being executed.
 
-The framework provides `AuthorizedFor`, `BlockCondition`, `MutuallyExclusive`, `NegatedCondition`, `NoFailedDependenciesCondition`, `SilentCondition`, `ReachilityCondition`, `RemoteNotificationCondition`, `UserConfirmationCondition` and `UserNotificationCondition`.
+The framework provides the following conditions: `AuthorizedFor`, `BlockCondition`, `MutuallyExclusive`, `NegatedCondition`, `NoFailedDependenciesCondition`, `SilentCondition`, `ReachilityCondition`, `RemoteNotificationCondition`, `UserConfirmationCondition` and `UserNotificationCondition`.
 
 See the programming guide on [Conditions](https://operations.readme.io/docs/conditions) for more information.
 
 ## Capabilities
-`CapabilityType` is a protocol which represents the applications authorization to access device or user account abilities. For example, location services, cloud kit contains, calendars etc. The protocol provides a unified model for checking the current authorization status, using `GetAuthorizationStatus`, explicitly requesting access, using `Authorize`, and as a condition with `AuthorizedFor`. For example:
+`CapabilityType` is a protocol which represents the application’s authorization to access device or user account abilities. For example, location services, cloud kit containers, calendars etc. The protocol provides a unified model to 
+1. Check the current authorization status, using `GetAuthorizationStatus`, 
+2. Explicitly request access, using `Authorize`
+3. Both of the above as a condition called `AuthorizedFor`. 
+
+For example:
 
 ```swift
 class ReminderOperation: Operation {
@@ -101,7 +106,7 @@ class LogExample: Operation {
 See the programming guide for more information: [logging](https://operations.readme.io/docs/logging) and [supporting 3rd party log frameworks](https://operations.readme.io/docs/custom-logging).
 
 ## Injecting Results
-State can be seamlessly transitioned between operations automatically. An operation which produces a *result* must conform to `ResultOperationType` and expose state via its `result` property. An operation which consumes state, has a *requirement* which must be set via its `requirement` property. Given conformance to these protocols, operations can be chained together:
+State can be seamlessly transitioned between operations automatically. An operation which produces a *result* can conform to `ResultOperationType` and expose state via its `result` property. An operation which consumes state, can conform to `AutomaticInjectionOperationType` and set its *requirement* via its `requirement` property. Given conformance to these protocols, operations can be chained together:
 
 ```swift
 let retrieval = DataRetrieval()
@@ -111,11 +116,6 @@ queue.addOperations(retrieval, processing)
 ```
 
 See the programming guide on [Injecting Results](https://operations.readme.io/docs/injecting-results) for more information.
-
-
-## Status - 21st Dec, 2015
-
-As of version 2.3, Operations is a multi-platform framework, with CocoaPods support in addition to framework targets for iOS Extensions, iOS Apps, OS X, watchOS and tvOS.
 
 ## Installation
 
@@ -138,4 +138,9 @@ Recently it was discovered that it is not currently possible to install the API 
 ## Motivation
 
 I want to stress that this code is heavily influenced by Apple. In no way am I attempting to assume any sort of credit for this architecture - that goes to [Dave DeLong](https://twitter.com/davedelong) and his team. My motivations are that I want to adopt this code in my own projects, and so require a solid well tested framework which I can integrate with.
+
+### Other Advanced NSOperations
+Other developers have created projects based off Apple’a WWDC sample code. Check them out too.
+
+1. [PSOperations](https://github.com/pluralsight/PSOperations)
 

--- a/README.md
+++ b/README.md
@@ -138,8 +138,13 @@ pod 'Operations'
 
 ### Carthage
 
-Recently it was discovered that it is not currently possible to install the API Extension compatible framework via Carthage. This boiled down to having two schemes for the same platform, and Carthage doesn’t provide a way to pick. Now, there are two separate projects, one for API extension compatible frameworks only, which doesn’t actually solve the problem. But, there is a [pull request](https://github.com/Carthage/Carthage/pull/892) which should allow all projects to be build. For now, the only semi-automatic way to integrate these flavors is to use Cocoapods: `pod 'Operations/Extension'`. 
+Add the following line to your Cartfile:
 
+```ruby
+github 'danthorpe/Operations'
+```
+
+It was recently discovered that it is not currently possible to install the API extension compatible framework via Carthage. This boiled down to having two schemes for the same platform, and Carthage doesn’t provide a way to pick. As of now, there are two separate projects. One for standard application version, and one for API extension compatible frameworks only. This doesn’t actually solve the problem, but there is a [pull request](https://github.com/Carthage/Carthage/pull/892) which should allow all projects in a repo to be built. For now, the only semi-automatic way to integrate these flavors is to use Cocoapods: `pod 'Operations/Extension'`. 
 
 ## Motivation
 


### PR DESCRIPTION
Definitely need to update the README to help people understand what Operations is all about. Off the top of my head, these are the things which need improving or better guidance.

- [x] Better / simpler / shorter examples of `Operation` subclasses
- [x] Example usage of provided conditions, observers, operations.
- [x] Device Capability permissions, including when to use `AuthorizedFor` or `GetAuthorizationStatus`.
- [x] Links to & compatibility with other *Advanced NSOperations* style frameworks.
- [x] Improved guides/info on writing custom `Operation` subclasses, what methods to override, how to manage cancellation.
- [x] When & how to use `GroupOperation` - other methods for scheduling & dependency management.
- [x] Use of built in logging capabilities
- [x] When & how to use mutual exclusivity