### PR TITLE
Retry Operation

### DIFF
--- a/Operations.xcodeproj/project.pbxproj
+++ b/Operations.xcodeproj/project.pbxproj
@@ -232,6 +232,9 @@
 		658158461C20DBAD0086FB2A /* ResultInjection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 658158441C20DBAD0086FB2A /* ResultInjection.swift */; };
 		658158471C20DBAD0086FB2A /* ResultInjection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 658158441C20DBAD0086FB2A /* ResultInjection.swift */; };
 		658158481C20DBAD0086FB2A /* ResultInjection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 658158441C20DBAD0086FB2A /* ResultInjection.swift */; };
+		65AE14971C34865E00F592D2 /* RetryOperationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65AE14961C34865E00F592D2 /* RetryOperationTests.swift */; };
+		65AE14981C34865E00F592D2 /* RetryOperationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65AE14961C34865E00F592D2 /* RetryOperationTests.swift */; };
+		65AE14991C34865E00F592D2 /* RetryOperationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65AE14961C34865E00F592D2 /* RetryOperationTests.swift */; };
 		65C98C721C281EEC00BA76B7 /* FunctionalOperations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65C98C711C281EEC00BA76B7 /* FunctionalOperations.swift */; };
 		65C98C731C281EEC00BA76B7 /* FunctionalOperations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65C98C711C281EEC00BA76B7 /* FunctionalOperations.swift */; };
 		65C98C741C281EEC00BA76B7 /* FunctionalOperations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65C98C711C281EEC00BA76B7 /* FunctionalOperations.swift */; };
@@ -375,6 +378,7 @@
 		658158441C20DBAD0086FB2A /* ResultInjection.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ResultInjection.swift; sourceTree = "<group>"; };
 		65A6BA7B1C220F09003A375D /* HealthCapability.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HealthCapability.swift; sourceTree = "<group>"; };
 		65A6BA7E1C220FBD003A375D /* HealthCapabilityTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HealthCapabilityTests.swift; sourceTree = "<group>"; };
+		65AE14961C34865E00F592D2 /* RetryOperationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RetryOperationTests.swift; sourceTree = "<group>"; };
 		65C98C711C281EEC00BA76B7 /* FunctionalOperations.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FunctionalOperations.swift; sourceTree = "<group>"; };
 		65C98C761C284EA600BA76B7 /* FunctionalOperationsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FunctionalOperationsTests.swift; sourceTree = "<group>"; };
 		65E4CDDC1C33422100B9F9D8 /* RetryOperation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RetryOperation.swift; sourceTree = "<group>"; };
@@ -646,6 +650,7 @@
 				652617171C11F5EB00654091 /* OperationTests.swift */,
 				65E4CDE61C33F97900B9F9D8 /* RepeatedOperationTests.swift */,
 				65691C9D1C21A29C00AF06B4 /* ResultInjectionTests.swift */,
+				65AE14961C34865E00F592D2 /* RetryOperationTests.swift */,
 				652617181C11F5EB00654091 /* SilentConditionTests.swift */,
 				652617191C11F5EB00654091 /* TimeoutObserverTests.swift */,
 				6526171A1C11F5EB00654091 /* UIOperationTests.swift */,
@@ -1108,6 +1113,7 @@
 				6526191D1C11FC3D00654091 /* AlertOperationTests.swift in Sources */,
 				6526197C1C11FE6D00654091 /* AddressBookTests.swift in Sources */,
 				6526191E1C11FC3D00654091 /* BackgroundObserverTests.swift in Sources */,
+				65AE14971C34865E00F592D2 /* RetryOperationTests.swift in Sources */,
 				652619221C11FC3D00654091 /* GroupOperationTests.swift in Sources */,
 				652619241C11FC3D00654091 /* LoggingTests.swift in Sources */,
 				652619711C11FE6900654091 /* LocationCapabilityTests.swift in Sources */,
@@ -1221,6 +1227,7 @@
 				65691C9F1C21A29C00AF06B4 /* ResultInjectionTests.swift in Sources */,
 				652619391C11FC3E00654091 /* OperationTests.swift in Sources */,
 				6526192D1C11FC3E00654091 /* AlertOperationTests.swift in Sources */,
+				65AE14981C34865E00F592D2 /* RetryOperationTests.swift in Sources */,
 				6526192E1C11FC3E00654091 /* BackgroundObserverTests.swift in Sources */,
 				652619321C11FC3E00654091 /* GroupOperationTests.swift in Sources */,
 				652619341C11FC3E00654091 /* LoggingTests.swift in Sources */,
@@ -1277,6 +1284,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				65AE14991C34865E00F592D2 /* RetryOperationTests.swift in Sources */,
 				657DBA351C208830001E00F3 /* BlockObserverTests.swift in Sources */,
 				652619461C11FC3F00654091 /* NegatedConditionTests.swift in Sources */,
 				652619501C11FCFF00654091 /* CloudCapabilityTests.swift in Sources */,

--- a/Operations.xcodeproj/project.pbxproj
+++ b/Operations.xcodeproj/project.pbxproj
@@ -239,6 +239,14 @@
 		65C98C771C284EA600BA76B7 /* FunctionalOperationsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65C98C761C284EA600BA76B7 /* FunctionalOperationsTests.swift */; };
 		65C98C781C284EA600BA76B7 /* FunctionalOperationsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65C98C761C284EA600BA76B7 /* FunctionalOperationsTests.swift */; };
 		65C98C791C284EA600BA76B7 /* FunctionalOperationsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65C98C761C284EA600BA76B7 /* FunctionalOperationsTests.swift */; };
+		65E4CDDD1C33422100B9F9D8 /* RetryOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65E4CDDC1C33422100B9F9D8 /* RetryOperation.swift */; };
+		65E4CDDE1C33422100B9F9D8 /* RetryOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65E4CDDC1C33422100B9F9D8 /* RetryOperation.swift */; };
+		65E4CDDF1C33422100B9F9D8 /* RetryOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65E4CDDC1C33422100B9F9D8 /* RetryOperation.swift */; };
+		65E4CDE01C33422100B9F9D8 /* RetryOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65E4CDDC1C33422100B9F9D8 /* RetryOperation.swift */; };
+		65E4CDE21C33427500B9F9D8 /* RepeatedOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65E4CDE11C33427500B9F9D8 /* RepeatedOperation.swift */; };
+		65E4CDE31C33427500B9F9D8 /* RepeatedOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65E4CDE11C33427500B9F9D8 /* RepeatedOperation.swift */; };
+		65E4CDE41C33427500B9F9D8 /* RepeatedOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65E4CDE11C33427500B9F9D8 /* RepeatedOperation.swift */; };
+		65E4CDE51C33427500B9F9D8 /* RepeatedOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65E4CDE11C33427500B9F9D8 /* RepeatedOperation.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -366,6 +374,8 @@
 		65A6BA7E1C220FBD003A375D /* HealthCapabilityTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HealthCapabilityTests.swift; sourceTree = "<group>"; };
 		65C98C711C281EEC00BA76B7 /* FunctionalOperations.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FunctionalOperations.swift; sourceTree = "<group>"; };
 		65C98C761C284EA600BA76B7 /* FunctionalOperationsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FunctionalOperationsTests.swift; sourceTree = "<group>"; };
+		65E4CDDC1C33422100B9F9D8 /* RetryOperation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RetryOperation.swift; sourceTree = "<group>"; };
+		65E4CDE11C33427500B9F9D8 /* RepeatedOperation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RepeatedOperation.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -485,7 +495,9 @@
 				652616DC1C11F5EB00654091 /* OperationCondition.swift */,
 				652616DD1C11F5EB00654091 /* OperationObserver.swift */,
 				652616DE1C11F5EB00654091 /* OperationQueue.swift */,
+				65E4CDE11C33427500B9F9D8 /* RepeatedOperation.swift */,
 				658158441C20DBAD0086FB2A /* ResultInjection.swift */,
+				65E4CDDC1C33422100B9F9D8 /* RetryOperation.swift */,
 				652616DF1C11F5EB00654091 /* SlientCondition.swift */,
 				652616E01C11F5EB00654091 /* Support.swift */,
 				652616E11C11F5EB00654091 /* TimeoutObserver.swift */,
@@ -1031,6 +1043,7 @@
 				652618D11C11F93D00654091 /* NetworkObserver.swift in Sources */,
 				652618B41C11F91200654091 /* Reachability.swift in Sources */,
 				652618DB1C11F98000654091 /* Contacts.swift in Sources */,
+				65E4CDE21C33427500B9F9D8 /* RepeatedOperation.swift in Sources */,
 				652618B31C11F91200654091 /* NetworkOperation.swift in Sources */,
 				652618B61C11F91200654091 /* ReachableOperation.swift in Sources */,
 				6526186B1C11F8FC00654091 /* NoFailedDependenciesCondition.swift in Sources */,
