### PR TITLE
Operations from conditions execute after the operation's dependencies

### DIFF
--- a/Sources/Core/Shared/Operation.swift
+++ b/Sources/Core/Shared/Operation.swift
@@ -343,7 +343,8 @@ public class Operation: NSOperation {
         super.addDependency(operation)
     }
 
-    public override var dependencies: [NSOperation] {
+    /// Public override to get the dependencies
+    public override final var dependencies: [NSOperation] {
         get {
             var _dependencies = super.dependencies
             guard let
@@ -360,20 +361,30 @@ public class Operation: NSOperation {
     }
 
     /**
-    Add another `NSOperation` as a dependency. It is a programmatic error to call this method after the receiver has 
-    already started executing. Therefore, best practice is to add dependencies before adding them to operation
-    queues.
+     Add another `NSOperation` as a dependency. It is a programmatic error to call
+     this method after the receiver has already started executing. Therefore, best 
+     practice is to add dependencies before adding them to operation queues.
     
      - requires: self must not have started yet. i.e. either hasn't been added
      to a queue, or is waiting on dependencies.
      - parameter operation: a `NSOperation` instance.
     */
-    public override func addDependency(operation: NSOperation) {
+    public override final func addDependency(operation: NSOperation) {
         precondition(state <= .Executing, "Dependencies cannot be modified after execution has begun, current state: \(state).")
         (waitForDependenciesOperation ?? createDidFinishDependenciesOperation()).addDependency(operation)
     }
 
-    public override func removeDependency(operation: NSOperation) {
+    /**
+     Remove another `NSOperation` as a dependency. It is a programmatic error to call
+     this method after the receiver has already started executing. Therefore, best 
+     practice is to manage dependencies before adding them to operation
+     queues.
+
+     - requires: self must not have started yet. i.e. either hasn't been added
+     to a queue, or is waiting on dependencies.
+     - parameter operation: a `NSOperation` instance.
+     */
+    public override final func removeDependency(operation: NSOperation) {
         precondition(state <= .Executing, "Dependencies cannot be modified after execution has begun, current state: \(state).")
         guard let waiter = waitForDependenciesOperation else {
             return

--- a/Sources/Core/Shared/Operation.swift
+++ b/Sources/Core/Shared/Operation.swift
@@ -375,15 +375,13 @@ public class Operation: NSOperation {
 
     public override func removeDependency(operation: NSOperation) {
         precondition(state <= .Executing, "Dependencies cannot be modified after execution has begun, current state: \(state).")
-        if let waiter = waitForDependenciesOperation {
-            waiter.removeDependency(operation)
-            if waiter.dependencies.count == 0 {
-                super.removeDependency(waiter)
-                waitForDependenciesOperation = nil
-            }
+        guard let waiter = waitForDependenciesOperation else {
+            return
         }
-        else {
-            super.removeDependency(operation)
+        waiter.removeDependency(operation)
+        if waiter.dependencies.count == 0 {
+            super.removeDependency(waiter)
+            waitForDependenciesOperation = nil
         }
     }
 
@@ -423,7 +421,6 @@ public class Operation: NSOperation {
     */
     public func execute() {
         print("\(self.dynamicType) must override `execute()`.", terminator: "")
-        
         finish()
     }
 

--- a/Sources/Core/Shared/Operation.swift
+++ b/Sources/Core/Shared/Operation.swift
@@ -338,11 +338,9 @@ public class Operation: NSOperation {
     internal func addConditionDependency(operation: NSOperation) {
         precondition(state <= .Executing, "Dependencies cannot be modified after execution has begun, current state: \(state).")
         if let waiter = waitForDependenciesOperation {
-            waiter.addDependency(operation)
+            operation.addDependency(waiter)
         }
-        else {
-            super.addDependency(operation)
-        }
+        super.addDependency(operation)
     }
 
     public override var dependencies: [NSOperation] {

--- a/Sources/Core/Shared/Operation.swift
+++ b/Sources/Core/Shared/Operation.swift
@@ -323,6 +323,44 @@ public class Operation: NSOperation {
         observers.append(observer)
     }
 
+    // MARK: - Dependencies
+
+    private func createDidFinishDependenciesOperation() -> NSOperation {
+        assert(waitForDependenciesOperation == nil, "Should only ever create the finishing dependency once.")
+        let __op = NSBlockOperation { }
+        super.addDependency(__op)
+        waitForDependenciesOperation = __op
+        return __op
+    }
+
+    internal var waitForDependenciesOperation: NSOperation? = .None
+
+    internal func addConditionDependency(operation: NSOperation) {
+        precondition(state <= .Executing, "Dependencies cannot be modified after execution has begun, current state: \(state).")
+        if let waiter = waitForDependenciesOperation {
+            waiter.addDependency(operation)
+        }
+        else {
+            super.addDependency(operation)
+        }
+    }
+
+    public override var dependencies: [NSOperation] {
+        get {
+            var _dependencies = super.dependencies
+            guard let
+                waiter = waitForDependenciesOperation,
+                index = _dependencies.indexOf(waiter) else {
+                return _dependencies
+            }
+
+            _dependencies.removeAtIndex(index)
+            _dependencies.appendContentsOf(waiter.dependencies)
+
+            return _dependencies
+        }
+    }
+
     /**
     Add another `NSOperation` as a dependency. It is a programmatic error to call this method after the receiver has 
     already started executing. Therefore, best practice is to add dependencies before adding them to operation
@@ -334,7 +372,21 @@ public class Operation: NSOperation {
     */
     public override func addDependency(operation: NSOperation) {
         precondition(state <= .Executing, "Dependencies cannot be modified after execution has begun, current state: \(state).")
-        super.addDependency(operation)
+        (waitForDependenciesOperation ?? createDidFinishDependenciesOperation()).addDependency(operation)
+    }
+
+    public override func removeDependency(operation: NSOperation) {
+        precondition(state <= .Executing, "Dependencies cannot be modified after execution has begun, current state: \(state).")
+        if let waiter = waitForDependenciesOperation {
+            waiter.removeDependency(operation)
+            if waiter.dependencies.count == 0 {
+                super.removeDependency(waiter)
+                waitForDependenciesOperation = nil
+            }
+        }
+        else {
+            super.removeDependency(operation)
+        }
     }
 
     // MARK: - Execution and Cancellation

--- a/Sources/Core/Shared/OperationQueue.swift
+++ b/Sources/Core/Shared/OperationQueue.swift
@@ -68,13 +68,20 @@ public class OperationQueue: NSOperationQueue {
                 }
             })
 
-            let dependencies = operation.conditions.flatMap {
+            let conditionDependencies = operation.conditions.flatMap {
                 $0.dependencyForOperation(operation)
             }
 
-            for dependency in dependencies {
-                operation.addDependency(dependency)
-                addOperation(dependency)
+            if let waiter = operation.waitForDependenciesOperation {
+                for conditionDependency in conditionDependencies {
+                    conditionDependency.addDependency(waiter)
+                }
+                addOperation(waiter)
+            }
+
+            for conditionDependency in conditionDependencies {
+                operation.addConditionDependency(conditionDependency)
+                addOperation(conditionDependency)
             }
 
             // Check for exclusive mutability constraints

--- a/Sources/Core/Shared/OperationQueue.swift
+++ b/Sources/Core/Shared/OperationQueue.swift
@@ -72,16 +72,13 @@ public class OperationQueue: NSOperationQueue {
                 $0.dependencyForOperation(operation)
             }
 
-            if let waiter = operation.waitForDependenciesOperation {
-                for conditionDependency in conditionDependencies {
-                    conditionDependency.addDependency(waiter)
-                }
-                addOperation(waiter)
-            }
-
             for conditionDependency in conditionDependencies {
                 operation.addConditionDependency(conditionDependency)
                 addOperation(conditionDependency)
+            }
+
+            if let waiter = operation.waitForDependenciesOperation {
+                addOperation(waiter)
             }
 
             // Check for exclusive mutability constraints

--- a/Tests/Core/RepeatedOperationTests.swift
+++ b/Tests/Core/RepeatedOperationTests.swift
@@ -26,7 +26,7 @@ class RandomFailGeneratorTests: XCTestCase {
 
         let probabilityFailure = Double(failures) / Double(total)
 
-        XCTAssertEqualWithAccuracy(probabilityFailure, 0.1, accuracy: 0.02)
+        XCTAssertEqualWithAccuracy(probabilityFailure, 0.1, accuracy: 0.05)
     }
 }
 

--- a/Tests/Features/LocationOperationsTests.swift
+++ b/Tests/Features/LocationOperationsTests.swift
@@ -159,8 +159,8 @@ class UserLocationOperationTests: LocationOperationTests {
         runOperation(operation)
         waitForExpectationsWithTimeout(3, handler: nil)
 
-        XCTAssertEqual(locationManager.desiredAccuracy!, accuracy)
-        XCTAssertEqual(receivedLocation!.horizontalAccuracy, accuracy)
+        XCTAssertEqual(locationManager.desiredAccuracy, accuracy)
+        XCTAssertEqual(receivedLocation?.horizontalAccuracy, accuracy)
         XCTAssertTrue(locationManager.didSetDelegate)
         XCTAssertTrue(locationManager.didStartUpdatingLocation)
         XCTAssertTrue(locationManager.didStopLocationUpdates)


### PR DESCRIPTION
This PR implements the changes as discussed in #147. Essentially each `Operation` instance now has an internal optional `NSOperation` property. This property is simply a *waiter*, and serves no purpose other than for dependency management.

We also now have the concept of *direct dependency* (or maybe regular dependency), and an *indirect dependency*. A direct dependency is one added via `addDependency` whereas an indirect dependency is the dependency of an operation condition.

When `addDependency` is invoked, the argument operation is added as a dependency to an internal `NSOperation` instance which is created on the fly (and added as a dependency of the receiver using `super.addDependency`). Essentially this creates a dummy operation which acts as a surrogate for the receiver. It waits for all the direct dependencies.

When `removeDependency` is invoked, this structure is broken down.

When accessing `dependencies` the array of dependencies has the waiter operation removed, but we add all of its dependencies to the array.

When an `Operation` is added to an `OperationQueue`, as before we extract the dependency operations from the conditions. For each of these dependencies we use an internal `addConditionDependency` function on the operation. If the receiver has a waiter set (i.e. it previously had direct dependencies added), we add the waiter as a dependency of the condition before adding the condition as a dependency of the receiver (using `super.addDependency`).

The diagram below represents the execution of operations on the queue for the green `Operation` instance.

![dependencywaiter](https://cloud.githubusercontent.com/assets/309420/12091406/c8dec334-b2ee-11e5-949d-1d9cc3fc0663.png)
