### PR TITLE
Refactor ComposedOperation & GatedOperation

### DIFF
--- a/Sources/Core/Shared/ComposedOperation.swift
+++ b/Sources/Core/Shared/ComposedOperation.swift
@@ -8,19 +8,15 @@
 
 import Foundation
 
-internal protocol ComposedOperationType: class {
-    typealias Composed: NSOperation
-}
-
-public class ComposedOperation<O: NSOperation>: Operation, OperationDidFinishObserver, ComposedOperationType {
-    typealias Composed = O
+public class ComposedOperation<O: NSOperation>: Operation, OperationDidFinishObserver {
 
     public let operation: O
     private var target: Operation? = nil
 
-    public required init(_ compose: O) {
-        operation = compose
+    public required init(operation: O) {
+        self.operation = operation
         super.init()
+        name = "Composed Operation<\(operation.dynamicType)>"
     }
 
     public override func execute() {

--- a/Sources/Core/Shared/ComposedOperation.swift
+++ b/Sources/Core/Shared/ComposedOperation.swift
@@ -17,6 +17,12 @@ public class ComposedOperation<O: NSOperation>: Operation, OperationDidFinishObs
         self.operation = operation
         super.init()
         name = "Composed Operation<\(operation.dynamicType)>"
+
+    }
+
+    public override func cancel() {
+        operation.cancel()
+        super.cancel()
     }
 
     public override func execute() {

--- a/Sources/Core/Shared/GatedOperation.swift
+++ b/Sources/Core/Shared/GatedOperation.swift
@@ -9,42 +9,44 @@
 import Foundation
 
 /**
-Allows a `NSOperation` to be composed inside an `Operation`, 
-with a block to act as a gate.
+ Allows a `NSOperation` to be composed inside an `Operation`,
+ with a block to act as a gate.
+ 
+ Use this class to execute another operation depending on other
+ logic. Unlike a `BlockCondition` this will not fail the operation.
 */
-public class GatedOperation<O: NSOperation>: GroupOperation {
+public class GatedOperation<O: NSOperation>: ComposedOperation<O> {
 
     public typealias GateBlockType = () -> Bool
 
-    /// The composed generic operation
-    public let operation: O
     let gate: GateBlockType
 
     /**
-    Return true from the block to have the composed operation
-    be executed, return false and the operation will not
-    be executed.
+     Return true from the block to have the composed operation
+     be executed, return false and the operation will not
+     be executed.
     
-    - parameter operation: any subclass of `NSOperation`.
-    - parameter gate: a block which returns a Bool.
+     - parameter operation: any subclass of `NSOperation`.
+     - parameter gate: a block which returns a Bool.
     */
-    public init(operation: O, gate: GateBlockType) {
-        self.operation = operation
+    public init(_ operation: O, gate: GateBlockType) {
         self.gate = gate
-        super.init(operations: [])
+        super.init(operation)
     }
 
     /**
-    Executes the block. If the result of executing the gate is
-    true, the operation is added. Then we call super.execute()
-    which will start the group's queue, meaning that the composed
-    operation will start.
+     Executes the block. If the result of executing the gate is
+     true, the composed operation will start. If the gate is
+     false, this operation will finish. Note that if the gate is
+     closed, the operation does not "fail" i.e. finish with errors.
     */
     public override func execute() {
         if gate() {
-            addOperation(operation)
+            super.execute()
         }
-        super.execute()
+        else {
+            finish()
+        }
     }
 }
 

--- a/Sources/Core/Shared/GatedOperation.swift
+++ b/Sources/Core/Shared/GatedOperation.swift
@@ -29,9 +29,9 @@ public class GatedOperation<O: NSOperation>: ComposedOperation<O> {
      - parameter operation: any subclass of `NSOperation`.
      - parameter gate: a block which returns a Bool.
     */
-    public init(_ operation: O, gate: GateBlockType) {
+    public init(operation: O, gate: GateBlockType) {
         self.gate = gate
-        super.init(operation)
+        super.init(operation: operation)
     }
 
     /**

--- a/Tests/Core/ComposedOperationTests.swift
+++ b/Tests/Core/ComposedOperationTests.swift
@@ -11,6 +11,26 @@ import XCTest
 
 class ComposedOperationTests: OperationTests {
 
+    func test__composed_operation_is_cancelled() {
+        let composed = ComposedOperation(operation: TestOperation())
+        composed.cancel()
+        XCTAssertTrue(composed.cancelled)
+        XCTAssertTrue(composed.operation.cancelled)
+    }
+
+    func test__composed_nsoperation_is_performed() {
+        var didExecute = false
+        let composed = ComposedOperation(operation: NSBlockOperation {
+            didExecute = true
+        })
+        addCompletionBlockToTestOperation(composed, withExpectation: expectationWithDescription("Test: \(__FUNCTION__)"))
+        runOperation(composed)
+
+        waitForExpectationsWithTimeout(3, handler: nil)
+        XCTAssertTrue(composed.finished)
+        XCTAssertTrue(didExecute)
+    }
+
     func test__composed_operation_is_performed() {
         let composed = ComposedOperation(operation: TestOperation())
         addCompletionBlockToTestOperation(composed, withExpectation: expectationWithDescription("Test: \(__FUNCTION__)"))

--- a/Tests/Core/ComposedOperationTests.swift
+++ b/Tests/Core/ComposedOperationTests.swift
@@ -12,14 +12,13 @@ import XCTest
 class ComposedOperationTests: OperationTests {
 
     func test__composed_operation_is_performed() {
-        let composed = ComposedOperation(operation: TestOperation())
+        let composed: ComposedOperation<TestOperation> = ComposedOperation(TestOperation())
         addCompletionBlockToTestOperation(composed, withExpectation: expectationWithDescription("Test: \(__FUNCTION__)"))
         runOperation(composed)
 
         waitForExpectationsWithTimeout(3, handler: nil)
         XCTAssertTrue(composed.finished)
         XCTAssertTrue(composed.operation.didExecute)
-
     }
 }
 

--- a/Tests/Core/ComposedOperationTests.swift
+++ b/Tests/Core/ComposedOperationTests.swift
@@ -12,7 +12,7 @@ import XCTest
 class ComposedOperationTests: OperationTests {
 
     func test__composed_operation_is_performed() {
-        let composed: ComposedOperation<TestOperation> = ComposedOperation(TestOperation())
+        let composed = ComposedOperation(operation: TestOperation())
         addCompletionBlockToTestOperation(composed, withExpectation: expectationWithDescription("Test: \(__FUNCTION__)"))
         runOperation(composed)
 

--- a/Tests/Core/GatedOperationTests.swift
+++ b/Tests/Core/GatedOperationTests.swift
@@ -13,7 +13,7 @@ class GatedOperationTests: OperationTests {
 
     func test__when_gate_is_closed_operation_is_not_performed() {
 
-        let gate = GatedOperation(operation: TestOperation()) { return false }
+        let gate = GatedOperation(TestOperation()) { return false }
         addCompletionBlockToTestOperation(gate, withExpectation: expectationWithDescription("Test: \(__FUNCTION__)"))
 
         runOperation(gate)
@@ -24,7 +24,7 @@ class GatedOperationTests: OperationTests {
     }
 
     func test__when_gate_is_open_operation_is_performed() {
-        let gate = GatedOperation(operation: TestOperation()) { return true }
+        let gate = GatedOperation(TestOperation()) { return true }
         addCompletionBlockToTestOperation(gate, withExpectation: expectationWithDescription("Test: \(__FUNCTION__), Gate"))
         addCompletionBlockToTestOperation(gate.operation, withExpectation: expectationWithDescription("Test: \(__FUNCTION__), Operation"))
 

--- a/Tests/Core/GatedOperationTests.swift
+++ b/Tests/Core/GatedOperationTests.swift
@@ -13,7 +13,7 @@ class GatedOperationTests: OperationTests {
 
     func test__when_gate_is_closed_operation_is_not_performed() {
 
-        let gate = GatedOperation(TestOperation()) { return false }
+        let gate = GatedOperation(operation: TestOperation()) { return false }
         addCompletionBlockToTestOperation(gate, withExpectation: expectationWithDescription("Test: \(__FUNCTION__)"))
 
         runOperation(gate)
@@ -24,7 +24,7 @@ class GatedOperationTests: OperationTests {
     }
 
     func test__when_gate_is_open_operation_is_performed() {
-        let gate = GatedOperation(TestOperation()) { return true }
+        let gate = GatedOperation(operation: TestOperation()) { return true }
         addCompletionBlockToTestOperation(gate, withExpectation: expectationWithDescription("Test: \(__FUNCTION__), Gate"))
         addCompletionBlockToTestOperation(gate.operation, withExpectation: expectationWithDescription("Test: \(__FUNCTION__), Operation"))
 


### PR DESCRIPTION
These two operations which are not used very much, and I want to tweak them to fix a few issues. The main idea behind `ComposedOperation` is that other `NSOperation` instances can be wrapped in an `Operation`. `GatedOperation` is the same, except it runs a block at execution which determines whether the composed operation is added to the queue.

If the composed operation is a subclass of `NSOperation` but not `Operation` then we *must* run it inside a group. However, if it is an `Operation` subclass, then we can use `produceOperation` and observers and not use a group. So, this logic should all be internal to `ComposedOperation`. `GatedOperation` is just a simple subclass of `ComposedOperation` (at the moment, it's the other way around).

Once this is all fixed, then things like `ReachableOperation` can subclass `ComposedOperation` and become much more useful.