@@ -1053,6 +1066,7 @@
 				652618601C11F8FC00654091 /* BlockObserver.swift in Sources */,
 				652618F41C11F9AA00654091 /* UserConfirmationCondition.swift in Sources */,
 				65C98C721C281EEC00BA76B7 /* FunctionalOperations.swift in Sources */,
+				65E4CDDD1C33422100B9F9D8 /* RetryOperation.swift in Sources */,
 				652618EA1C11F99E00654091 /* AddressBook.swift in Sources */,
 				6526186D1C11F8FC00654091 /* OperationCondition.swift in Sources */,
 				652618F11C11F9AA00654091 /* PassbookCapability.swift in Sources */,
@@ -1108,6 +1122,7 @@
 			files = (
 				652618FA1C11F9AD00654091 /* PassbookCapability.swift in Sources */,
 				652618841C11F8FD00654091 /* SlientCondition.swift in Sources */,
+				65E4CDDE1C33422100B9F9D8 /* RetryOperation.swift in Sources */,
 				652618831C11F8FD00654091 /* OperationQueue.swift in Sources */,
 				6526187E1C11F8FD00654091 /* NegatedCondition.swift in Sources */,
 				652618801C11F8FD00654091 /* Operation.swift in Sources */,
@@ -1122,6 +1137,7 @@
 				6526187F1C11F8FD00654091 /* NoFailedDependenciesCondition.swift in Sources */,
 				652618791C11F8FD00654091 /* GatedOperation.swift in Sources */,
 				652618781C11F8FD00654091 /* ExclusivityManager.swift in Sources */,
+				65E4CDE31C33427500B9F9D8 /* RepeatedOperation.swift in Sources */,
 				6526187D1C11F8FD00654091 /* MutuallyExclusive.swift in Sources */,
 				658158461C20DBAD0086FB2A /* ResultInjection.swift in Sources */,
 				6526187C1C11F8FD00654091 /* LoggingObserver.swift in Sources */,
@@ -1169,6 +1185,8 @@
 				652618DA1C11F93F00654091 /* UIOperation.swift in Sources */,
 				652618871C11F8FE00654091 /* BlockCondition.swift in Sources */,
 				6526188F1C11F8FE00654091 /* Logging.swift in Sources */,
+				65E4CDDF1C33422100B9F9D8 /* RetryOperation.swift in Sources */,
+				65E4CDE41C33427500B9F9D8 /* RepeatedOperation.swift in Sources */,
 				652618881C11F8FE00654091 /* BlockObserver.swift in Sources */,
 				652618951C11F8FE00654091 /* OperationCondition.swift in Sources */,
 				652619061C11F9AF00654091 /* UserConfirmationCondition.swift in Sources */,
@@ -1240,6 +1258,8 @@
 				652618C81C11F91500654091 /* Capability.swift in Sources */,
 				652618E41C11F98200654091 /* Contacts.swift in Sources */,
 				6526189B1C11F8FF00654091 /* BlockCondition.swift in Sources */,
+				65E4CDE01C33422100B9F9D8 /* RetryOperation.swift in Sources */,
+				65E4CDE51C33427500B9F9D8 /* RepeatedOperation.swift in Sources */,
 				652618A31C11F8FF00654091 /* Logging.swift in Sources */,
 				6526189C1C11F8FF00654091 /* BlockObserver.swift in Sources */,
 				652618A91C11F8FF00654091 /* OperationCondition.swift in Sources */,

--- a/Operations.xcodeproj/project.pbxproj
+++ b/Operations.xcodeproj/project.pbxproj
@@ -247,6 +247,9 @@
 		65E4CDE31C33427500B9F9D8 /* RepeatedOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65E4CDE11C33427500B9F9D8 /* RepeatedOperation.swift */; };
 		65E4CDE41C33427500B9F9D8 /* RepeatedOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65E4CDE11C33427500B9F9D8 /* RepeatedOperation.swift */; };
 		65E4CDE51C33427500B9F9D8 /* RepeatedOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65E4CDE11C33427500B9F9D8 /* RepeatedOperation.swift */; };
+		65E4CDE71C33F97900B9F9D8 /* RepeatedOperationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65E4CDE61C33F97900B9F9D8 /* RepeatedOperationTests.swift */; };
+		65E4CDE81C33F97900B9F9D8 /* RepeatedOperationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65E4CDE61C33F97900B9F9D8 /* RepeatedOperationTests.swift */; };
+		65E4CDE91C33F97900B9F9D8 /* RepeatedOperationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65E4CDE61C33F97900B9F9D8 /* RepeatedOperationTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -376,6 +379,7 @@
 		65C98C761C284EA600BA76B7 /* FunctionalOperationsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FunctionalOperationsTests.swift; sourceTree = "<group>"; };
 		65E4CDDC1C33422100B9F9D8 /* RetryOperation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RetryOperation.swift; sourceTree = "<group>"; };
 		65E4CDE11C33427500B9F9D8 /* RepeatedOperation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RepeatedOperation.swift; sourceTree = "<group>"; };
+		65E4CDE61C33F97900B9F9D8 /* RepeatedOperationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RepeatedOperationTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -640,6 +644,7 @@
 				652617151C11F5EB00654091 /* NetworkObserverTests.swift */,
 				652617161C11F5EB00654091 /* NoFailedDependenciesConditionTests.swift */,
 				652617171C11F5EB00654091 /* OperationTests.swift */,
+				65E4CDE61C33F97900B9F9D8 /* RepeatedOperationTests.swift */,
 				65691C9D1C21A29C00AF06B4 /* ResultInjectionTests.swift */,
 				652617181C11F5EB00654091 /* SilentConditionTests.swift */,
 				652617191C11F5EB00654091 /* TimeoutObserverTests.swift */,
@@ -1109,6 +1114,7 @@
 				6526196F1C11FE6900654091 /* CloudCapabilityTests.swift in Sources */,
 				652619771C11FE6900654091 /* ReachableOperationTests.swift in Sources */,
 				652619741C11FE6900654091 /* PhotosCapabilityTests.swift in Sources */,
+				65E4CDE71C33F97900B9F9D8 /* RepeatedOperationTests.swift in Sources */,
 				6526192B1C11FC3D00654091 /* TimeoutObserverTests.swift in Sources */,
 				6526196C1C11FE6900654091 /* AuthorizationTests.swift in Sources */,
 				65691C9E1C21A29C00AF06B4 /* ResultInjectionTests.swift in Sources */,
@@ -1207,6 +1213,7 @@
 				6526195E1C11FD9900654091 /* CapabilityTests.swift in Sources */,
 				6526193A1C11FC3E00654091 /* SilentConditionTests.swift in Sources */,
 				657DBA341C208830001E00F3 /* BlockObserverTests.swift in Sources */,
+				65E4CDE81C33F97900B9F9D8 /* RepeatedOperationTests.swift in Sources */,
 				6526192F1C11FC3E00654091 /* BlockConditionTests.swift in Sources */,
 				652619301C11FC3E00654091 /* ComposedOperationTests.swift in Sources */,
 				652619381C11FC3E00654091 /* NoFailedDependenciesConditionTests.swift in Sources */,
@@ -1291,6 +1298,7 @@
 				6526194F1C11FCFF00654091 /* CapabilityTests.swift in Sources */,
 				652619441C11FC3F00654091 /* LoggingTests.swift in Sources */,
 				652619561C11FCFF00654091 /* ReachabilityConditionTests.swift in Sources */,
+				65E4CDE91C33F97900B9F9D8 /* RepeatedOperationTests.swift in Sources */,
 				6526196B1C11FDF300654091 /* ContactsOperationsTests.swift in Sources */,
 				6526194B1C11FC3F00654091 /* TimeoutObserverTests.swift in Sources */,
 			);

--- a/Sources/Core/Shared/ComposedOperation.swift
+++ b/Sources/Core/Shared/ComposedOperation.swift
@@ -9,9 +9,9 @@
 import Foundation
 
 /**
-Allows a `NSOperation` to be composed inside an `Operation`. This
-is very handy for applying `Operation` level features such as 
-conditions and observers to `NSOperation` instances.
+ Allows a `NSOperation` to be composed inside an `Operation`. This
+ is very handy for applying `Operation` level features such as
+ conditions and observers to `NSOperation` instances.
 */
 public class ComposedOperation<O: NSOperation>: GatedOperation<O> {
 

--- a/Sources/Core/Shared/GroupOperation.swift
+++ b/Sources/Core/Shared/GroupOperation.swift
@@ -84,6 +84,15 @@ public class GroupOperation: Operation {
     }
 
     /**
+     Add multiple operations at once.
+
+     - parameter operations: an array of `NSOperation` instances.
+     */
+    public func addOperations(operations: NSOperation...) {
+        addOperations(operations)
+    }
+
+    /**
      Append an error to the list of aggregate errors. Subclasses can use this
      to maintain the errors received by operations within the group.
      

--- a/Sources/Core/Shared/GroupOperation.swift
+++ b/Sources/Core/Shared/GroupOperation.swift
@@ -70,6 +70,9 @@ public class GroupOperation: Operation {
     */
     public func addOperation(operation: NSOperation) {
         log.notice("Add operation \(operation.operationName) to group.")
+        if let op = operation as? Operation {
+            op.log.severity = log.severity
+        }
         queue.addOperation(operation)
     }
 
@@ -80,6 +83,11 @@ public class GroupOperation: Operation {
     */
     public func addOperations(operations: [NSOperation]) {
         log.notice("Add operations to group \(operations.map { $0.operationName })")
+        operations.forEach {
+            if let op = $0 as? Operation {
+                op.log.severity = log.severity
+            }
+        }
         queue.addOperations(operations, waitUntilFinished: false)
     }
 

--- a/Sources/Core/Shared/Operation.swift
+++ b/Sources/Core/Shared/Operation.swift
@@ -322,7 +322,7 @@ public class Operation: NSOperation {
     
      - requires: self must not have started yet. i.e. either hasn't been added
      to a queue, or is waiting on dependencies.
-    - parameter operation: a `NSOperation` instance.
+     - parameter operation: a `NSOperation` instance.
     */
     public override func addDependency(operation: NSOperation) {
         precondition(state <= .Executing, "Dependencies cannot be modified after execution has begun, current state: \(state).")

--- a/Sources/Core/Shared/RepeatedOperation.swift
+++ b/Sources/Core/Shared/RepeatedOperation.swift
@@ -166,7 +166,7 @@ public class RepeatedOperation<T where T: NSOperation>: GroupOperation {
     private var generator: AnyGenerator<T>
     public internal(set) var operation: T? = .None
 
-    public private(set) var count: Int = 0
+    public private(set) var attempts: Int = 0
 
     public init(strategy: WaitStrategy = .Fixed(0.1), maxNumberOfAttempts attempts: Int? = .None, _ generator: AnyGenerator<T>) {
 
@@ -195,7 +195,6 @@ public class RepeatedOperation<T where T: NSOperation>: GroupOperation {
         if let _ = operation as? DelayOperation { return }
         if let _ = operation as? T {
             addNextOperation()
-            count += 1
         }
     }
 
@@ -204,6 +203,7 @@ public class RepeatedOperation<T where T: NSOperation>: GroupOperation {
         if let op = operation, delay = nextDelayOperation() {
             op.addDependency(delay)
             addOperations(delay, op)
+            attempts += 1
         }
     }
 

--- a/Sources/Core/Shared/RepeatedOperation.swift
+++ b/Sources/Core/Shared/RepeatedOperation.swift
@@ -319,7 +319,14 @@ public class RepeatedOperation<T where T: NSOperation>: GroupOperation {
             preconditionFailure("The generator must return an operation to start with.")
         }
 
-        self.delay = anyGenerator(delay)
+        switch max {
+        case .Some(let max):
+            // Subtract 1 to account for the 1st attempt
+            self.delay = anyGenerator(FiniteGenerator(delay, limit: max - 1))
+        case .None:
+            self.delay = anyGenerator(delay)
+        }
+
         self.generator = generator
         super.init(operations: [op])
         name = "Repeated Operation"
@@ -334,13 +341,7 @@ public class RepeatedOperation<T where T: NSOperation>: GroupOperation {
      - parameter: (unnamed) the AnyGenerator<T> generator.
      */
     public convenience init(strategy: WaitStrategy = .Fixed(0.1), maxCount max: Int? = .None, _ generator: AnyGenerator<T>) {
-        switch max {
-        case .Some(let max):
-            // Subtract 1 to account for the 1st attempt
-            self.init(delay: FiniteGenerator(strategy.generate(), limit: max - 1), maxCount: max, generator)
-        case .None:
-            self.init(delay: strategy.generate(), maxCount: max, generator)
-        }
+        self.init(delay: strategy.generate(), maxCount: max, generator)
     }
 
     /**

--- a/Sources/Core/Shared/RepeatedOperation.swift
+++ b/Sources/Core/Shared/RepeatedOperation.swift
@@ -8,65 +8,182 @@
 
 import Foundation
 
-public enum MaximumTimeInterval {
-    case Interval(NSTimeInterval)
-    case Backoff
+struct FiniteGenerator<G: GeneratorType>: GeneratorType {
+
+    private let limit: Int
+    private var generator: G
+
+    var count: Int = 0
+
+    init(_ generator: G, limit: Int = 10) {
+        self.generator = generator
+        self.limit = limit
+    }
+
+    mutating func next() -> G.Element? {
+        guard count < limit else {
+            return nil
+        }
+        count += 1
+        return generator.next()
+    }
 }
 
-struct TimeDelayGenerator: GeneratorType {
+func arc4random<T: IntegerLiteralConvertible>(type: T.Type) -> T {
+    var r: T = 0
+    arc4random_buf(&r, Int(sizeof(T)))
+    return r
+}
 
-    struct Info {
+struct FixedWaitGenerator: GeneratorType {
+    let period: NSTimeInterval
 
-        let minimum: NSTimeInterval
-        let maximum: MaximumTimeInterval
-        let attempts: Int?
-
-        func interval(count: Int) -> NSTimeInterval {
-            switch maximum {
-
-            case .Backoff:
-                let exp = (2.0 * pow(2.0, Double(count))) - 1
-                let numberOfIntervals = NSTimeInterval(arc4random_uniform(UInt32(exp)))
-                return minimum * numberOfIntervals
-
-            case .Interval(let _interval):
-                return _interval
-            }
-        }
-    }
-
-    private let info: Info
-    private var count: Int = 0
-
-    init(info: Info) {
-        self.info = info
-    }
-
-    init(min: NSTimeInterval = 1, max: MaximumTimeInterval = .Backoff, attempts: Int? = .None) {
-        self.init(info: Info(minimum: min, maximum: max, attempts: attempts))
+    init(period: NSTimeInterval) {
+        precondition(period >= 0, "The minimum must be greater than or equal to zero, but it is: \(period)")
+        self.period = period
     }
 
     mutating func next() -> NSTimeInterval? {
-        if let maxNumberOfAttempts = info.attempts {
-            guard count == maxNumberOfAttempts else {
-                return nil
-            }
-        }
-        return info.interval(count)
+        return period
     }
 }
 
-public class RepeatedOperation<G: GeneratorType where G.Element: NSOperation>: GroupOperation {
+struct RandomWaitGenerator: GeneratorType {
+    let minimum: NSTimeInterval
+    let maximum: NSTimeInterval
+
+    init(minimum: NSTimeInterval, maximum: NSTimeInterval) {
+        precondition(minimum >= 0, "The minimum must be greater than or equal to zero, but it is: \(minimum)")
+        precondition(maximum > minimum, "The maximum must be greater than minimum.")
+        self.minimum = minimum
+        self.maximum = maximum
+    }
+
+    mutating func next() -> NSTimeInterval? {
+        let r = Double(arc4random(UInt64)) / Double(UInt64.max)
+        return (r * (maximum - minimum)) + minimum
+    }
+}
+
+struct IncrementingWaitGenerator: GeneratorType {
+    let initial: NSTimeInterval
+    let increment: NSTimeInterval
+    var count: Int = 0
+
+    init(initial: NSTimeInterval, increment: NSTimeInterval) {
+        precondition(initial >= 0, "The initial must be greater than or equal to zero, but it is: \(initial)")
+        self.initial = initial
+        self.increment = increment
+    }
+
+    mutating func next() -> NSTimeInterval? {
+        let interval = initial + (NSTimeInterval(count) * increment)
+        count += 1
+        return max(0, interval)
+    }
+}
+
+struct ExponentialWaitGenerator: GeneratorType {
+    let period: NSTimeInterval
+    let maximum: NSTimeInterval
+    var count: Int = 0
+
+    init(period: NSTimeInterval, maximum: NSTimeInterval) {
+        precondition(period >= 0, "The period must be greater than or equal to zero, but it is: \(period)")
+        precondition(maximum > 0, "The maximum must be greater than zero, but it is: \(maximum)")
+        precondition(period < maximum, "The period must be less than the maximum, but it period: \(period) and maximum: \(maximum)")
+        self.period = period
+        self.maximum = maximum
+    }
+
+    mutating func next() -> NSTimeInterval? {
+        let interval = period * pow(2.0, Double(count))
+        count += 1
+        return max(0, min(maximum, interval))
+    }
+}
+
+struct FibonacciGenerator: GeneratorType {
+    var currentValue = 0, nextValue = 1
+
+    mutating func next() -> Int? {
+        let result = currentValue
+        currentValue = nextValue
+        nextValue += result
+        return result
+    }
+}
+
+struct FibonacciWaitGenerator: GeneratorType {
+    let period: NSTimeInterval
+    let maximum: NSTimeInterval
+
+    private var fibonacci = FibonacciGenerator()
+
+    init(period: NSTimeInterval, maximum: NSTimeInterval) {
+        precondition(period >= 0, "The period must be greater than or equal to zero, but it is: \(period)")
+        precondition(maximum > 0, "The maximum must be greater than zero, but it is: \(maximum)")
+        precondition(period < maximum, "The period must be less than the maximum, but it period: \(period) and maximum: \(maximum)")
+        self.period = period
+        self.maximum = maximum
+    }
+
+    mutating func next() -> NSTimeInterval? {
+        return fibonacci.next().map { fib in
+            let interval = period * NSTimeInterval(fib)
+            return max(0, min(maximum, interval))
+        }
+    }
+}
+
+public enum WaitStrategy {
+
+    case Fixed(NSTimeInterval)
+    case Random((minimum: NSTimeInterval, maximum: NSTimeInterval))
+    case Incrementing((initial: NSTimeInterval, increment: NSTimeInterval))
+    case Exponential((period: NSTimeInterval, maximum: NSTimeInterval))
+    case Fibonacci((period: NSTimeInterval, maximum: NSTimeInterval))
+
+    func generate() -> AnyGenerator<NSTimeInterval> {
+        switch self {
+        case .Fixed(let period):
+            return anyGenerator(FixedWaitGenerator(period: period))
+        case .Random(let (minimum, maximum)):
+            return anyGenerator(RandomWaitGenerator(minimum: minimum, maximum: maximum))
+        case .Incrementing(let (initial, increment)):
+            return anyGenerator(IncrementingWaitGenerator(initial: initial, increment: increment))
+        case .Exponential(let (period, maximum)):
+            return anyGenerator(ExponentialWaitGenerator(period: period, maximum: maximum))
+        case .Fibonacci(let (period, maximum)):
+            return anyGenerator(FibonacciWaitGenerator(period: period, maximum: maximum))
+        }
+    }
+}
+
+public class RepeatedOperation<T where T: NSOperation>: GroupOperation {
 
     private var delay: AnyGenerator<NSTimeInterval>
-    private var generator: G
-    public internal(set) var operation: G.Element? = .None
+    private var generator: AnyGenerator<T>
+    public internal(set) var operation: T? = .None
 
-    public init(min: NSTimeInterval = 1, max: MaximumTimeInterval = .Backoff, maxNumberOfAttempts attempts: Int? = .None, generator: G) {
-        self.delay = anyGenerator(TimeDelayGenerator(min: min, max: max, attempts: attempts))
+    public private(set) var count: Int = 0
+
+    public init(strategy: WaitStrategy = .Fixed(0.1), maxNumberOfAttempts attempts: Int? = .None, _ generator: AnyGenerator<T>) {
+
+        switch attempts {
+        case .Some(let attempts):
+            delay = anyGenerator(FiniteGenerator(strategy.generate(), limit: attempts))
+        case .None:
+            delay = strategy.generate()
+        }
+
         self.generator = generator
         super.init(operations: [])
         name = "Repeated Operation"
+    }
+
+    public convenience init<G where G: GeneratorType, G.Element == T>(strategy: WaitStrategy = .Fixed(0.1), maxNumberOfAttempts attempts: Int? = .None, _ generator: G) {
+        self.init(strategy: strategy, maxNumberOfAttempts: attempts, anyGenerator(generator))
     }
 
     public override func execute() {
@@ -75,8 +192,10 @@ public class RepeatedOperation<G: GeneratorType where G.Element: NSOperation>: G
     }
 
     public override func operationDidFinish(operation: NSOperation, withErrors errors: [ErrorType]) {
-        if errors.isEmpty, let _ = operation as? G.Element {
+        if let _ = operation as? DelayOperation { return }
+        if let _ = operation as? T {
             addNextOperation()
+            count += 1
         }
     }
 
@@ -93,13 +212,14 @@ public class RepeatedOperation<G: GeneratorType where G.Element: NSOperation>: G
     }
 }
 
-public protocol RepeatingType {
-    var shouldRepeat: Bool { get }
+public protocol Repeatable {
+    func shouldRepeat(count: Int) -> Bool
 }
 
-public class RepeatingGenerator<G: GeneratorType where G.Element: RepeatingType>: GeneratorType {
+public class RepeatingGenerator<G: GeneratorType where G.Element: Repeatable>: GeneratorType {
 
     private var generator: G
+    private var count: Int = 0
     private var current: G.Element?
 
     public init(_ generator: G) {
@@ -108,20 +228,20 @@ public class RepeatingGenerator<G: GeneratorType where G.Element: RepeatingType>
 
     public func next() -> G.Element? {
         if let current = current {
-            guard current.shouldRepeat else {
+            guard current.shouldRepeat(count) else {
                 return nil
             }
         }
         current = generator.next()
+        count += 1
         return current
     }
 }
 
-extension RepeatedOperation {
+extension RepeatedOperation where T: Repeatable {
 
-    public convenience init<T: GeneratorType where T.Element: NSOperation, T.Element: RepeatingType>(min: NSTimeInterval = 1, max: MaximumTimeInterval = .Backoff, maxNumberOfAttempts attempts: Int? = .None, generator: T) {
-        self.init(min: min, max: max, maxNumberOfAttempts: attempts, generator: RepeatingGenerator(generator))
+    public convenience init(strategy: WaitStrategy = .Fixed(0.1), maxNumberOfAttempts attempts: Int? = .None, body: () -> T?) {
+        self.init(strategy: strategy, maxNumberOfAttempts: attempts, RepeatingGenerator(anyGenerator(body)))
     }
 }
-
 

--- a/Sources/Core/Shared/RepeatedOperation.swift
+++ b/Sources/Core/Shared/RepeatedOperation.swift
@@ -136,6 +136,47 @@ struct FibonacciWaitGenerator: GeneratorType {
     }
 }
 
+/**
+ Define a strategy for waiting a given time interval. The strategy
+ can then create a NSTimeInterval generator. The strategies are:
+ 
+ ### Fixed
+ The fixed strategy is initialized with a time interval. Every
+ interval is this value.
+ - Requires: time interval must be greater than zero
+
+ ### Random
+ The random strategy is initialized with minimum and maximum
+ bounds. These are both NSTimeInterval values. Each value from
+ the generator is a random interval between these bounds.
+ - requires: minimum time interval must be greater than or equal to zero
+ - requires: maximum time interval must be greater than the minimum
+
+ ### Incrementing
+ The incrementing strategy is initialized with an starting or
+ initial interval, and an increment value. Each value adds the
+ increment to the previous value.
+ - requires: initial time interval must be greater than or equal to zero.
+ - notes: a decrementing strategy can be created with a large initial
+    value and negative increments. The value will never be less than
+    zero however.
+
+ ### Exponential
+ The exponential strategy is initialized with a time period, and
+ a maximum value. Successive value of the generator multiply the
+ period by an exponentially increasing factors, but not past the
+ maximum.
+ - requires: time period must be greater than or equal to zero
+ - requires: maximum time interval must be greater than zero
+ - requires: time period must be less than maxium
+ ### Fibonacci
+ Like the exponential strategy except the period is multipled by
+ the Fibonacci numbers instead.
+ - requires: time period must be greater than or equal to zero
+ - requires: maximum time interval must be greater than zero
+ - requires: time period must be less than maxium
+
+*/
 public enum WaitStrategy {
 
     case Fixed(NSTimeInterval)
@@ -144,7 +185,11 @@ public enum WaitStrategy {
     case Exponential((period: NSTimeInterval, maximum: NSTimeInterval))
     case Fibonacci((period: NSTimeInterval, maximum: NSTimeInterval))
 
-    func generate() -> AnyGenerator<NSTimeInterval> {
+    /**
+     Returns a new generator using the strategy.
+     - returns: a `AnyGenerator<NSTimeInterval>` instance.
+    */
+    public func generate() -> AnyGenerator<NSTimeInterval> {
         switch self {
         case .Fixed(let period):
             return anyGenerator(FixedWaitGenerator(period: period))
@@ -166,7 +211,7 @@ public class RepeatedOperation<T where T: NSOperation>: GroupOperation {
     private var generator: AnyGenerator<T>
     public internal(set) var operation: T? = .None
 
-    public private(set) var attempts: Int = 0
+    public private(set) var attempts: Int = 1
 
     public init(strategy: WaitStrategy = .Fixed(0.1), maxNumberOfAttempts attempts: Int? = .None, _ generator: AnyGenerator<T>) {
         operation = generator.next()

--- a/Sources/Core/Shared/RepeatedOperation.swift
+++ b/Sources/Core/Shared/RepeatedOperation.swift
@@ -1,0 +1,94 @@
+//
+//  RepeatedOperation.swift
+//  Operations
+//
+//  Created by Daniel Thorpe on 29/12/2015.
+//
+//
+
+import Foundation
+
+public enum MaximumTimeInterval {
+    case Interval(NSTimeInterval)
+    case Backoff
+}
+
+struct TimeDelayGenerator: GeneratorType {
+
+    struct Info {
+
+        let minimum: NSTimeInterval
+        let maximum: MaximumTimeInterval
+        let limit: Int?
+
+        func interval(count: Int) -> NSTimeInterval {
+            switch maximum {
+
+            case .Backoff:
+                let exp = (2.0 * pow(2.0, Double(count))) - 1
+                let numberOfIntervals = NSTimeInterval(arc4random_uniform(UInt32(exp)))
+                return minimum * numberOfIntervals
+
+            case .Interval(let _interval):
+                return _interval
+            }
+        }
+    }
+
+    private let info: Info
+    private var count: Int = 0
+
+    init(info: Info) {
+        self.info = info
+    }
+
+    init(min: NSTimeInterval = 1, max: MaximumTimeInterval = .Backoff, limit: Int? = .None) {
+        self.init(info: Info(minimum: min, maximum: max, limit: limit))
+    }
+
+    mutating func next() -> NSTimeInterval? {
+        if let limit = info.limit {
+            guard count == limit else {
+                return nil
+            }
+        }
+        return info.interval(count)
+    }
+}
+
+public class RepeatedOperation<Generator: GeneratorType where Generator.Element: NSOperation>: GroupOperation {
+
+    private var delay: TimeDelayGenerator
+    private var generator: Generator
+    public internal(set) var operation: Generator.Element? = .None
+
+    public init(min: NSTimeInterval = 1, max: MaximumTimeInterval = .Backoff, limit: Int? = .None, generator: Generator) {
+        self.delay = TimeDelayGenerator(min: min, max: max, limit: limit)
+        self.generator = generator
+        super.init(operations: [])
+        name = "Repeated Operation"
+    }
+
+    public override func execute() {
+        addNextOperation()
+        super.execute()
+    }
+
+    public override func operationDidFinish(operation: NSOperation, withErrors errors: [ErrorType]) {
+        if errors.isEmpty {
+            addNextOperation()
+        }
+    }
+
+    public func addNextOperation() {
+        operation = generator.next()
+        if let op = operation, interval = nextDelayOperation() {
+            op.addDependency(interval)
+            addOperations(interval, op)
+        }
+    }
+
+    internal func nextDelayOperation() -> DelayOperation? {
+        return delay.next().map { DelayOperation(interval: $0) }
+    }
+}

--- a/Sources/Core/Shared/RepeatedOperation.swift
+++ b/Sources/Core/Shared/RepeatedOperation.swift
@@ -82,9 +82,9 @@ public class RepeatedOperation<Generator: GeneratorType where Generator.Element:
 
     public func addNextOperation() {
         operation = generator.next()
-        if let op = operation, interval = nextDelayOperation() {
-            op.addDependency(interval)
-            addOperations(interval, op)
+        if let op = operation, delay = nextDelayOperation() {
+            op.addDependency(delay)
+            addOperations(delay, op)
         }
     }
 
@@ -92,3 +92,4 @@ public class RepeatedOperation<Generator: GeneratorType where Generator.Element:
         return delay.next().map { DelayOperation(interval: $0) }
     }
 }
+

--- a/Sources/Core/Shared/RepeatedOperation.swift
+++ b/Sources/Core/Shared/RepeatedOperation.swift
@@ -205,6 +205,9 @@ public enum WaitStrategy {
     }
 }
 
+/**
+
+*/
 public class RepeatedOperation<T where T: NSOperation>: GroupOperation {
 
     private var delay: AnyGenerator<NSTimeInterval>
@@ -221,7 +224,8 @@ public class RepeatedOperation<T where T: NSOperation>: GroupOperation {
 
         switch attempts {
         case .Some(let attempts):
-            delay = anyGenerator(FiniteGenerator(strategy.generate(), limit: attempts))
+            // Subtract 1 to account for the 1st attempt
+            delay = anyGenerator(FiniteGenerator(strategy.generate(), limit: attempts - 1))
         case .None:
             delay = strategy.generate()
         }

--- a/Sources/Core/Shared/RepeatedOperation.swift
+++ b/Sources/Core/Shared/RepeatedOperation.swift
@@ -93,3 +93,30 @@ public class RepeatedOperation<Generator: GeneratorType where Generator.Element:
     }
 }
 
+public protocol RepeatingOperationType {
+    var shouldRepeat: Bool { get }
+}
+
+public class RepeatingOperationGenerator<O where O: NSOperation, O: RepeatingOperationType>: GeneratorType {
+
+    private var generator: AnyGenerator<O>
+    private var operation: O?
+
+    public init(_ creator: () -> O?) {
+        generator = anyGenerator(creator)
+    }
+
+    public func next() -> O? {
+        if let op = operation {
+            guard op.shouldRepeat else {
+                return nil
+            }
+        }
+
+        operation = generator.next()
+
+        return operation
+    }
+}
+
+

--- a/Sources/Core/Shared/RepeatedOperation.swift
+++ b/Sources/Core/Shared/RepeatedOperation.swift
@@ -169,6 +169,10 @@ public class RepeatedOperation<T where T: NSOperation>: GroupOperation {
     public private(set) var attempts: Int = 0
 
     public init(strategy: WaitStrategy = .Fixed(0.1), maxNumberOfAttempts attempts: Int? = .None, _ generator: AnyGenerator<T>) {
+        operation = generator.next()
+        guard let op = operation else {
+            preconditionFailure("The generator must return an operation to start with.")
+        }
 
         switch attempts {
         case .Some(let attempts):
@@ -178,17 +182,12 @@ public class RepeatedOperation<T where T: NSOperation>: GroupOperation {
         }
 
         self.generator = generator
-        super.init(operations: [])
+        super.init(operations: [op])
         name = "Repeated Operation"
     }
 
     public convenience init<G where G: GeneratorType, G.Element == T>(strategy: WaitStrategy = .Fixed(0.1), maxNumberOfAttempts attempts: Int? = .None, _ generator: G) {
         self.init(strategy: strategy, maxNumberOfAttempts: attempts, anyGenerator(generator))
-    }
-
-    public override func execute() {
-        addNextOperation()
-        super.execute()
     }
 
     public override func operationDidFinish(operation: NSOperation, withErrors errors: [ErrorType]) {

--- a/Sources/Core/Shared/RetryOperation.swift
+++ b/Sources/Core/Shared/RetryOperation.swift
@@ -10,12 +10,18 @@ import Foundation
 
 public class RetryOperation<O: NSOperation>: RepeatedOperation<AnyGenerator<O>> {
 
-    public init(min: NSTimeInterval = 1, max: MaximumTimeInterval = .Backoff, limit: Int? = .None, operation op: O) {
+    public init(min: NSTimeInterval = 1, max: MaximumTimeInterval = .Backoff, maxNumberOfAttempts attempts: Int? = .None, operation op: O) {
         if let op = op as? Operation {
             op.addCondition(NoFailedDependenciesCondition())
         }
-        super.init(min: min, max: max, limit: limit, generator: anyGenerator { return op })
+        super.init(min: min, max: max, maxNumberOfAttempts: attempts, generator: anyGenerator { return op })
         name = "Retry Operation"
+    }
+
+    public override func operationDidFinish(operation: NSOperation, withErrors errors: [ErrorType]) {
+        if !errors.isEmpty, let _ = operation as? O  {
+            addNextOperation()
+        }
     }
 }
 

--- a/Sources/Core/Shared/RetryOperation.swift
+++ b/Sources/Core/Shared/RetryOperation.swift
@@ -10,13 +10,23 @@ import Foundation
 
 public class RetryOperation<T: Operation>: RepeatedOperation<T> {
 
-    public init(strategy: WaitStrategy = .Fixed(0.1), maxCount max: Int? = .None, _ body: () -> T?) {
-        super.init(strategy: strategy, maxCount: max, anyGenerator {
+    public init<G where G: GeneratorType, G.Element == NSTimeInterval>(delay: G, maxCount max: Int? = .None, _ body: () -> T?) {
+        super.init(delay: delay, maxCount: max, anyGenerator {
             guard let op = body() else { return nil }
             op.addCondition(NoFailedDependenciesCondition())
             return op
         })
         name = "Retry Operation"
+    }
+
+    public convenience init(strategy: WaitStrategy = .Fixed(0.1), maxCount max: Int? = .None, _ body: () -> T?) {
+        switch max {
+        case .Some(let max):
+            // Subtract 1 to account for the 1st attempt
+            self.init(delay: FiniteGenerator(strategy.generate(), limit: max - 1), maxCount: max, body)
+        case .None:
+            self.init(delay: strategy.generate(), maxCount: max, body)
+        }
     }
 
     public override func operationDidFinish(operation: NSOperation, withErrors errors: [ErrorType]) {

--- a/Sources/Core/Shared/RetryOperation.swift
+++ b/Sources/Core/Shared/RetryOperation.swift
@@ -8,18 +8,18 @@
 
 import Foundation
 
-public class RetryOperation<O: NSOperation>: RepeatedOperation<AnyGenerator<O>> {
+public class RetryOperation<T: NSOperation>: RepeatedOperation<T> {
 
-    public init(min: NSTimeInterval = 1, max: MaximumTimeInterval = .Backoff, maxNumberOfAttempts attempts: Int? = .None, _ op: O) {
+    public init(strategy: WaitStrategy, maxNumberOfAttempts attempts: Int? = .None, _ op: T) {
         if let op = op as? Operation {
             op.addCondition(NoFailedDependenciesCondition())
         }
-        super.init(min: min, max: max, maxNumberOfAttempts: attempts, generator: anyGenerator { return op })
+        super.init(strategy: strategy, maxNumberOfAttempts: attempts, anyGenerator { return op })
         name = "Retry Operation"
     }
 
     public override func operationDidFinish(operation: NSOperation, withErrors errors: [ErrorType]) {
-        if !errors.isEmpty, let _ = operation as? O  {
+        if !errors.isEmpty, let _ = operation as? T  {
             addNextOperation()
         }
     }

--- a/Sources/Core/Shared/RetryOperation.swift
+++ b/Sources/Core/Shared/RetryOperation.swift
@@ -20,13 +20,7 @@ public class RetryOperation<T: Operation>: RepeatedOperation<T> {
     }
 
     public convenience init(strategy: WaitStrategy = .Fixed(0.1), maxCount max: Int? = .None, _ body: () -> T?) {
-        switch max {
-        case .Some(let max):
-            // Subtract 1 to account for the 1st attempt
-            self.init(delay: FiniteGenerator(strategy.generate(), limit: max - 1), maxCount: max, body)
-        case .None:
-            self.init(delay: strategy.generate(), maxCount: max, body)
-        }
+        self.init(delay: strategy.generate(), maxCount: max, body)
     }
 
     public override func operationDidFinish(operation: NSOperation, withErrors errors: [ErrorType]) {

--- a/Sources/Core/Shared/RetryOperation.swift
+++ b/Sources/Core/Shared/RetryOperation.swift
@@ -8,5 +8,13 @@
 
 import Foundation
 
+public class RetryOperation<O: NSOperation>: RepeatedOperation<AnyGenerator<O>> {
 
+    public init(min: NSTimeInterval = 1, max: MaximumTimeInterval = .Backoff, limit: Int? = .None, operation op: O) {
+        if let op = op as? Operation {
+            op.addCondition(NoFailedDependenciesCondition())
+        }
+        super.init(min: min, max: max, limit: limit, generator: anyGenerator { return op })
+    }
+}
 

--- a/Sources/Core/Shared/RetryOperation.swift
+++ b/Sources/Core/Shared/RetryOperation.swift
@@ -10,7 +10,7 @@ import Foundation
 
 public class RetryOperation<O: NSOperation>: RepeatedOperation<AnyGenerator<O>> {
 
-    public init(min: NSTimeInterval = 1, max: MaximumTimeInterval = .Backoff, maxNumberOfAttempts attempts: Int? = .None, operation op: O) {
+    public init(min: NSTimeInterval = 1, max: MaximumTimeInterval = .Backoff, maxNumberOfAttempts attempts: Int? = .None, _ op: O) {
         if let op = op as? Operation {
             op.addCondition(NoFailedDependenciesCondition())
         }

--- a/Sources/Core/Shared/RetryOperation.swift
+++ b/Sources/Core/Shared/RetryOperation.swift
@@ -10,8 +10,8 @@ import Foundation
 
 public class RetryOperation<T: Operation>: RepeatedOperation<T> {
 
-    public init(strategy: WaitStrategy = .Fixed(0.1), maxNumberOfAttempts attempts: Int? = .None, _ body: () -> T?) {
-        super.init(strategy: strategy, maxNumberOfAttempts: attempts, anyGenerator {
+    public init(strategy: WaitStrategy = .Fixed(0.1), maxCount max: Int? = .None, _ body: () -> T?) {
+        super.init(strategy: strategy, maxCount: max, anyGenerator {
             guard let op = body() else { return nil }
             op.addCondition(NoFailedDependenciesCondition())
             return op

--- a/Sources/Core/Shared/RetryOperation.swift
+++ b/Sources/Core/Shared/RetryOperation.swift
@@ -15,6 +15,7 @@ public class RetryOperation<O: NSOperation>: RepeatedOperation<AnyGenerator<O>> 
             op.addCondition(NoFailedDependenciesCondition())
         }
         super.init(min: min, max: max, limit: limit, generator: anyGenerator { return op })
+        name = "Retry Operation"
     }
 }
 

--- a/Sources/Core/Shared/RetryOperation.swift
+++ b/Sources/Core/Shared/RetryOperation.swift
@@ -1,0 +1,12 @@
+//
+//  RetryOperation.swift
+//  Operations
+//
+//  Created by Daniel Thorpe on 29/12/2015.
+//
+//
+
+import Foundation
+
+
+

--- a/Sources/Core/Shared/RetryOperation.swift
+++ b/Sources/Core/Shared/RetryOperation.swift
@@ -8,13 +8,14 @@
 
 import Foundation
 
-public class RetryOperation<T: NSOperation>: RepeatedOperation<T> {
+public class RetryOperation<T: Operation>: RepeatedOperation<T> {
 
-    public init(strategy: WaitStrategy, maxNumberOfAttempts attempts: Int? = .None, _ op: T) {
-        if let op = op as? Operation {
+    public init(strategy: WaitStrategy = .Fixed(0.1), maxNumberOfAttempts attempts: Int? = .None, _ body: () -> T?) {
+        super.init(strategy: strategy, maxNumberOfAttempts: attempts, anyGenerator {
+            guard let op = body() else { return nil }
             op.addCondition(NoFailedDependenciesCondition())
-        }
-        super.init(strategy: strategy, maxNumberOfAttempts: attempts, anyGenerator { return op })
+            return op
+        })
         name = "Retry Operation"
     }
 

--- a/Sources/Features/Shared/ReachableOperation.swift
+++ b/Sources/Features/Shared/ReachableOperation.swift
@@ -45,7 +45,7 @@ public class ReachableOperation<O: NSOperation>: GroupOperation {
         self.connectivity = connectivity
         self.reachability = reachability
         super.init(operations: [])
-
+        name = "Reachable Operation <\(operation.operationName)>"
         token = reachability.addObserver { status in
             self.status = status
         }

--- a/Tests/Core/RepeatedOperationTests.swift
+++ b/Tests/Core/RepeatedOperationTests.swift
@@ -342,14 +342,14 @@ class RepeatableRepeatedOperationTests: OperationTests {
     func test__repeatable_operation() {
 
         var errors: [ErrorType] = []
-        let operation = RepeatedOperation(maxCount: 10) { () -> RepeatableOperation<TestOperation> in
-            let op = RepeatableOperation(TestOperation(error: TestOperation.Error.SimulatedError)) { _ in
-                return errors.count < 3
-            }
+        let operation = RepeatedOperation(maxCount: 10) {() -> RepeatableOperation<TestOperation> in
+
+            let op = TestOperation(error: TestOperation.Error.SimulatedError)
             op.addObserver(FinishedObserver { _, e in
                 errors.appendContentsOf(e)
             })
-            return op
+
+            return RepeatableOperation(op) { _ in errors.count < 3 }
         }
 
         addCompletionBlockToTestOperation(operation, withExpectation: expectationWithDescription("Test: \(__FUNCTION__)"))

--- a/Tests/Core/RepeatedOperationTests.swift
+++ b/Tests/Core/RepeatedOperationTests.swift
@@ -1,0 +1,336 @@
+//
+//  RepeatedOperationTests.swift
+//  Operations
+//
+//  Created by Daniel Thorpe on 30/12/2015.
+//
+//
+
+import XCTest
+@testable import Operations
+
+class FiniteGeneratorTests: XCTestCase {
+
+    var generator: FiniteGenerator<AnyGenerator<Int>>!
+
+    override func setUp() {
+        super.setUp()
+        generator = FiniteGenerator(anyGenerator(0.stride(to: 10, by: 1).generate()), limit: 2)
+    }
+
+    func test__limits_are_reached() {
+        guard let _ = generator.next(), _ = generator.next() else {
+            XCTFail("Should return values up to a limit.")
+            return
+        }
+
+        if let _ = generator.next() {
+            XCTFail("Should not return a value once the limit is reached.")
+        }
+    }
+}
+
+class FixedWaitGeneratorTests: XCTestCase {
+
+    var strategy: WaitStrategy!
+    var generator: AnyGenerator<NSTimeInterval>!
+
+    override func setUp() {
+        super.setUp()
+        strategy = .Fixed(1.0)
+        generator = strategy.generate()
+    }
+    
+    func test__next_interval() {
+        guard let interval = generator.next() else {
+            XCTFail("FixedWaitGenerator never ends.")
+            return
+        }
+        XCTAssertEqual(interval, 1)
+    }
+}
+
+class RandomWaitGeneratorTests: XCTestCase {
+
+    var strategy: WaitStrategy!
+    var generator: AnyGenerator<NSTimeInterval>!
+
+    override func setUp() {
+        super.setUp()
+        strategy = .Random((minimum: 1.0, maximum: 2.0))
+        generator = strategy.generate()
+    }
+
+    func test__next_interval() {
+        for _ in 0..<100 {
+            guard let interval = generator.next() else {
+                XCTFail("RandomWaitGenerator never ends.")
+                return
+            }
+            XCTAssertGreaterThanOrEqual(interval, 1.0)
+            XCTAssertLessThanOrEqual(interval, 2.0)
+        }
+    }
+}
+
+class IncrementingWaitGeneratorTests: XCTestCase {
+
+    var strategy: WaitStrategy!
+    var generator: AnyGenerator<NSTimeInterval>!
+
+    override func setUp() {
+        super.setUp()
+        strategy = .Incrementing((initial: 1.0, increment: 1.0))
+        generator = strategy.generate()
+    }
+
+    func test__next_interval() {
+        for i in 0..<100 {
+            guard let interval = generator.next() else {
+                XCTFail("IncrementingWaitGenerator never ends.")
+                return
+            }
+            XCTAssertEqual(interval, NSTimeInterval(i + 1))
+        }
+    }
+}
+
+class ExponentialWaitGeneratorTests: XCTestCase {
+
+    var strategy: WaitStrategy!
+    var generator: AnyGenerator<NSTimeInterval>!
+
+    override func setUp() {
+        super.setUp()
+        strategy = .Exponential((period: 1, maximum: 20))
+        generator = strategy.generate()
+    }
+
+    func getInterval(count: Int) -> NSTimeInterval? {
+        for _ in 0..<count {
+            guard let _ = generator.next() else {
+                XCTFail("ExponentialWaitGenerator never ends.")
+                break
+            }
+        }
+        return generator.next()
+    }
+
+    func test__next_0() {
+        guard let interval = getInterval(0) else {
+            XCTFail("ExponentialWaitGenerator never ends.")
+            return
+        }
+        XCTAssertEqual(interval, 1)
+    }
+
+    func test__next_1() {
+        guard let interval = getInterval(1) else {
+            XCTFail("ExponentialWaitGenerator never ends.")
+            return
+        }
+        XCTAssertEqual(interval, 2)
+    }
+
+    func test__next_2() {
+        guard let interval = getInterval(2) else {
+            XCTFail("ExponentialWaitGenerator never ends.")
+            return
+        }
+        XCTAssertEqual(interval, 4)
+    }
+
+    func test__next_3() {
+        guard let interval = getInterval(3) else {
+            XCTFail("ExponentialWaitGenerator never ends.")
+            return
+        }
+        XCTAssertEqual(interval, 8)
+    }
+
+    func test__next_4() {
+        guard let interval = getInterval(4) else {
+            XCTFail("ExponentialWaitGenerator never ends.")
+            return
+        }
+        XCTAssertEqual(interval, 16)
+    }
+
+    func test__next_5() {
+        guard let interval = getInterval(5) else {
+            XCTFail("ExponentialWaitGenerator never ends.")
+            return
+        }
+        XCTAssertEqual(interval, 20)
+    }
+}
+
+class FibonacciWaitGeneratorTests: XCTestCase {
+
+    var strategy: WaitStrategy!
+    var generator: AnyGenerator<NSTimeInterval>!
+
+    override func setUp() {
+        super.setUp()
+        strategy = .Fibonacci((period: 1, maximum: 10))
+        generator = strategy.generate()
+    }
+    
+    func getInterval(count: Int) -> NSTimeInterval? {
+        for _ in 0..<count {
+            guard let _ = generator.next() else {
+                XCTFail("FibonacciWaitGenerator never ends.")
+                break
+            }
+        }
+        return generator.next()
+    }
+
+    func test__next_0() {
+        guard let interval = getInterval(0) else {
+            XCTFail("FibonacciWaitGenerator never ends.")
+            return
+        }
+        XCTAssertEqual(interval, 0)
+    }
+
+    func test__next_1() {
+        guard let interval = getInterval(1) else {
+            XCTFail("FibonacciWaitGenerator never ends.")
+            return
+        }
+        XCTAssertEqual(interval, 1)
+    }
+
+    func test__next_2() {
+        guard let interval = getInterval(2) else {
+            XCTFail("FibonacciWaitGenerator never ends.")
+            return
+        }
+        XCTAssertEqual(interval, 1)
+    }
+
+    func test__next_3() {
+        guard let interval = getInterval(3) else {
+            XCTFail("FibonacciWaitGenerator never ends.")
+            return
+        }
+        XCTAssertEqual(interval, 2)
+    }
+
+    func test__next_4() {
+        guard let interval = getInterval(4) else {
+            XCTFail("FibonacciWaitGenerator never ends.")
+            return
+        }
+        XCTAssertEqual(interval, 3)
+    }
+
+    func test__next_5() {
+        guard let interval = getInterval(5) else {
+            XCTFail("FibonacciWaitGenerator never ends.")
+            return
+        }
+        XCTAssertEqual(interval, 5)
+    }
+
+    func test__next_6() {
+        guard let interval = getInterval(6) else {
+            XCTFail("FibonacciWaitGenerator never ends.")
+            return
+        }
+        XCTAssertEqual(interval, 8)
+    }
+
+    func test__next_7() {
+        guard let interval = getInterval(7) else {
+            XCTFail("FibonacciWaitGenerator never ends.")
+            return
+        }
+        XCTAssertEqual(interval, 10) // max reached
+    }
+}
+
+class NonRepeatableRepeatedOperationTests: OperationTests {
+
+    func createGenerator(succeedsAfterCount target: Int = 1) -> AnyGenerator<TestOperation> {
+        var count = 0
+        return anyGenerator { () -> TestOperation? in
+            guard count < target else { return nil }
+            defer { count += 1 }
+            if count < target - 1 {
+                return TestOperation(error: TestOperation.Error.SimulatedError)
+            }
+            else {
+                return TestOperation()
+            }
+        }
+    }
+
+    func test__repeated_operation_repeats() {
+        let operation = RepeatedOperation(createGenerator(succeedsAfterCount: 5))
+
+        addCompletionBlockToTestOperation(operation, withExpectation: expectationWithDescription("Test: \(__FUNCTION__)"))
+        runOperation(operation)
+        waitForExpectationsWithTimeout(3, handler: nil)
+
+        XCTAssertEqual(operation.count, 5)
+        XCTAssertEqual(operation.aggregateErrors.count, 4)
+    }
+
+    func test__repeated_with_max_number_of_attempts() {
+        let operation = RepeatedOperation(maxNumberOfAttempts: 2, createGenerator(succeedsAfterCount: 5))
+
+        addCompletionBlockToTestOperation(operation, withExpectation: expectationWithDescription("Test: \(__FUNCTION__)"))
+        runOperation(operation)
+        waitForExpectationsWithTimeout(3, handler: nil)
+
+        XCTAssertEqual(operation.count, 2)
+    }
+}
+
+class RepeatingTestOperation: TestOperation, Repeatable {
+
+    func shouldRepeat(count: Int) -> Bool {
+        return count < 5
+    }
+}
+
+class RepeatableRepeatedOperationTests: OperationTests {
+
+    func test__repeated_operation_repeats() {
+        let operation = RepeatedOperation { return RepeatingTestOperation() }
+
+        addCompletionBlockToTestOperation(operation, withExpectation: expectationWithDescription("Test: \(__FUNCTION__)"))
+        runOperation(operation)
+        waitForExpectationsWithTimeout(3, handler: nil)
+
+        XCTAssertEqual(operation.count, 5)
+    }
+
+    func test__repeated_with_max_number_of_attempts() {
+        let operation = RepeatedOperation(maxNumberOfAttempts: 2) { return RepeatingTestOperation() }
+
+        addCompletionBlockToTestOperation(operation, withExpectation: expectationWithDescription("Test: \(__FUNCTION__)"))
+        runOperation(operation)
+        waitForExpectationsWithTimeout(3, handler: nil)
+
+        XCTAssertEqual(operation.count, 2)
+    }
+}
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/Tests/Core/RepeatedOperationTests.swift
+++ b/Tests/Core/RepeatedOperationTests.swift
@@ -274,18 +274,18 @@ class NonRepeatableRepeatedOperationTests: OperationTests {
         runOperation(operation)
         waitForExpectationsWithTimeout(3, handler: nil)
 
-        XCTAssertEqual(operation.attempts, 5)
+        XCTAssertEqual(operation.count, 5)
         XCTAssertEqual(operation.aggregateErrors.count, 4)
     }
 
     func test__repeated_with_max_number_of_attempts() {
-        let operation = RepeatedOperation(maxNumberOfAttempts: 2, createGenerator(succeedsAfterCount: 5))
+        let operation = RepeatedOperation(maxCount: 2, createGenerator(succeedsAfterCount: 5))
 
         addCompletionBlockToTestOperation(operation, withExpectation: expectationWithDescription("Test: \(__FUNCTION__)"))
         runOperation(operation)
         waitForExpectationsWithTimeout(3, handler: nil)
 
-        XCTAssertEqual(operation.attempts, 2)
+        XCTAssertEqual(operation.count, 2)
     }
 }
 
@@ -305,17 +305,17 @@ class RepeatableRepeatedOperationTests: OperationTests {
         runOperation(operation)
         waitForExpectationsWithTimeout(3, handler: nil)
 
-        XCTAssertEqual(operation.attempts, 5)
+        XCTAssertEqual(operation.count, 5)
     }
 
     func test__repeated_with_max_number_of_attempts() {
-        let operation = RepeatedOperation(maxNumberOfAttempts: 2) { return RepeatingTestOperation() }
+        let operation = RepeatedOperation(maxCount: 2) { return RepeatingTestOperation() }
 
         addCompletionBlockToTestOperation(operation, withExpectation: expectationWithDescription("Test: \(__FUNCTION__)"))
         runOperation(operation)
         waitForExpectationsWithTimeout(3, handler: nil)
 
-        XCTAssertEqual(operation.attempts, 2)
+        XCTAssertEqual(operation.count, 2)
     }
 }
 

--- a/Tests/Core/RepeatedOperationTests.swift
+++ b/Tests/Core/RepeatedOperationTests.swift
@@ -9,6 +9,27 @@
 import XCTest
 @testable import Operations
 
+class RandomFailGeneratorTests: XCTestCase {
+
+    func test__failure_probability_distribution() {
+
+        var generator = RandomFailGenerator(anyGenerator { true })
+
+        let total = 1_000
+        var failures = 0
+        for _ in 0..<total {
+            if let _ = generator.next() { }
+            else {
+                failures += 1
+            }
+        }
+
+        let probabilityFailure = Double(failures) / Double(total)
+
+        XCTAssertEqualWithAccuracy(probabilityFailure, 0.1, accuracy: 0.02)
+    }
+}
+
 class FiniteGeneratorTests: XCTestCase {
 
     var generator: FiniteGenerator<AnyGenerator<Int>>!

--- a/Tests/Core/RepeatedOperationTests.swift
+++ b/Tests/Core/RepeatedOperationTests.swift
@@ -274,7 +274,7 @@ class NonRepeatableRepeatedOperationTests: OperationTests {
         runOperation(operation)
         waitForExpectationsWithTimeout(3, handler: nil)
 
-        XCTAssertEqual(operation.count, 5)
+        XCTAssertEqual(operation.attempts, 5)
         XCTAssertEqual(operation.aggregateErrors.count, 4)
     }
 
@@ -285,7 +285,7 @@ class NonRepeatableRepeatedOperationTests: OperationTests {
         runOperation(operation)
         waitForExpectationsWithTimeout(3, handler: nil)
 
-        XCTAssertEqual(operation.count, 2)
+        XCTAssertEqual(operation.attempts, 2)
     }
 }
 
@@ -305,7 +305,7 @@ class RepeatableRepeatedOperationTests: OperationTests {
         runOperation(operation)
         waitForExpectationsWithTimeout(3, handler: nil)
 
-        XCTAssertEqual(operation.count, 5)
+        XCTAssertEqual(operation.attempts, 5)
     }
 
     func test__repeated_with_max_number_of_attempts() {
@@ -315,7 +315,7 @@ class RepeatableRepeatedOperationTests: OperationTests {
         runOperation(operation)
         waitForExpectationsWithTimeout(3, handler: nil)
 
-        XCTAssertEqual(operation.count, 2)
+        XCTAssertEqual(operation.attempts, 2)
     }
 }
 

--- a/Tests/Core/RetryOperationTests.swift
+++ b/Tests/Core/RetryOperationTests.swift
@@ -1,0 +1,53 @@
+//
+//  RetryOperationTests.swift
+//  Operations
+//
+//  Created by Daniel Thorpe on 30/12/2015.
+//
+//
+
+import XCTest
+@testable import Operations
+
+class OperationWhichFailsThenSucceeds: Operation {
+
+    let shouldFail: Bool
+
+    init(shouldFail: Bool) {
+        self.shouldFail = shouldFail
+        super.init()
+        name = "Operation Which Fails But Then Succeeds"
+    }
+
+    override func execute() {
+        if shouldFail {
+            finish(TestOperation.Error.SimulatedError)
+        }
+        else {
+            finish()
+        }
+    }
+}
+
+class RetryOperationTests: OperationTests {
+
+    func test__retry_operation() {
+
+        var shouldFail = true
+
+        let operation = RetryOperation {
+            let op = OperationWhichFailsThenSucceeds(shouldFail: shouldFail)
+            op.addObserver(StartedObserver { _ in
+                shouldFail = false
+            })
+            return op
+        }
+
+        addCompletionBlockToTestOperation(operation, withExpectation: expectationWithDescription("Test: \(__FUNCTION__)"))
+        runOperation(operation)
+        waitForExpectationsWithTimeout(3, handler: nil)
+
+        XCTAssertTrue(operation.finished)
+        XCTAssertEqual(operation.attempts, 2)
+    }
+}

--- a/Tests/Core/RetryOperationTests.swift
+++ b/Tests/Core/RetryOperationTests.swift
@@ -48,6 +48,6 @@ class RetryOperationTests: OperationTests {
         waitForExpectationsWithTimeout(3, handler: nil)
 
         XCTAssertTrue(operation.finished)
-        XCTAssertEqual(operation.attempts, 2)
+        XCTAssertEqual(operation.count, 2)
     }
 }

--- a/Tests/Core/RetryOperationTests.swift
+++ b/Tests/Core/RetryOperationTests.swift
@@ -11,16 +11,16 @@ import XCTest
 
 class OperationWhichFailsThenSucceeds: Operation {
 
-    let shouldFail: Bool
+    let shouldFail: () -> Bool
 
-    init(shouldFail: Bool) {
+    init(shouldFail: () -> Bool) {
         self.shouldFail = shouldFail
         super.init()
         name = "Operation Which Fails But Then Succeeds"
     }
 
     override func execute() {
-        if shouldFail {
+        if shouldFail() {
             finish(TestOperation.Error.SimulatedError)
         }
         else {
@@ -31,14 +31,15 @@ class OperationWhichFailsThenSucceeds: Operation {
 
 class RetryOperationTests: OperationTests {
 
+    var operation: RetryOperation<OperationWhichFailsThenSucceeds>!
+
     func test__retry_operation() {
 
-        var shouldFail = true
-
-        let operation = RetryOperation {
-            let op = OperationWhichFailsThenSucceeds(shouldFail: shouldFail)
+        var numberOfFailures = 0
+        operation = RetryOperation {
+            let op = OperationWhichFailsThenSucceeds { return numberOfFailures < 2 }
             op.addObserver(StartedObserver { _ in
-                shouldFail = false
+                numberOfFailures += 1
             })
             return op
         }
@@ -49,5 +50,25 @@ class RetryOperationTests: OperationTests {
 
         XCTAssertTrue(operation.finished)
         XCTAssertEqual(operation.count, 2)
+    }
+
+    func test__retry_operation_where_max_count_is_reached() {
+        var numberOfFailures = 0
+        operation = RetryOperation(maxCount: 5) {
+            let op = OperationWhichFailsThenSucceeds { return numberOfFailures < 9 }
+            op.addObserver(StartedObserver { _ in
+                numberOfFailures += 1
+            })
+            return op
+        }
+
+
+        addCompletionBlockToTestOperation(operation, withExpectation: expectationWithDescription("Test: \(__FUNCTION__)"))
+        runOperation(operation)
+        waitForExpectationsWithTimeout(3, handler: nil)
+
+        XCTAssertTrue(operation.finished)
+        XCTAssertEqual(operation.count, 5)
+
     }
 }


### PR DESCRIPTION
Here are my thoughts on a possible `RetryOperation`.

1. It would be a way of reliably executing an operation which can "fail" (finish with errors).
2. It would be a little bit like `ReachableOperation` / `ComposedOperation` where the target operation is composed inside a group operation.
3. The target operation gets a `NoFailedDependenciesCondition` added
4. If the target operation finishes with any errors, another instance of the same operation is added to the group after a delay
5. When creating the `RetryOperation`, the initializer should accept a (minimum) time delay, a flag for whether the delay should be exponentially backed-off (is that a term?).
6. Perhaps also define a maximum number of attempts - but default to `.None`.


It might also be useful to architecture this as a subclass of `RepeatedOperation` which is basically just like above, except it just executes instances of the same operation a number of times. Would that be useful? I don't know....
