### PR TITLE
Refactor CloudKitOperation, phase 3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ DerivedData
 # http://guides.cocoapods.org/using/using-cocoapods.html#should-i-ignore-the-pods-directory-in-source-control
 #
 # Pods/
+Examples/*/Pods
 
 # Carthage
 #

--- a/Examples/Last Opened/Last Opened.xcodeproj/project.pbxproj
+++ b/Examples/Last Opened/Last Opened.xcodeproj/project.pbxproj
@@ -1,0 +1,371 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 46;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		230FD1542F50B9F09F7BE0BC /* Pods.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 88895C4860B44D3360D59F9D /* Pods.framework */; };
+		655CC9F31C44033A00E4ECF9 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 655CC9F21C44033A00E4ECF9 /* AppDelegate.swift */; };
+		655CC9F51C44033A00E4ECF9 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 655CC9F41C44033A00E4ECF9 /* ViewController.swift */; };
+		655CC9F81C44033A00E4ECF9 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 655CC9F61C44033A00E4ECF9 /* Main.storyboard */; };
+		655CC9FA1C44033A00E4ECF9 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 655CC9F91C44033A00E4ECF9 /* Assets.xcassets */; };
+		655CC9FD1C44033A00E4ECF9 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 655CC9FB1C44033A00E4ECF9 /* LaunchScreen.storyboard */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		655CC9EF1C44033A00E4ECF9 /* Last Opened.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Last Opened.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+		655CC9F21C44033A00E4ECF9 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		655CC9F41C44033A00E4ECF9 /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
+		655CC9F71C44033A00E4ECF9 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
+		655CC9F91C44033A00E4ECF9 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		655CC9FC1C44033A00E4ECF9 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
+		655CC9FE1C44033A00E4ECF9 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		88895C4860B44D3360D59F9D /* Pods.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		C28D7021DB32420D31F57E60 /* Pods.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.release.xcconfig; path = "Pods/Target Support Files/Pods/Pods.release.xcconfig"; sourceTree = "<group>"; };
+		D0B635E806C9A53BEBB9E960 /* Pods.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.debug.xcconfig; path = "Pods/Target Support Files/Pods/Pods.debug.xcconfig"; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		655CC9EC1C44033A00E4ECF9 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				230FD1542F50B9F09F7BE0BC /* Pods.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		04AD28568D1F88912889DB50 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				88895C4860B44D3360D59F9D /* Pods.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		655CC9E61C44033A00E4ECF9 = {
+			isa = PBXGroup;
+			children = (
+				655CC9F11C44033A00E4ECF9 /* Last Opened */,
+				655CC9F01C44033A00E4ECF9 /* Products */,
+				8E40EAC3C19327F6B03EF6EC /* Pods */,
+				04AD28568D1F88912889DB50 /* Frameworks */,
+			);
+			sourceTree = "<group>";
+		};
+		655CC9F01C44033A00E4ECF9 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				655CC9EF1C44033A00E4ECF9 /* Last Opened.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		655CC9F11C44033A00E4ECF9 /* Last Opened */ = {
+			isa = PBXGroup;
+			children = (
+				655CC9F21C44033A00E4ECF9 /* AppDelegate.swift */,
+				655CC9F41C44033A00E4ECF9 /* ViewController.swift */,
+				655CC9F61C44033A00E4ECF9 /* Main.storyboard */,
+				655CC9F91C44033A00E4ECF9 /* Assets.xcassets */,
+				655CC9FB1C44033A00E4ECF9 /* LaunchScreen.storyboard */,
+				655CC9FE1C44033A00E4ECF9 /* Info.plist */,
+			);
+			path = "Last Opened";
+			sourceTree = "<group>";
+		};
+		8E40EAC3C19327F6B03EF6EC /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				D0B635E806C9A53BEBB9E960 /* Pods.debug.xcconfig */,
+				C28D7021DB32420D31F57E60 /* Pods.release.xcconfig */,
+			);
+			name = Pods;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		655CC9EE1C44033A00E4ECF9 /* Last Opened */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 655CCA011C44033A00E4ECF9 /* Build configuration list for PBXNativeTarget "Last Opened" */;
+			buildPhases = (
+				DD4EFA58D24950C4397A7196 /* Check Pods Manifest.lock */,
+				655CC9EB1C44033A00E4ECF9 /* Sources */,
+				655CC9EC1C44033A00E4ECF9 /* Frameworks */,
+				655CC9ED1C44033A00E4ECF9 /* Resources */,
+				7DD600BBDF0F2798A6812F6C /* Embed Pods Frameworks */,
+				F24D284A7EA5691C628C6293 /* Copy Pods Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "Last Opened";
+			productName = "Last Opened";
+			productReference = 655CC9EF1C44033A00E4ECF9 /* Last Opened.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		655CC9E71C44033A00E4ECF9 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastSwiftUpdateCheck = 0720;
+				LastUpgradeCheck = 0720;
+				ORGANIZATIONNAME = "Daniel Thorpe";
+				TargetAttributes = {
+					655CC9EE1C44033A00E4ECF9 = {
+						CreatedOnToolsVersion = 7.2;
+					};
+				};
+			};
+			buildConfigurationList = 655CC9EA1C44033A00E4ECF9 /* Build configuration list for PBXProject "Last Opened" */;
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = English;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = 655CC9E61C44033A00E4ECF9;
+			productRefGroup = 655CC9F01C44033A00E4ECF9 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				655CC9EE1C44033A00E4ECF9 /* Last Opened */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		655CC9ED1C44033A00E4ECF9 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				655CC9FD1C44033A00E4ECF9 /* LaunchScreen.storyboard in Resources */,
+				655CC9FA1C44033A00E4ECF9 /* Assets.xcassets in Resources */,
+				655CC9F81C44033A00E4ECF9 /* Main.storyboard in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		7DD600BBDF0F2798A6812F6C /* Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Embed Pods Frameworks";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods/Pods-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		DD4EFA58D24950C4397A7196 /* Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Check Pods Manifest.lock";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
+			showEnvVarsInLog = 0;
+		};
+		F24D284A7EA5691C628C6293 /* Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Copy Pods Resources";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods/Pods-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+/* End PBXShellScriptBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		655CC9EB1C44033A00E4ECF9 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				655CC9F51C44033A00E4ECF9 /* ViewController.swift in Sources */,
+				655CC9F31C44033A00E4ECF9 /* AppDelegate.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXVariantGroup section */
+		655CC9F61C44033A00E4ECF9 /* Main.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				655CC9F71C44033A00E4ECF9 /* Base */,
+			);
+			name = Main.storyboard;
+			sourceTree = "<group>";
+		};
+		655CC9FB1C44033A00E4ECF9 /* LaunchScreen.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				655CC9FC1C44033A00E4ECF9 /* Base */,
+			);
+			name = LaunchScreen.storyboard;
+			sourceTree = "<group>";
+		};
+/* End PBXVariantGroup section */
+
+/* Begin XCBuildConfiguration section */
+		655CC9FF1C44033A00E4ECF9 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		655CCA001C44033A00E4ECF9 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		655CCA021C44033A00E4ECF9 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = D0B635E806C9A53BEBB9E960 /* Pods.debug.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				INFOPLIST_FILE = "Last Opened/Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "me.danthorpe.Last-Opened";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Debug;
+		};
+		655CCA031C44033A00E4ECF9 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = C28D7021DB32420D31F57E60 /* Pods.release.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				INFOPLIST_FILE = "Last Opened/Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "me.danthorpe.Last-Opened";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		655CC9EA1C44033A00E4ECF9 /* Build configuration list for PBXProject "Last Opened" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				655CC9FF1C44033A00E4ECF9 /* Debug */,
+				655CCA001C44033A00E4ECF9 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		655CCA011C44033A00E4ECF9 /* Build configuration list for PBXNativeTarget "Last Opened" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				655CCA021C44033A00E4ECF9 /* Debug */,
+				655CCA031C44033A00E4ECF9 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 655CC9E71C44033A00E4ECF9 /* Project object */;
+}

--- a/Examples/Last Opened/Last Opened.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/Examples/Last Opened/Last Opened.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:Last Opened.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/Examples/Last Opened/Last Opened.xcworkspace/contents.xcworkspacedata
+++ b/Examples/Last Opened/Last Opened.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "group:Last Opened.xcodeproj">
+   </FileRef>
+   <FileRef
+      location = "group:Pods/Pods.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/Examples/Last Opened/Last Opened/AppDelegate.swift
+++ b/Examples/Last Opened/Last Opened/AppDelegate.swift
@@ -1,0 +1,46 @@
+//
+//  AppDelegate.swift
+//  Last Opened
+//
+//  Created by Daniel Thorpe on 11/01/2016.
+//  Copyright © 2016 Daniel Thorpe. All rights reserved.
+//
+
+import UIKit
+
+@UIApplicationMain
+class AppDelegate: UIResponder, UIApplicationDelegate {
+
+    var window: UIWindow?
+
+
+    func application(application: UIApplication, didFinishLaunchingWithOptions launchOptions: [NSObject: AnyObject]?) -> Bool {
+        // Override point for customization after application launch.
+        return true
+    }
+
+    func applicationWillResignActive(application: UIApplication) {
+        // Sent when the application is about to move from active to inactive state. This can occur for certain types of temporary interruptions (such as an incoming phone call or SMS message) or when the user quits the application and it begins the transition to the background state.
+        // Use this method to pause ongoing tasks, disable timers, and throttle down OpenGL ES frame rates. Games should use this method to pause the game.
+    }
+
+    func applicationDidEnterBackground(application: UIApplication) {
+        // Use this method to release shared resources, save user data, invalidate timers, and store enough application state information to restore your application to its current state in case it is terminated later.
+        // If your application supports background execution, this method is called instead of applicationWillTerminate: when the user quits.
+    }
+
+    func applicationWillEnterForeground(application: UIApplication) {
+        // Called as part of the transition from the background to the inactive state; here you can undo many of the changes made on entering the background.
+    }
+
+    func applicationDidBecomeActive(application: UIApplication) {
+        // Restart any tasks that were paused (or not yet started) while the application was inactive. If the application was previously in the background, optionally refresh the user interface.
+    }
+
+    func applicationWillTerminate(application: UIApplication) {
+        // Called when the application is about to terminate. Save data if appropriate. See also applicationDidEnterBackground:.
+    }
+
+
+}
+

--- a/Examples/Last Opened/Last Opened/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/Examples/Last Opened/Last Opened/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,68 @@
+{
+  "images" : [
+    {
+      "idiom" : "iphone",
+      "size" : "29x29",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "29x29",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "40x40",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "40x40",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "60x60",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "60x60",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "29x29",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "29x29",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "40x40",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "40x40",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "76x76",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "76x76",
+      "scale" : "2x"
+    }
+  ],
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/Examples/Last Opened/Last Opened/Base.lproj/LaunchScreen.storyboard
+++ b/Examples/Last Opened/Last Opened/Base.lproj/LaunchScreen.storyboard
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="8150" systemVersion="15A204g" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" initialViewController="01J-lp-oVM">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="8122"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="EHf-IW-A2E">
+            <objects>
+                <viewController id="01J-lp-oVM" sceneMemberID="viewController">
+                    <layoutGuides>
+                        <viewControllerLayoutGuide type="top" id="Llm-lL-Icb"/>
+                        <viewControllerLayoutGuide type="bottom" id="xb3-aO-Qok"/>
+                    </layoutGuides>
+                    <view key="view" contentMode="scaleToFill" id="Ze5-6b-2t3">
+                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <animations/>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="iYj-Kq-Ea1" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="53" y="375"/>
+        </scene>
+    </scenes>
+</document>

--- a/Examples/Last Opened/Last Opened/Base.lproj/Main.storyboard
+++ b/Examples/Last Opened/Last Opened/Base.lproj/Main.storyboard
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="6211" systemVersion="14A298i" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="BYZ-38-t0r">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="6204"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="tne-QT-ifu">
+            <objects>
+                <viewController id="BYZ-38-t0r" customClass="ViewController" customModuleProvider="target" sceneMemberID="viewController">
+                    <layoutGuides>
+                        <viewControllerLayoutGuide type="top" id="y3c-jy-aDJ"/>
+                        <viewControllerLayoutGuide type="bottom" id="wfy-db-euE"/>
+                    </layoutGuides>
+                    <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
+                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
+            </objects>
+        </scene>
+    </scenes>
+</document>

--- a/Examples/Last Opened/Last Opened/Info.plist
+++ b/Examples/Last Opened/Last Opened/Info.plist
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>UILaunchStoryboardName</key>
+	<string>LaunchScreen</string>
+	<key>UIMainStoryboardFile</key>
+	<string>Main</string>
+	<key>UIRequiredDeviceCapabilities</key>
+	<array>
+		<string>armv7</string>
+	</array>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+</dict>
+</plist>

--- a/Examples/Last Opened/Last Opened/ViewController.swift
+++ b/Examples/Last Opened/Last Opened/ViewController.swift
@@ -1,0 +1,27 @@
+//
+//  ViewController.swift
+//  Last Opened
+//
+//  Created by Daniel Thorpe on 11/01/2016.
+//  Copyright © 2016 Daniel Thorpe. All rights reserved.
+//
+
+import UIKit
+import CloudKit
+import Operations
+
+class ViewController: UIViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        // Do any additional setup after loading the view, typically from a nib.
+    }
+
+    override func didReceiveMemoryWarning() {
+        super.didReceiveMemoryWarning()
+        // Dispose of any resources that can be recreated.
+    }
+
+
+}
+

--- a/Examples/Last Opened/Podfile
+++ b/Examples/Last Opened/Podfile
@@ -1,0 +1,6 @@
+platform :ios, '9.0'
+
+inhibit_all_warnings!
+use_frameworks!
+
+pod 'Operations', :path => '../../'

--- a/Examples/Last Opened/Podfile.lock
+++ b/Examples/Last Opened/Podfile.lock
@@ -1,0 +1,16 @@
+PODS:
+  - Operations (2.5.1):
+    - Operations/Standard (= 2.5.1)
+  - Operations/Standard (2.5.1)
+
+DEPENDENCIES:
+  - Operations (from `../../`)
+
+EXTERNAL SOURCES:
+  Operations:
+    :path: "../../"
+
+SPEC CHECKSUMS:
+  Operations: 3c646c48620ac4b6c624d825d42c1e684ecb6a53
+
+COCOAPODS: 0.39.0

--- a/Sources/Core/Shared/ComposedOperation.swift
+++ b/Sources/Core/Shared/ComposedOperation.swift
@@ -11,14 +11,15 @@ import Foundation
 public class ComposedOperation<T: NSOperation>: Operation, OperationDidFinishObserver {
 
     public let target: Operation
-    public var creator: () -> T    
     public var operation: T
 
-    public required init(@autoclosure(escaping) operation _creator: () -> T) {
-        let op = _creator()
-        creator = _creator
-        target = op as? Operation ?? GroupOperation(operations: [op])
-        operation = op
+    public convenience init(_ op: T) {
+        self.init(operation: op)
+    }
+
+    init(operation op: T) {
+        self.target = op as? Operation ?? GroupOperation(operations: [op])
+        self.operation = op
         super.init()
         name = "Composed Operation"
         target.addObserver(self)

--- a/Sources/Core/Shared/ComposedOperation.swift
+++ b/Sources/Core/Shared/ComposedOperation.swift
@@ -10,14 +10,17 @@ import Foundation
 
 public class ComposedOperation<T: NSOperation>: Operation, OperationDidFinishObserver {
 
-    public let operation: T
     public let target: Operation
+    public var creator: () -> T    
+    public var operation: T
 
-    public required init(operation op: T) {
+    public required init(@autoclosure(escaping) operation _creator: () -> T) {
+        let op = _creator()
+        creator = _creator
         target = op as? Operation ?? GroupOperation(operations: [op])
         operation = op
         super.init()
-        name = "Composed Operation<\(operation.dynamicType)>"
+        name = "Composed Operation"
         target.addObserver(self)
     }
 

--- a/Sources/Core/Shared/GatedOperation.swift
+++ b/Sources/Core/Shared/GatedOperation.swift
@@ -29,9 +29,9 @@ public class GatedOperation<T: NSOperation>: ComposedOperation<T> {
      - parameter operation: any subclass of `NSOperation`.
      - parameter gate: a block which returns a Bool.
     */
-    public init(operation: T, gate: GateBlockType) {
+    public init(_ op: T, gate: GateBlockType) {
         self.gate = gate
-        super.init(operation: operation)
+        super.init(operation: op)
     }
 
     /**

--- a/Sources/Core/Shared/GroupOperation.swift
+++ b/Sources/Core/Shared/GroupOperation.swift
@@ -86,13 +86,15 @@ public class GroupOperation: Operation {
      - parameter operations: an array of `NSOperation` instances.
      */
     public func addOperations(operations: [NSOperation]) {
-        log.notice("Add operations to group \(operations.map { $0.operationName })")
-        operations.forEach {
-            if let op = $0 as? Operation {
-                op.log.severity = log.severity
+        if operations.count > 0 {
+            log.notice("Add operations to group \(operations.map { $0.operationName })")
+            operations.forEach {
+                if let op = $0 as? Operation {
+                    op.log.severity = log.severity
+                }
             }
+            queue.addOperations(operations, waitUntilFinished: false)
         }
-        queue.addOperations(operations, waitUntilFinished: false)
     }
 
     /**

--- a/Sources/Core/Shared/GroupOperation.swift
+++ b/Sources/Core/Shared/GroupOperation.swift
@@ -24,33 +24,10 @@ operations.
 */
 public class GroupOperation: Operation {
 
-    public struct ChildObserver {
-        public typealias BlockType = (GroupOperation, NSOperation, [ErrorType]) -> Void
-
-        private let block: BlockType
-
-        /**
-         Initialize the observer with a block.
-
-         - parameter didStart: the `DidStartBlock`
-         - returns: an observer.
-         */
-        public init(didFinish: BlockType) {
-            self.block = didFinish
-        }
-
-        /// Conforms to `OperationDidFinishObserver`, executes the block
-        func group(group: GroupOperation, childDidFinish operation: NSOperation, withErrors errors: [ErrorType]) {
-            block(group, operation, errors)
-        }
-    }
-
-    private let finishingOperation = NSBlockOperation(block: {})
+    private let finishingOperation = NSBlockOperation { }
 
     public let queue = OperationQueue()
     public let operations: [NSOperation]
-
-    var __observers: [ChildObserver] = []
 
     /// - returns: an aggregation of errors [ErrorType]
     public private(set) var aggregateErrors = Array<ErrorType>()
@@ -65,7 +42,6 @@ public class GroupOperation: Operation {
         super.init()
         queue.suspended = true
         queue.delegate = self
-        queue.addOperation(finishingOperation)
         addOperations(operations)
         addObserver(CancelledObserver { [weak self] _ in
             self?.queue.cancelAllOperations()
@@ -82,6 +58,7 @@ public class GroupOperation: Operation {
      starting the queue, and adding the finishing operation.
     */
     public override func execute() {
+        queue.addOperation(finishingOperation)
         queue.suspended = false
     }
 
@@ -127,14 +104,6 @@ public class GroupOperation: Operation {
     public final func aggregateError(error: ErrorType) {
         log.warning("Aggregating error: \(error)")
         aggregateErrors.append(error)
-    }
-
-    public func addChildObserver(block: ChildObserver.BlockType) {
-        addChildObserver(ChildObserver(didFinish: block))
-    }
-
-    public func addChildObserver(observer: ChildObserver) {
-        __observers.append(observer)
     }
 
     /**
@@ -190,7 +159,8 @@ extension GroupOperation: OperationQueueDelegate {
      when there are no more operations in the group.
     */
     public func operationQueue(queue: OperationQueue, willAddOperation operation: NSOperation) {
-        assert(!finishingOperation.finished && !finishingOperation.executing, "Cannot add new operations to a group after the group has completed.")
+        assert(!finishingOperation.executing, "Cannot add new operations to a group after the group has started to finish.")
+        assert(!finishingOperation.finished, "Cannot add new operations to a group after the group has completed.")
 
         if operation !== finishingOperation {
             finishingOperation.addDependency(operation)
@@ -210,7 +180,6 @@ extension GroupOperation: OperationQueueDelegate {
             finish(aggregateErrors)
         }
         else {
-            __observers.forEach { $0.group(self, childDidFinish: operation, withErrors: errors) }
             operationDidFinish(operation, withErrors: errors)
         }
     }

--- a/Sources/Core/Shared/Operation.swift
+++ b/Sources/Core/Shared/Operation.swift
@@ -466,6 +466,7 @@ public class Operation: NSOperation {
             _cancelled = true
 
             if state > .Ready {
+                super.cancel()
                 finish()
             }
         }

--- a/Sources/Features/Shared/CloudKitOperation.swift
+++ b/Sources/Features/Shared/CloudKitOperation.swift
@@ -672,6 +672,8 @@ public class BatchedCloudKitOperation<T where T: NSOperation, T: CKBatchedOperat
     }
 }
 
+// MARK: - CKFetchNotificationChangesOperation
+
 extension BatchedCloudKitOperation where T: CKFetchNotificationChangesOperationType {
 
     public typealias FetchNotificationChangesChangedBlock = T.Notification -> Void
@@ -681,19 +683,49 @@ extension BatchedCloudKitOperation where T: CKFetchNotificationChangesOperationT
         get { return operation.notificationChangedBlock }
         set {
             operation.notificationChangedBlock = newValue
-            addConfigureBlock { op in
-                op.notificationChangedBlock = newValue
-            }
+            addConfigureBlock { $0.notificationChangedBlock = newValue }
         }
     }
 
     public func setFetchNotificationChangesCompletionBlock(block: FetchNotificationChangesCompletionBlock) {
-        addConfigureBlock { op in
-            op.setFetchNotificationChangesCompletionBlock(block)
-        }
+        addConfigureBlock { $0.setFetchNotificationChangesCompletionBlock(block) }
     }
 }
 
+// MARK: - CKFetchRecordChangesOperation
+
+extension BatchedCloudKitOperation where T: CKFetchRecordChangesOperationType {
+
+    public typealias FetchRecordChangesCompletionBlock = (T.ServerChangeToken?, NSData?) -> Void
+
+    public var recordZoneID: T.RecordZoneID {
+        get { return operation.recordZoneID }
+        set {
+            operation.recordZoneID = newValue
+            addConfigureBlock { $0.recordZoneID = newValue }
+        }
+    }
+
+    public var recordChangedBlock: ((T.Record) -> Void)? {
+        get { return operation.recordChangedBlock }
+        set {
+            operation.recordChangedBlock = newValue
+            addConfigureBlock { $0.recordChangedBlock = newValue }
+        }
+    }
+
+    public var recordWithIDWasDeletedBlock: ((T.RecordID) -> Void)? {
+        get { return operation.recordWithIDWasDeletedBlock }
+        set {
+            operation.recordWithIDWasDeletedBlock = newValue
+            addConfigureBlock { $0.recordWithIDWasDeletedBlock = newValue }
+        }
+    }
+
+    public func setFetchRecordChangesCompletionBlock(block: FetchRecordChangesCompletionBlock) {
+        addConfigureBlock { $0.setFetchRecordChangesCompletionBlock(block) }
+    }
+}
 
 
 

--- a/Sources/Features/Shared/CloudKitOperation.swift
+++ b/Sources/Features/Shared/CloudKitOperation.swift
@@ -28,29 +28,9 @@ public protocol CKOperationType: class {
     var container: Container? { get set }
 }
 
-extension CKOperation: CKOperationType {
-    public typealias Container = CKContainer
-    public typealias ServerChangeToken = CKServerChangeToken
-    public typealias DiscoveredUserInfo = CKDiscoveredUserInfo
-    public typealias RecordZone = CKRecordZone
-    public typealias RecordZoneID = CKRecordZoneID
-    public typealias Notification = CKNotification
-    public typealias NotificationID = CKNotificationID
-    public typealias Record = CKRecord
-    public typealias RecordID = CKRecordID
-    public typealias Subscription = CKSubscription
-    public typealias RecordSavePolicy = CKRecordSavePolicy
-    public typealias Query = CKQuery
-    public typealias QueryCursor = CKQueryCursor
-}
-
 public protocol CKDatabaseOperationType: CKOperationType {
     typealias Database
     var database: Database? { get set }
-}
-
-extension CKDatabaseOperation: CKDatabaseOperationType {
-    public typealias Database = CKDatabase
 }
 
 public protocol CKPreviousServerChangeToken: CKOperationType {
@@ -75,15 +55,11 @@ public protocol CKDiscoverAllContactsOperationType: CKOperationType {
     var discoverAllContactsCompletionBlock: (([DiscoveredUserInfo]?, NSError?) -> Void)? { get set }
 }
 
-extension CKDiscoverAllContactsOperation: CKDiscoverAllContactsOperationType { }
-
 public protocol CKDiscoverUserInfosOperationType: CKOperationType {
     var emailAddresses: [String]? { get set }
     var userRecordIDs: [RecordID]? { get set }
     var discoverUserInfosCompletionBlock: (([String: DiscoveredUserInfo]?, [RecordID: DiscoveredUserInfo]?, NSError?) -> Void)? { get set }
 }
-
-extension CKDiscoverUserInfosOperation: CKDiscoverUserInfosOperationType { }
 
 public protocol CKFetchNotificationChangesOperationType: CKFetchOperationType {
 
@@ -91,21 +67,15 @@ public protocol CKFetchNotificationChangesOperationType: CKFetchOperationType {
     var fetchNotificationChangesCompletionBlock: ((ServerChangeToken?, NSError?) -> Void)? { get set }
 }
 
-extension CKFetchNotificationChangesOperation: CKFetchNotificationChangesOperationType { }
-
 public protocol CKMarkNotificationsReadOperationType: CKOperationType {
     var notificationIDs: [NotificationID] { get set }
     var markNotificationsReadCompletionBlock: (([NotificationID]?, NSError?) -> Void)? { get set }
 }
 
-extension CKMarkNotificationsReadOperation: CKMarkNotificationsReadOperationType { }
-
 public protocol CKModifyBadgeOperationType: CKOperationType {
     var badgeValue: Int { get set }
     var modifyBadgeCompletionBlock: ((NSError?) -> Void)? { get set }
 }
-
-extension CKModifyBadgeOperation: CKModifyBadgeOperationType { }
 
 public protocol CKFetchRecordChangesOperationType: CKDatabaseOperationType, CKFetchOperationType, CKDesiredKeys {
 
@@ -115,14 +85,10 @@ public protocol CKFetchRecordChangesOperationType: CKDatabaseOperationType, CKFe
     var fetchRecordChangesCompletionBlock: ((ServerChangeToken?, NSData?, NSError?) -> Void)? { get set }
 }
 
-extension CKFetchRecordChangesOperation: CKFetchRecordChangesOperationType { }
-
 public protocol CKFetchRecordZonesOperationType: CKDatabaseOperationType {
     var recordZoneIDs: [RecordZoneID]? { get set }
     var fetchRecordZonesCompletionBlock: (([RecordZoneID: RecordZone]?, NSError?) -> Void)? { get set }
 }
-
-extension CKFetchRecordZonesOperation: CKFetchRecordZonesOperationType { }
 
 public protocol CKFetchRecordsOperationType: CKDatabaseOperationType, CKDesiredKeys {
     var recordIDs: [RecordID]? { get set }
@@ -131,22 +97,16 @@ public protocol CKFetchRecordsOperationType: CKDatabaseOperationType, CKDesiredK
     var fetchRecordsCompletionBlock: (([RecordID: Record]?, NSError?) -> Void)? { get set }
 }
 
-extension CKFetchRecordsOperation: CKFetchRecordsOperationType { }
-
 public protocol CKFetchSubscriptionsOperationType: CKDatabaseOperationType {
     var subscriptionIDs: [String]? { get set }
     var fetchSubscriptionCompletionBlock: (([String: Subscription]?, NSError?) -> Void)? { get set }
 }
-
-extension CKFetchSubscriptionsOperation: CKFetchSubscriptionsOperationType { }
 
 public protocol CKModifyRecordZonesOperationType: CKDatabaseOperationType {
     var recordZonesToSave: [RecordZone]? { get set }
     var recordZoneIDsToDelete: [RecordZoneID]? { get set }
     var modifyRecordZonesCompletionBlock: (([RecordZone]?, [RecordZoneID]?, NSError?) -> Void)? { get set }
 }
-
-extension CKModifyRecordZonesOperation: CKModifyRecordZonesOperationType { }
 
 public protocol CKModifyRecordsOperationType: CKDatabaseOperationType {
     var recordsToSave: [Record]? { get set }
@@ -160,15 +120,11 @@ public protocol CKModifyRecordsOperationType: CKDatabaseOperationType {
     var modifyRecordsCompletionBlock: (([Record]?, [RecordID]?, NSError?) -> Void)? { get set }
 }
 
-extension CKModifyRecordsOperation: CKModifyRecordsOperationType { }
-
 public protocol CKModifySubscriptionsOperationType: CKDatabaseOperationType {
     var subscriptionsToSave: [Subscription]? { get set }
     var subscriptionIDsToDelete: [String]? { get set }
     var modifySubscriptionsCompletionBlock: (([Subscription]?, [String]?, NSError?) -> Void)? { get set }
 }
-
-extension CKModifySubscriptionsOperation: CKModifySubscriptionsOperationType { }
 
 public protocol CKQueryOperationType: CKDatabaseOperationType, CKResultsLimit, CKDesiredKeys {
 
@@ -179,14 +135,58 @@ public protocol CKQueryOperationType: CKDatabaseOperationType, CKResultsLimit, C
     var queryCompletionBlock: ((QueryCursor?, NSError?) -> Void)? { get set }
 }
 
+extension CKOperation: CKOperationType {
+    public typealias Container = CKContainer
+    public typealias ServerChangeToken = CKServerChangeToken
+    public typealias DiscoveredUserInfo = CKDiscoveredUserInfo
+    public typealias RecordZone = CKRecordZone
+    public typealias RecordZoneID = CKRecordZoneID
+    public typealias Notification = CKNotification
+    public typealias NotificationID = CKNotificationID
+    public typealias Record = CKRecord
+    public typealias RecordID = CKRecordID
+    public typealias Subscription = CKSubscription
+    public typealias RecordSavePolicy = CKRecordSavePolicy
+    public typealias Query = CKQuery
+    public typealias QueryCursor = CKQueryCursor
+}
+
+extension CKDatabaseOperation: CKDatabaseOperationType {
+    public typealias Database = CKDatabase
+}
+
+extension CKDiscoverAllContactsOperation: CKDiscoverAllContactsOperationType { }
+
+extension CKDiscoverUserInfosOperation: CKDiscoverUserInfosOperationType { }
+
+extension CKFetchNotificationChangesOperation: CKFetchNotificationChangesOperationType { }
+
+extension CKMarkNotificationsReadOperation: CKMarkNotificationsReadOperationType { }
+
+extension CKModifyBadgeOperation: CKModifyBadgeOperationType { }
+
+extension CKFetchRecordChangesOperation: CKFetchRecordChangesOperationType { }
+
+extension CKFetchRecordZonesOperation: CKFetchRecordZonesOperationType { }
+
+extension CKFetchRecordsOperation: CKFetchRecordsOperationType { }
+
+extension CKFetchSubscriptionsOperation: CKFetchSubscriptionsOperationType { }
+
+extension CKModifyRecordZonesOperation: CKModifyRecordZonesOperationType { }
+
+extension CKModifyRecordsOperation: CKModifyRecordsOperationType { }
+
+extension CKModifySubscriptionsOperation: CKModifySubscriptionsOperationType { }
+
 extension CKQueryOperation: CKQueryOperationType { }
 
 // MARK: - CloudKitOperation
 
 public class CloudKitOperation<T where T: NSOperation, T: CKOperationType>: ReachableOperation<T> {
 
-    override init(operation: T, connectivity: Reachability.Connectivity = .AnyConnectionKind, reachability: SystemReachabilityType) {
-        super.init(operation: operation, connectivity: connectivity, reachability: reachability)
+    init(_ op: T, connectivity: Reachability.Connectivity = .AnyConnectionKind, reachability: SystemReachabilityType) {
+        super.init(operation: op, connectivity: connectivity, reachability: reachability)
         name = "CloudKit Operation<\(operation.dynamicType)>"
     }
 }

--- a/Sources/Features/Shared/CloudKitOperation.swift
+++ b/Sources/Features/Shared/CloudKitOperation.swift
@@ -183,10 +183,10 @@ extension CKQueryOperation: CKQueryOperationType { }
 
 // MARK: - CloudKitOperation
 
-public class CloudKitOperation<T where T: NSOperation, T: CKOperationType>: ComposedOperation<T> {
+public class CloudKitOperation<T where T: NSOperation, T: CKOperationType>: ReachableOperation<T> {
 
-    public required init(_ op: T) {
-        super.init(operation: op)
+    override init(operation: T, connectivity: Reachability.Connectivity = .AnyConnectionKind, reachability: SystemReachabilityType) {
+        super.init(operation: operation, connectivity: connectivity, reachability: reachability)
         name = "CloudKit Operation<\(operation.dynamicType)>"
     }
 }
@@ -200,7 +200,6 @@ extension CloudKitOperation where T: CKOperationType {
         set { operation.container = newValue }
     }
 }
-
 
 // MARK: - CKDatabaseOperation
 

--- a/Sources/Features/Shared/ReachableOperation.swift
+++ b/Sources/Features/Shared/ReachableOperation.swift
@@ -33,14 +33,14 @@ public class ReachableOperation<T: NSOperation>: ComposedOperation<T> {
      - parameter [unlabeled] operation: any `NSOperation` type.
      - parameter connectivity: a `Reachability.Connectivity` value, defaults to `.AnyConnectionKind`.
     */
-    public convenience init(_ operation: T, connectivity: Reachability.Connectivity = .AnyConnectionKind) {
-        self.init(operation: operation, connectivity: connectivity, reachability: Reachability.sharedInstance)
+    public convenience init(connectivity: Reachability.Connectivity = .AnyConnectionKind, @autoclosure(escaping) operation: () -> T) {
+        self.init(connectivity: connectivity, reachability: Reachability.sharedInstance, operation: operation)
     }
 
-    init(operation: T, connectivity: Reachability.Connectivity = .AnyConnectionKind, reachability: SystemReachabilityType) {
+    init(connectivity: Reachability.Connectivity = .AnyConnectionKind, reachability: SystemReachabilityType, @autoclosure(escaping) operation creator: () -> T) {
         self.connectivity = connectivity
         self.reachability = reachability
-        super.init(operation: operation)
+        super.init(operation: creator)
         name = "Reachable Operation <\(operation.operationName)>"
     }
 

--- a/Sources/Features/Shared/ReachableOperation.swift
+++ b/Sources/Features/Shared/ReachableOperation.swift
@@ -33,14 +33,14 @@ public class ReachableOperation<T: NSOperation>: ComposedOperation<T> {
      - parameter [unlabeled] operation: any `NSOperation` type.
      - parameter connectivity: a `Reachability.Connectivity` value, defaults to `.AnyConnectionKind`.
     */
-    public convenience init(connectivity: Reachability.Connectivity = .AnyConnectionKind, @autoclosure(escaping) operation: () -> T) {
-        self.init(connectivity: connectivity, reachability: Reachability.sharedInstance, operation: operation)
+    public convenience init(operation op: T, connectivity: Reachability.Connectivity = .AnyConnectionKind) {
+        self.init(operation: op, connectivity: connectivity, reachability: Reachability.sharedInstance)
     }
 
-    init(connectivity: Reachability.Connectivity = .AnyConnectionKind, reachability: SystemReachabilityType, @autoclosure(escaping) operation creator: () -> T) {
+    init(operation op: T, connectivity: Reachability.Connectivity = .AnyConnectionKind, reachability: SystemReachabilityType) {
         self.connectivity = connectivity
         self.reachability = reachability
-        super.init(operation: creator)
+        super.init(operation: op)
         name = "Reachable Operation <\(operation.operationName)>"
     }
 

--- a/Sources/Features/Shared/ReachableOperation.swift
+++ b/Sources/Features/Shared/ReachableOperation.swift
@@ -33,7 +33,7 @@ public class ReachableOperation<T: NSOperation>: ComposedOperation<T> {
      - parameter [unlabeled] operation: any `NSOperation` type.
      - parameter connectivity: a `Reachability.Connectivity` value, defaults to `.AnyConnectionKind`.
     */
-    public convenience init(operation op: T, connectivity: Reachability.Connectivity = .AnyConnectionKind) {
+    public convenience init(_ op: T, connectivity: Reachability.Connectivity = .AnyConnectionKind) {
         self.init(operation: op, connectivity: connectivity, reachability: Reachability.sharedInstance)
     }
 

--- a/Tests/Core/ComposedOperationTests.swift
+++ b/Tests/Core/ComposedOperationTests.swift
@@ -12,7 +12,7 @@ import XCTest
 class ComposedOperationTests: OperationTests {
 
     func test__composed_operation_is_cancelled() {
-        let composed = ComposedOperation(operation: TestOperation())
+        let composed = ComposedOperation(TestOperation())
         composed.cancel()
         XCTAssertTrue(composed.cancelled)
         XCTAssertTrue(composed.operation.cancelled)
@@ -20,7 +20,7 @@ class ComposedOperationTests: OperationTests {
 
     func test__composed_nsoperation_is_performed() {
         var didExecute = false
-        let composed = ComposedOperation(operation: NSBlockOperation {
+        let composed = ComposedOperation(NSBlockOperation {
             didExecute = true
         })
         addCompletionBlockToTestOperation(composed, withExpectation: expectationWithDescription("Test: \(__FUNCTION__)"))

--- a/Tests/Core/GatedOperationTests.swift
+++ b/Tests/Core/GatedOperationTests.swift
@@ -13,7 +13,7 @@ class GatedOperationTests: OperationTests {
 
     func test__when_gate_is_closed_operation_is_not_performed() {
 
-        let gate = GatedOperation(operation: TestOperation()) { return false }
+        let gate = GatedOperation(TestOperation()) { return false }
         addCompletionBlockToTestOperation(gate, withExpectation: expectationWithDescription("Test: \(__FUNCTION__)"))
 
         runOperation(gate)
@@ -24,7 +24,7 @@ class GatedOperationTests: OperationTests {
     }
 
     func test__when_gate_is_open_operation_is_performed() {
-        let gate = GatedOperation(operation: TestOperation()) { return true }
+        let gate = GatedOperation(TestOperation()) { return true }
         addCompletionBlockToTestOperation(gate, withExpectation: expectationWithDescription("Test: \(__FUNCTION__), Gate"))
         addCompletionBlockToTestOperation(gate.operation, withExpectation: expectationWithDescription("Test: \(__FUNCTION__), Operation"))
 

--- a/Tests/Core/GroupOperationTests.swift
+++ b/Tests/Core/GroupOperationTests.swift
@@ -16,6 +16,17 @@ class GroupOperationTests: OperationTests {
         return (0..<3).map { _ in TestOperation() }
     }
 
+    func test__cancel_group_operation() {
+
+        let operations = createGroupOperations()
+        let operation = GroupOperation(operations: operations)
+        operation.cancel()
+
+        for op in operations {
+            XCTAssertTrue(op.cancelled)
+        }
+    }
+
     func test__group_operations_are_performed_in_order() {
         let group = createGroupOperations()
         let expectation = expectationWithDescription("Test: \(__FUNCTION__)")
@@ -77,6 +88,22 @@ class GroupOperationTests: OperationTests {
         XCTAssertTrue(operations[0].didExecute)
         XCTAssertTrue(operations[1].didExecute)
         XCTAssertTrue(operations[2].didExecute)
+    }
+
+    func test__child_observer_is_called() {
+        let group = createGroupOperations()
+        let operation = GroupOperation(operations: group)
+
+        var childDidFinish: Int = 0
+        operation.addChildObserver { group, op, errors in
+            childDidFinish += 1
+        }
+
+        addCompletionBlockToTestOperation(operation, withExpectation: expectationWithDescription("Test: \(__FUNCTION__)"))
+        runOperation(operation)
+        waitForExpectationsWithTimeout(3, handler: nil)
+
+        XCTAssertEqual(childDidFinish, 3)
     }
 }
 

--- a/Tests/Core/GroupOperationTests.swift
+++ b/Tests/Core/GroupOperationTests.swift
@@ -89,22 +89,6 @@ class GroupOperationTests: OperationTests {
         XCTAssertTrue(operations[1].didExecute)
         XCTAssertTrue(operations[2].didExecute)
     }
-
-    func test__child_observer_is_called() {
-        let group = createGroupOperations()
-        let operation = GroupOperation(operations: group)
-
-        var childDidFinish: Int = 0
-        operation.addChildObserver { group, op, errors in
-            childDidFinish += 1
-        }
-
-        addCompletionBlockToTestOperation(operation, withExpectation: expectationWithDescription("Test: \(__FUNCTION__)"))
-        runOperation(operation)
-        waitForExpectationsWithTimeout(3, handler: nil)
-
-        XCTAssertEqual(childDidFinish, 3)
-    }
 }
 
 

--- a/Tests/Features/CloudKitOperationTests.swift
+++ b/Tests/Features/CloudKitOperationTests.swift
@@ -318,21 +318,27 @@ class TestQueryOperation: TestDatabaseOperation, CKQueryOperationType {
 
 // MARK: - Test Cases
 
-class CloudKitOperationTests<Target where Target: NSOperation, Target: CKOperationType>: OperationTests {
+class CloudKitOperationTests: OperationTests {
 
-    var target: Target!
     var reachability: TestableSystemReachability!
-    var operation: CloudKitOperation<Target>!
 
     override func setUp() {
         super.setUp()
         reachability = TestableSystemReachability()
-        target = Target()
-        operation = CloudKitOperation(operation: target, reachability: reachability)
+        reachability.status = .Reachable(.ViaWiFi)
     }
 }
 
-class CloudOperationTests: CloudKitOperationTests<TestCloudOperation> {
+class CloudOperationTests: CloudKitOperationTests {
+
+    var target: TestCloudOperation!
+    var operation: CloudKitOperation<TestCloudOperation>!
+
+    override func setUp() {
+        super.setUp()
+        target = TestCloudOperation()
+        operation = CloudKitOperation(operation: target, reachability: reachability)
+    }
 
     func test__get_countainer() {
         let container = "I'm a test container!"
@@ -347,7 +353,16 @@ class CloudOperationTests: CloudKitOperationTests<TestCloudOperation> {
     }
 }
 
-class DatabaseOperationTests: CloudKitOperationTests<TestDatabaseOperation> {
+class DatabaseOperationTests: CloudKitOperationTests {
+
+    var target: TestDatabaseOperation!
+    var operation: CloudKitOperation<TestDatabaseOperation>!
+
+    override func setUp() {
+        super.setUp()
+        target = TestDatabaseOperation()
+        operation = CloudKitOperation(operation: target, reachability: reachability)
+    }
 
     func test__get_database() {
         let db = "I'm a test database!"
@@ -403,7 +418,16 @@ class DatabaseOperationTests: CloudKitOperationTests<TestDatabaseOperation> {
     }
 }
 
-class DiscoverAllContactsOperationTests: CloudKitOperationTests<TestDiscoverAllContactsOperation> {
+class DiscoverAllContactsOperationTests: CloudKitOperationTests {
+
+    var target: TestDiscoverAllContactsOperation!
+    var operation: CloudKitOperation<TestDiscoverAllContactsOperation>!
+
+    override func setUp() {
+        super.setUp()
+        target = TestDiscoverAllContactsOperation(result: [])
+        operation = CloudKitOperation(operation: target, reachability: reachability)
+    }
 
     func test__execution_after_cancellation() {
         operation.cancel()
@@ -468,7 +492,16 @@ class DiscoverAllContactsOperationTests: CloudKitOperationTests<TestDiscoverAllC
     }
 }
 
-class DiscoverUserInfosOperationTests: CloudKitOperationTests<TestDiscoverUserInfosOperation> {
+class DiscoverUserInfosOperationTests: CloudKitOperationTests {
+
+    var target: TestDiscoverUserInfosOperation!
+    var operation: CloudKitOperation<TestDiscoverUserInfosOperation>!
+
+    override func setUp() {
+        super.setUp()
+        target = TestDiscoverUserInfosOperation(userInfosByEmailAddress: [:], userInfoByRecordID: [:])
+        operation = CloudKitOperation(operation: target, reachability: reachability)
+    }
 
     func test__get_email_addresses() {
         target.emailAddresses = [ "hello@world.com" ]
@@ -533,15 +566,17 @@ class DiscoverUserInfosOperationTests: CloudKitOperationTests<TestDiscoverUserIn
     }
 }
 
-class FetchNotificationChangesOperationTests: CloudKitOperationTests<TestFetchNotificationChangesOperation> {
+class FetchNotificationChangesOperationTests: CloudKitOperationTests {
 
+    var target: TestFetchNotificationChangesOperation!
+    var operation: CloudKitOperation<TestFetchNotificationChangesOperation>!
     var token: TestFetchNotificationChangesOperation.ServerChangeToken!
 
     override func setUp() {
         super.setUp()
         token = "i'm a server token"
         target = TestFetchNotificationChangesOperation(token: token)
-        operation = CloudKitOperation(target)
+        operation = CloudKitOperation(operation: target, reachability: reachability)
     }
 
     func test__get_set_notification_charged_block() {
@@ -587,15 +622,17 @@ class FetchNotificationChangesOperationTests: CloudKitOperationTests<TestFetchNo
     }
 }
 
-class MarkNotificationsReadOperationTests: CloudKitOperationTests<TestMarkNotificationsReadOperation> {
+class MarkNotificationsReadOperationTests: CloudKitOperationTests {
 
+    var target: TestMarkNotificationsReadOperation!
+    var operation: CloudKitOperation<TestMarkNotificationsReadOperation>!
     var toMark: [TestMarkNotificationsReadOperation.NotificationID]!
 
     override func setUp() {
         super.setUp()
         toMark = [ "this-is-an-id", "this-is-another-id" ]
         target = TestMarkNotificationsReadOperation(markIDsToRead: toMark)
-        operation = CloudKitOperation(target)
+        operation = CloudKitOperation(operation: target, reachability: reachability)
     }
 
     func test__get_notification_id() {
@@ -637,15 +674,17 @@ class MarkNotificationsReadOperationTests: CloudKitOperationTests<TestMarkNotifi
     }
 }
 
-class ModifyBadgeOperationTests: CloudKitOperationTests<TestModifyBadgeOperation> {
+class ModifyBadgeOperationTests: CloudKitOperationTests {
 
+    var target: TestModifyBadgeOperation!
+    var operation: CloudKitOperation<TestModifyBadgeOperation>!
     var badge: Int!
 
     override func setUp() {
         super.setUp()
         badge = 9
         target = TestModifyBadgeOperation(value: badge)
-        operation = CloudKitOperation(target)
+        operation = CloudKitOperation(operation: target, reachability: reachability)
     }
 
     func test__get_badge_value() {
@@ -687,7 +726,16 @@ class ModifyBadgeOperationTests: CloudKitOperationTests<TestModifyBadgeOperation
     }
 }
 
-class FetchRecordChangesOperationTests: CloudKitOperationTests<TestFetchRecordChangesOperation> {
+class FetchRecordChangesOperationTests: CloudKitOperationTests {
+
+    var target: TestFetchRecordChangesOperation!
+    var operation: CloudKitOperation<TestFetchRecordChangesOperation>!
+
+    override func setUp() {
+        super.setUp()
+        target = TestFetchRecordChangesOperation()
+        operation = CloudKitOperation(operation: target, reachability: reachability)
+    }
 
     func test__get_record_zone_id() {
         let zoneID = "zone-id"
@@ -750,7 +798,16 @@ class FetchRecordChangesOperationTests: CloudKitOperationTests<TestFetchRecordCh
     }
 }
 
-class FetchRecordZonesOperationTests: CloudKitOperationTests<TestFetchRecordZonesOperation> {
+class FetchRecordZonesOperationTests: CloudKitOperationTests {
+
+    var target: TestFetchRecordZonesOperation!
+    var operation: CloudKitOperation<TestFetchRecordZonesOperation>!
+
+    override func setUp() {
+        super.setUp()
+        target = TestFetchRecordZonesOperation()
+        operation = CloudKitOperation(operation: target, reachability: reachability)
+    }
 
     func test__get_record_zone_ids() {
         let zoneIDs = [ "a-zone-id", "another-zone-id" ]
@@ -793,7 +850,16 @@ class FetchRecordZonesOperationTests: CloudKitOperationTests<TestFetchRecordZone
     }
 }
 
-class FetchRecordsOperationTests: CloudKitOperationTests<TestFetchRecordsOperation> {
+class FetchRecordsOperationTests: CloudKitOperationTests {
+
+    var target: TestFetchRecordsOperation!
+    var operation: CloudKitOperation<TestFetchRecordsOperation>!
+
+    override func setUp() {
+        super.setUp()
+        target = TestFetchRecordsOperation()
+        operation = CloudKitOperation(operation: target, reachability: reachability)
+    }
 
     func test__get_record_ids() {
         let IDs = [ "an-id", "another-id" ]
@@ -858,7 +924,16 @@ class FetchRecordsOperationTests: CloudKitOperationTests<TestFetchRecordsOperati
     }
 }
 
-class FetchSubscriptionsOperationTests: CloudKitOperationTests<TestFetchSubscriptionsOperation> {
+class FetchSubscriptionsOperationTests: CloudKitOperationTests {
+
+    var target: TestFetchSubscriptionsOperation!
+    var operation: CloudKitOperation<TestFetchSubscriptionsOperation>!
+
+    override func setUp() {
+        super.setUp()
+        target = TestFetchSubscriptionsOperation()
+        operation = CloudKitOperation(operation: target, reachability: reachability)
+    }
 
     func test__get_subscription_ids() {
         let IDs = [ "an-id", "another-id" ]
@@ -901,7 +976,16 @@ class FetchSubscriptionsOperationTests: CloudKitOperationTests<TestFetchSubscrip
     }
 }
 
-class ModifyRecordZonesOperationTests: CloudKitOperationTests<TestModifyRecordZonesOperation> {
+class ModifyRecordZonesOperationTests: CloudKitOperationTests {
+
+    var target: TestModifyRecordZonesOperation!
+    var operation: CloudKitOperation<TestModifyRecordZonesOperation>!
+
+    override func setUp() {
+        super.setUp()
+        target = TestModifyRecordZonesOperation()
+        operation = CloudKitOperation(operation: target, reachability: reachability)
+    }
 
     func test__get_zones_to_save() {
         let zones = [ "a-zone", "another-zone" ]
@@ -956,7 +1040,16 @@ class ModifyRecordZonesOperationTests: CloudKitOperationTests<TestModifyRecordZo
     }
 }
 
-class ModifyRecordsOperationTests: CloudKitOperationTests<TestModifyRecordsOperation> {
+class ModifyRecordsOperationTests: CloudKitOperationTests {
+
+    var target: TestModifyRecordsOperation!
+    var operation: CloudKitOperation<TestModifyRecordsOperation>!
+
+    override func setUp() {
+        super.setUp()
+        target = TestModifyRecordsOperation()
+        operation = CloudKitOperation(operation: target, reachability: reachability)
+    }
 
     func test__get_records_to_save() {
         let records = [ "a-record", "another-record" ]
@@ -1063,7 +1156,16 @@ class ModifyRecordsOperationTests: CloudKitOperationTests<TestModifyRecordsOpera
     }
 }
 
-class ModifySubscriptionsOperationTests: CloudKitOperationTests<TestModifySubscriptionsOperation> {
+class ModifySubscriptionsOperationTests: CloudKitOperationTests {
+
+    var target: TestModifySubscriptionsOperation!
+    var operation: CloudKitOperation<TestModifySubscriptionsOperation>!
+
+    override func setUp() {
+        super.setUp()
+        target = TestModifySubscriptionsOperation()
+        operation = CloudKitOperation(operation: target, reachability: reachability)
+    }
 
     func test__get_subscriptions_to_save() {
         let subscriptions = [ "a-subscription", "another-subscription" ]
@@ -1118,7 +1220,16 @@ class ModifySubscriptionsOperationTests: CloudKitOperationTests<TestModifySubscr
     }
 }
 
-class QueryOperationTests: CloudKitOperationTests<TestQueryOperation> {
+class QueryOperationTests: CloudKitOperationTests {
+
+    var target: TestQueryOperation!
+    var operation: CloudKitOperation<TestQueryOperation>!
+
+    override func setUp() {
+        super.setUp()
+        target = TestQueryOperation()
+        operation = CloudKitOperation(operation: target, reachability: reachability)
+    }
 
     func test__get_query() {
         let query = "a-query"

--- a/Tests/Features/CloudKitOperationTests.swift
+++ b/Tests/Features/CloudKitOperationTests.swift
@@ -10,8 +10,6 @@ import XCTest
 import CloudKit
 @testable import Operations
 
-class CloudKitOperationTests: OperationTests { }
-
 // MARK: Test Operations
 
 class TestCloudOperation: NSOperation, CKOperationType {
@@ -318,21 +316,23 @@ class TestQueryOperation: TestDatabaseOperation, CKQueryOperationType {
 
 
 
-
-
-
 // MARK: - Test Cases
 
-class CloudOperationTests: CloudKitOperationTests {
+class CloudKitOperationTests<Target where Target: NSOperation, Target: CKOperationType>: OperationTests {
 
-    var target: TestCloudOperation!
-    var operation: CloudKitOperation<TestCloudOperation>!
+    var target: Target!
+    var reachability: TestableSystemReachability!
+    var operation: CloudKitOperation<Target>!
 
     override func setUp() {
         super.setUp()
-        target = TestCloudOperation()
-        operation = CloudKitOperation(target)
+        reachability = TestableSystemReachability()
+        target = Target()
+        operation = CloudKitOperation(operation: target, reachability: reachability)
     }
+}
+
+class CloudOperationTests: CloudKitOperationTests<TestCloudOperation> {
 
     func test__get_countainer() {
         let container = "I'm a test container!"
@@ -347,16 +347,7 @@ class CloudOperationTests: CloudKitOperationTests {
     }
 }
 
-class DatabaseOperationTests: CloudKitOperationTests {
-
-    var target: TestDatabaseOperation!
-    var operation: CloudKitOperation<TestDatabaseOperation>!
-
-    override func setUp() {
-        super.setUp()
-        target = TestDatabaseOperation()
-        operation = CloudKitOperation(target)
-    }
+class DatabaseOperationTests: CloudKitOperationTests<TestDatabaseOperation> {
 
     func test__get_database() {
         let db = "I'm a test database!"
@@ -412,16 +403,7 @@ class DatabaseOperationTests: CloudKitOperationTests {
     }
 }
 
-class DiscoverAllContactsOperationTests: CloudKitOperationTests {
-
-    var target: TestDiscoverAllContactsOperation!
-    var operation: CloudKitOperation<TestDiscoverAllContactsOperation>!
-
-    override func setUp() {
-        super.setUp()
-        target = TestDiscoverAllContactsOperation(result: [])
-        operation = CloudKitOperation(target)
-    }
+class DiscoverAllContactsOperationTests: CloudKitOperationTests<TestDiscoverAllContactsOperation> {
 
     func test__execution_after_cancellation() {
         operation.cancel()
@@ -486,16 +468,7 @@ class DiscoverAllContactsOperationTests: CloudKitOperationTests {
     }
 }
 
-class DiscoverUserInfosOperationTests: CloudKitOperationTests {
-
-    var target: TestDiscoverUserInfosOperation!
-    var operation: CloudKitOperation<TestDiscoverUserInfosOperation>!
-
-    override func setUp() {
-        super.setUp()
-        target = TestDiscoverUserInfosOperation(userInfosByEmailAddress: [:], userInfoByRecordID: [:])
-        operation = CloudKitOperation(target)
-    }
+class DiscoverUserInfosOperationTests: CloudKitOperationTests<TestDiscoverUserInfosOperation> {
 
     func test__get_email_addresses() {
         target.emailAddresses = [ "hello@world.com" ]
@@ -560,11 +533,9 @@ class DiscoverUserInfosOperationTests: CloudKitOperationTests {
     }
 }
 
-class FetchNotificationChangesOperationTests: CloudKitOperationTests {
+class FetchNotificationChangesOperationTests: CloudKitOperationTests<TestFetchNotificationChangesOperation> {
 
     var token: TestFetchNotificationChangesOperation.ServerChangeToken!
-    var target: TestFetchNotificationChangesOperation!
-    var operation: CloudKitOperation<TestFetchNotificationChangesOperation>!
 
     override func setUp() {
         super.setUp()
@@ -616,11 +587,9 @@ class FetchNotificationChangesOperationTests: CloudKitOperationTests {
     }
 }
 
-class MarkNotificationsReadOperationTests: CloudKitOperationTests {
+class MarkNotificationsReadOperationTests: CloudKitOperationTests<TestMarkNotificationsReadOperation> {
 
     var toMark: [TestMarkNotificationsReadOperation.NotificationID]!
-    var target: TestMarkNotificationsReadOperation!
-    var operation: CloudKitOperation<TestMarkNotificationsReadOperation>!
 
     override func setUp() {
         super.setUp()
@@ -668,11 +637,9 @@ class MarkNotificationsReadOperationTests: CloudKitOperationTests {
     }
 }
 
-class ModifyBadgeOperationTests: CloudKitOperationTests {
+class ModifyBadgeOperationTests: CloudKitOperationTests<TestModifyBadgeOperation> {
 
     var badge: Int!
-    var target: TestModifyBadgeOperation!
-    var operation: CloudKitOperation<TestModifyBadgeOperation>!
 
     override func setUp() {
         super.setUp()
@@ -720,16 +687,7 @@ class ModifyBadgeOperationTests: CloudKitOperationTests {
     }
 }
 
-class FetchRecordChangesOperationTests: CloudKitOperationTests {
-
-    var target: TestFetchRecordChangesOperation!
-    var operation: CloudKitOperation<TestFetchRecordChangesOperation>!
-
-    override func setUp() {
-        super.setUp()
-        target = TestFetchRecordChangesOperation()
-        operation = CloudKitOperation(target)
-    }
+class FetchRecordChangesOperationTests: CloudKitOperationTests<TestFetchRecordChangesOperation> {
 
     func test__get_record_zone_id() {
         let zoneID = "zone-id"
@@ -792,16 +750,7 @@ class FetchRecordChangesOperationTests: CloudKitOperationTests {
     }
 }
 
-class FetchRecordZonesOperationTests: CloudKitOperationTests {
-
-    var target: TestFetchRecordZonesOperation!
-    var operation: CloudKitOperation<TestFetchRecordZonesOperation>!
-
-    override func setUp() {
-        super.setUp()
-        target = TestFetchRecordZonesOperation()
-        operation = CloudKitOperation(target)
-    }
+class FetchRecordZonesOperationTests: CloudKitOperationTests<TestFetchRecordZonesOperation> {
 
     func test__get_record_zone_ids() {
         let zoneIDs = [ "a-zone-id", "another-zone-id" ]
@@ -844,17 +793,8 @@ class FetchRecordZonesOperationTests: CloudKitOperationTests {
     }
 }
 
-class FetchRecordsOperationTests: CloudKitOperationTests {
+class FetchRecordsOperationTests: CloudKitOperationTests<TestFetchRecordsOperation> {
 
-    var target: TestFetchRecordsOperation!
-    var operation: CloudKitOperation<TestFetchRecordsOperation>!
-
-    override func setUp() {
-        super.setUp()
-        target = TestFetchRecordsOperation()
-        operation = CloudKitOperation(target)
-    }
-    
     func test__get_record_ids() {
         let IDs = [ "an-id", "another-id" ]
         target.recordIDs = IDs
@@ -918,16 +858,7 @@ class FetchRecordsOperationTests: CloudKitOperationTests {
     }
 }
 
-class FetchSubscriptionsOperationTests: CloudKitOperationTests {
-
-    var target: TestFetchSubscriptionsOperation!
-    var operation: CloudKitOperation<TestFetchSubscriptionsOperation>!
-
-    override func setUp() {
-        super.setUp()
-        target = TestFetchSubscriptionsOperation()
-        operation = CloudKitOperation(target)
-    }
+class FetchSubscriptionsOperationTests: CloudKitOperationTests<TestFetchSubscriptionsOperation> {
 
     func test__get_subscription_ids() {
         let IDs = [ "an-id", "another-id" ]
@@ -970,16 +901,7 @@ class FetchSubscriptionsOperationTests: CloudKitOperationTests {
     }
 }
 
-class ModifyRecordZonesOperationTests: CloudKitOperationTests {
-
-    var target: TestModifyRecordZonesOperation!
-    var operation: CloudKitOperation<TestModifyRecordZonesOperation>!
-
-    override func setUp() {
-        super.setUp()
-        target = TestModifyRecordZonesOperation()
-        operation = CloudKitOperation(target)
-    }
+class ModifyRecordZonesOperationTests: CloudKitOperationTests<TestModifyRecordZonesOperation> {
 
     func test__get_zones_to_save() {
         let zones = [ "a-zone", "another-zone" ]
@@ -1034,17 +956,8 @@ class ModifyRecordZonesOperationTests: CloudKitOperationTests {
     }
 }
 
-class ModifyRecordsOperationTests: CloudKitOperationTests {
+class ModifyRecordsOperationTests: CloudKitOperationTests<TestModifyRecordsOperation> {
 
-    var target: TestModifyRecordsOperation!
-    var operation: CloudKitOperation<TestModifyRecordsOperation>!
-
-    override func setUp() {
-        super.setUp()
-        target = TestModifyRecordsOperation()
-        operation = CloudKitOperation(target)
-    }
-    
     func test__get_records_to_save() {
         let records = [ "a-record", "another-record" ]
         target.recordsToSave = records
@@ -1150,17 +1063,8 @@ class ModifyRecordsOperationTests: CloudKitOperationTests {
     }
 }
 
-class ModifySubscriptionsOperationTests: CloudKitOperationTests {
+class ModifySubscriptionsOperationTests: CloudKitOperationTests<TestModifySubscriptionsOperation> {
 
-    var target: TestModifySubscriptionsOperation!
-    var operation: CloudKitOperation<TestModifySubscriptionsOperation>!
-
-    override func setUp() {
-        super.setUp()
-        target = TestModifySubscriptionsOperation()
-        operation = CloudKitOperation(target)
-    }
-    
     func test__get_subscriptions_to_save() {
         let subscriptions = [ "a-subscription", "another-subscription" ]
         target.subscriptionsToSave = subscriptions
@@ -1214,17 +1118,8 @@ class ModifySubscriptionsOperationTests: CloudKitOperationTests {
     }
 }
 
-class QueryOperationTests: CloudKitOperationTests {
+class QueryOperationTests: CloudKitOperationTests<TestQueryOperation> {
 
-    var target: TestQueryOperation!
-    var operation: CloudKitOperation<TestQueryOperation>!
-
-    override func setUp() {
-        super.setUp()
-        target = TestQueryOperation()
-        operation = CloudKitOperation(target)
-    }
-    
     func test__get_query() {
         let query = "a-query"
         target.query = query

--- a/Tests/Features/CloudKitOperationTests.swift
+++ b/Tests/Features/CloudKitOperationTests.swift
@@ -337,7 +337,7 @@ class CloudOperationTests: CloudKitOperationTests {
     override func setUp() {
         super.setUp()
         target = TestCloudOperation()
-        operation = CloudKitOperation(operation: target, reachability: reachability)
+        operation = CloudKitOperation(target, reachability: reachability)
     }
 
     func test__get_countainer() {
@@ -361,7 +361,7 @@ class DatabaseOperationTests: CloudKitOperationTests {
     override func setUp() {
         super.setUp()
         target = TestDatabaseOperation()
-        operation = CloudKitOperation(operation: target, reachability: reachability)
+        operation = CloudKitOperation(target, reachability: reachability)
     }
 
     func test__get_database() {
@@ -426,7 +426,7 @@ class DiscoverAllContactsOperationTests: CloudKitOperationTests {
     override func setUp() {
         super.setUp()
         target = TestDiscoverAllContactsOperation(result: [])
-        operation = CloudKitOperation(operation: target, reachability: reachability)
+        operation = CloudKitOperation(target, reachability: reachability)
     }
 
     func test__execution_after_cancellation() {
@@ -500,7 +500,7 @@ class DiscoverUserInfosOperationTests: CloudKitOperationTests {
     override func setUp() {
         super.setUp()
         target = TestDiscoverUserInfosOperation(userInfosByEmailAddress: [:], userInfoByRecordID: [:])
-        operation = CloudKitOperation(operation: target, reachability: reachability)
+        operation = CloudKitOperation(target, reachability: reachability)
     }
 
     func test__get_email_addresses() {
@@ -576,7 +576,7 @@ class FetchNotificationChangesOperationTests: CloudKitOperationTests {
         super.setUp()
         token = "i'm a server token"
         target = TestFetchNotificationChangesOperation(token: token)
-        operation = CloudKitOperation(operation: target, reachability: reachability)
+        operation = CloudKitOperation(target, reachability: reachability)
     }
 
     func test__get_set_notification_charged_block() {
@@ -632,7 +632,7 @@ class MarkNotificationsReadOperationTests: CloudKitOperationTests {
         super.setUp()
         toMark = [ "this-is-an-id", "this-is-another-id" ]
         target = TestMarkNotificationsReadOperation(markIDsToRead: toMark)
-        operation = CloudKitOperation(operation: target, reachability: reachability)
+        operation = CloudKitOperation(target, reachability: reachability)
     }
 
     func test__get_notification_id() {
@@ -684,7 +684,7 @@ class ModifyBadgeOperationTests: CloudKitOperationTests {
         super.setUp()
         badge = 9
         target = TestModifyBadgeOperation(value: badge)
-        operation = CloudKitOperation(operation: target, reachability: reachability)
+        operation = CloudKitOperation(target, reachability: reachability)
     }
 
     func test__get_badge_value() {
@@ -734,7 +734,7 @@ class FetchRecordChangesOperationTests: CloudKitOperationTests {
     override func setUp() {
         super.setUp()
         target = TestFetchRecordChangesOperation()
-        operation = CloudKitOperation(operation: target, reachability: reachability)
+        operation = CloudKitOperation(target, reachability: reachability)
     }
 
     func test__get_record_zone_id() {
@@ -806,7 +806,7 @@ class FetchRecordZonesOperationTests: CloudKitOperationTests {
     override func setUp() {
         super.setUp()
         target = TestFetchRecordZonesOperation()
-        operation = CloudKitOperation(operation: target, reachability: reachability)
+        operation = CloudKitOperation(target, reachability: reachability)
     }
 
     func test__get_record_zone_ids() {
@@ -858,7 +858,7 @@ class FetchRecordsOperationTests: CloudKitOperationTests {
     override func setUp() {
         super.setUp()
         target = TestFetchRecordsOperation()
-        operation = CloudKitOperation(operation: target, reachability: reachability)
+        operation = CloudKitOperation(target, reachability: reachability)
     }
 
     func test__get_record_ids() {
@@ -932,7 +932,7 @@ class FetchSubscriptionsOperationTests: CloudKitOperationTests {
     override func setUp() {
         super.setUp()
         target = TestFetchSubscriptionsOperation()
-        operation = CloudKitOperation(operation: target, reachability: reachability)
+        operation = CloudKitOperation(target, reachability: reachability)
     }
 
     func test__get_subscription_ids() {
@@ -984,7 +984,7 @@ class ModifyRecordZonesOperationTests: CloudKitOperationTests {
     override func setUp() {
         super.setUp()
         target = TestModifyRecordZonesOperation()
-        operation = CloudKitOperation(operation: target, reachability: reachability)
+        operation = CloudKitOperation(target, reachability: reachability)
     }
 
     func test__get_zones_to_save() {
@@ -1048,7 +1048,7 @@ class ModifyRecordsOperationTests: CloudKitOperationTests {
     override func setUp() {
         super.setUp()
         target = TestModifyRecordsOperation()
-        operation = CloudKitOperation(operation: target, reachability: reachability)
+        operation = CloudKitOperation(target, reachability: reachability)
     }
 
     func test__get_records_to_save() {
@@ -1164,7 +1164,7 @@ class ModifySubscriptionsOperationTests: CloudKitOperationTests {
     override func setUp() {
         super.setUp()
         target = TestModifySubscriptionsOperation()
-        operation = CloudKitOperation(operation: target, reachability: reachability)
+        operation = CloudKitOperation(target, reachability: reachability)
     }
 
     func test__get_subscriptions_to_save() {
@@ -1228,7 +1228,7 @@ class QueryOperationTests: CloudKitOperationTests {
     override func setUp() {
         super.setUp()
         target = TestQueryOperation()
-        operation = CloudKitOperation(operation: target, reachability: reachability)
+        operation = CloudKitOperation(target, reachability: reachability)
     }
 
     func test__get_query() {

--- a/Tests/Features/CloudKitOperationTests.swift
+++ b/Tests/Features/CloudKitOperationTests.swift
@@ -337,7 +337,7 @@ class CloudOperationTests: CloudKitOperationTests {
     override func setUp() {
         super.setUp()
         target = TestCloudOperation()
-        operation = CloudKitOperation(target, reachability: reachability)
+        operation = CloudKitOperation(reachability: reachability, operation: self.target)
     }
 
     func test__get_countainer() {
@@ -361,7 +361,7 @@ class DatabaseOperationTests: CloudKitOperationTests {
     override func setUp() {
         super.setUp()
         target = TestDatabaseOperation()
-        operation = CloudKitOperation(target, reachability: reachability)
+        operation = CloudKitOperation(reachability: reachability, operation: self.target)
     }
 
     func test__get_database() {
@@ -426,7 +426,7 @@ class DiscoverAllContactsOperationTests: CloudKitOperationTests {
     override func setUp() {
         super.setUp()
         target = TestDiscoverAllContactsOperation(result: [])
-        operation = CloudKitOperation(target, reachability: reachability)
+        operation = CloudKitOperation(reachability: reachability, operation: self.target)
     }
 
     func test__execution_after_cancellation() {
@@ -500,7 +500,7 @@ class DiscoverUserInfosOperationTests: CloudKitOperationTests {
     override func setUp() {
         super.setUp()
         target = TestDiscoverUserInfosOperation(userInfosByEmailAddress: [:], userInfoByRecordID: [:])
-        operation = CloudKitOperation(target, reachability: reachability)
+        operation = CloudKitOperation(reachability: reachability, operation: self.target)
     }
 
     func test__get_email_addresses() {
@@ -576,7 +576,7 @@ class FetchNotificationChangesOperationTests: CloudKitOperationTests {
         super.setUp()
         token = "i'm a server token"
         target = TestFetchNotificationChangesOperation(token: token)
-        operation = CloudKitOperation(target, reachability: reachability)
+        operation = CloudKitOperation(reachability: reachability, operation: self.target)
     }
 
     func test__get_set_notification_charged_block() {
@@ -632,7 +632,7 @@ class MarkNotificationsReadOperationTests: CloudKitOperationTests {
         super.setUp()
         toMark = [ "this-is-an-id", "this-is-another-id" ]
         target = TestMarkNotificationsReadOperation(markIDsToRead: toMark)
-        operation = CloudKitOperation(target, reachability: reachability)
+        operation = CloudKitOperation(reachability: reachability, operation: self.target)
     }
 
     func test__get_notification_id() {
@@ -684,7 +684,7 @@ class ModifyBadgeOperationTests: CloudKitOperationTests {
         super.setUp()
         badge = 9
         target = TestModifyBadgeOperation(value: badge)
-        operation = CloudKitOperation(target, reachability: reachability)
+        operation = CloudKitOperation(reachability: reachability, operation: self.target)
     }
 
     func test__get_badge_value() {
@@ -734,7 +734,7 @@ class FetchRecordChangesOperationTests: CloudKitOperationTests {
     override func setUp() {
         super.setUp()
         target = TestFetchRecordChangesOperation()
-        operation = CloudKitOperation(target, reachability: reachability)
+        operation = CloudKitOperation(reachability: reachability, operation: self.target)
     }
 
     func test__get_record_zone_id() {
@@ -806,7 +806,7 @@ class FetchRecordZonesOperationTests: CloudKitOperationTests {
     override func setUp() {
         super.setUp()
         target = TestFetchRecordZonesOperation()
-        operation = CloudKitOperation(target, reachability: reachability)
+        operation = CloudKitOperation(reachability: reachability, operation: self.target)
     }
 
     func test__get_record_zone_ids() {
@@ -858,7 +858,7 @@ class FetchRecordsOperationTests: CloudKitOperationTests {
     override func setUp() {
         super.setUp()
         target = TestFetchRecordsOperation()
-        operation = CloudKitOperation(target, reachability: reachability)
+        operation = CloudKitOperation(reachability: reachability, operation: self.target)
     }
 
     func test__get_record_ids() {
@@ -932,7 +932,7 @@ class FetchSubscriptionsOperationTests: CloudKitOperationTests {
     override func setUp() {
         super.setUp()
         target = TestFetchSubscriptionsOperation()
-        operation = CloudKitOperation(target, reachability: reachability)
+        operation = CloudKitOperation(reachability: reachability, operation: self.target)
     }
 
     func test__get_subscription_ids() {
@@ -984,7 +984,7 @@ class ModifyRecordZonesOperationTests: CloudKitOperationTests {
     override func setUp() {
         super.setUp()
         target = TestModifyRecordZonesOperation()
-        operation = CloudKitOperation(target, reachability: reachability)
+        operation = CloudKitOperation(reachability: reachability, operation: self.target)
     }
 
     func test__get_zones_to_save() {
@@ -1048,7 +1048,7 @@ class ModifyRecordsOperationTests: CloudKitOperationTests {
     override func setUp() {
         super.setUp()
         target = TestModifyRecordsOperation()
-        operation = CloudKitOperation(target, reachability: reachability)
+        operation = CloudKitOperation(reachability: reachability, operation: self.target)
     }
 
     func test__get_records_to_save() {
@@ -1164,7 +1164,7 @@ class ModifySubscriptionsOperationTests: CloudKitOperationTests {
     override func setUp() {
         super.setUp()
         target = TestModifySubscriptionsOperation()
-        operation = CloudKitOperation(target, reachability: reachability)
+        operation = CloudKitOperation(reachability: reachability, operation: self.target)
     }
 
     func test__get_subscriptions_to_save() {
@@ -1228,7 +1228,7 @@ class QueryOperationTests: CloudKitOperationTests {
     override func setUp() {
         super.setUp()
         target = TestQueryOperation()
-        operation = CloudKitOperation(target, reachability: reachability)
+        operation = CloudKitOperation(reachability: reachability, operation: self.target)
     }
 
     func test__get_query() {

--- a/Tests/Features/CloudKitOperationTests.swift
+++ b/Tests/Features/CloudKitOperationTests.swift
@@ -337,7 +337,7 @@ class CloudOperationTests: CloudKitOperationTests {
     override func setUp() {
         super.setUp()
         target = TestCloudOperation()
-        operation = CloudKitOperation(reachability: reachability, operation: self.target)
+        operation = CloudKitOperation(operation: target, reachability: reachability)
     }
 
     func test__get_countainer() {
@@ -361,7 +361,7 @@ class DatabaseOperationTests: CloudKitOperationTests {
     override func setUp() {
         super.setUp()
         target = TestDatabaseOperation()
-        operation = CloudKitOperation(reachability: reachability, operation: self.target)
+        operation = CloudKitOperation(operation: target, reachability: reachability)
     }
 
     func test__get_database() {
@@ -426,7 +426,7 @@ class DiscoverAllContactsOperationTests: CloudKitOperationTests {
     override func setUp() {
         super.setUp()
         target = TestDiscoverAllContactsOperation(result: [])
-        operation = CloudKitOperation(reachability: reachability, operation: self.target)
+        operation = CloudKitOperation(operation: target, reachability: reachability)
     }
 
     func test__execution_after_cancellation() {
@@ -500,7 +500,7 @@ class DiscoverUserInfosOperationTests: CloudKitOperationTests {
     override func setUp() {
         super.setUp()
         target = TestDiscoverUserInfosOperation(userInfosByEmailAddress: [:], userInfoByRecordID: [:])
-        operation = CloudKitOperation(reachability: reachability, operation: self.target)
+        operation = CloudKitOperation(operation: target, reachability: reachability)
     }
 
     func test__get_email_addresses() {
@@ -576,10 +576,10 @@ class FetchNotificationChangesOperationTests: CloudKitOperationTests {
         super.setUp()
         token = "i'm a server token"
         target = TestFetchNotificationChangesOperation(token: token)
-        operation = CloudKitOperation(reachability: reachability, operation: self.target)
+        operation = CloudKitOperation(operation: target, reachability: reachability)
     }
 
-    func test__get_set_notification_charged_block() {
+    func test__get_set_notification_changed_block() {
 
         var didItWork = false
         operation.notificationChangedBlock = { _ in
@@ -620,6 +620,10 @@ class FetchNotificationChangesOperationTests: CloudKitOperationTests {
         XCTAssertTrue(operation.finished)
         XCTAssertEqual(operation.errors.count, 1)
     }
+
+    func test__batch_operation() {
+
+    }
 }
 
 class MarkNotificationsReadOperationTests: CloudKitOperationTests {
@@ -632,7 +636,7 @@ class MarkNotificationsReadOperationTests: CloudKitOperationTests {
         super.setUp()
         toMark = [ "this-is-an-id", "this-is-another-id" ]
         target = TestMarkNotificationsReadOperation(markIDsToRead: toMark)
-        operation = CloudKitOperation(reachability: reachability, operation: self.target)
+        operation = CloudKitOperation(operation: target, reachability: reachability)
     }
 
     func test__get_notification_id() {
@@ -684,7 +688,7 @@ class ModifyBadgeOperationTests: CloudKitOperationTests {
         super.setUp()
         badge = 9
         target = TestModifyBadgeOperation(value: badge)
-        operation = CloudKitOperation(reachability: reachability, operation: self.target)
+        operation = CloudKitOperation(operation: target, reachability: reachability)
     }
 
     func test__get_badge_value() {
@@ -734,7 +738,7 @@ class FetchRecordChangesOperationTests: CloudKitOperationTests {
     override func setUp() {
         super.setUp()
         target = TestFetchRecordChangesOperation()
-        operation = CloudKitOperation(reachability: reachability, operation: self.target)
+        operation = CloudKitOperation(operation: target, reachability: reachability)
     }
 
     func test__get_record_zone_id() {
@@ -806,7 +810,7 @@ class FetchRecordZonesOperationTests: CloudKitOperationTests {
     override func setUp() {
         super.setUp()
         target = TestFetchRecordZonesOperation()
-        operation = CloudKitOperation(reachability: reachability, operation: self.target)
+        operation = CloudKitOperation(operation: target, reachability: reachability)
     }
 
     func test__get_record_zone_ids() {
@@ -858,7 +862,7 @@ class FetchRecordsOperationTests: CloudKitOperationTests {
     override func setUp() {
         super.setUp()
         target = TestFetchRecordsOperation()
-        operation = CloudKitOperation(reachability: reachability, operation: self.target)
+        operation = CloudKitOperation(operation: target, reachability: reachability)
     }
 
     func test__get_record_ids() {
@@ -932,7 +936,7 @@ class FetchSubscriptionsOperationTests: CloudKitOperationTests {
     override func setUp() {
         super.setUp()
         target = TestFetchSubscriptionsOperation()
-        operation = CloudKitOperation(reachability: reachability, operation: self.target)
+        operation = CloudKitOperation(operation: target, reachability: reachability)
     }
 
     func test__get_subscription_ids() {
@@ -984,7 +988,7 @@ class ModifyRecordZonesOperationTests: CloudKitOperationTests {
     override func setUp() {
         super.setUp()
         target = TestModifyRecordZonesOperation()
-        operation = CloudKitOperation(reachability: reachability, operation: self.target)
+        operation = CloudKitOperation(operation: target, reachability: reachability)
     }
 
     func test__get_zones_to_save() {
@@ -1048,7 +1052,7 @@ class ModifyRecordsOperationTests: CloudKitOperationTests {
     override func setUp() {
         super.setUp()
         target = TestModifyRecordsOperation()
-        operation = CloudKitOperation(reachability: reachability, operation: self.target)
+        operation = CloudKitOperation(operation: target, reachability: reachability)
     }
 
     func test__get_records_to_save() {
@@ -1164,7 +1168,7 @@ class ModifySubscriptionsOperationTests: CloudKitOperationTests {
     override func setUp() {
         super.setUp()
         target = TestModifySubscriptionsOperation()
-        operation = CloudKitOperation(reachability: reachability, operation: self.target)
+        operation = CloudKitOperation(operation: target, reachability: reachability)
     }
 
     func test__get_subscriptions_to_save() {
@@ -1228,7 +1232,7 @@ class QueryOperationTests: CloudKitOperationTests {
     override func setUp() {
         super.setUp()
         target = TestQueryOperation()
-        operation = CloudKitOperation(reachability: reachability, operation: self.target)
+        operation = CloudKitOperation(operation: target, reachability: reachability)
     }
 
     func test__get_query() {

--- a/Tests/Features/ReachableOperationTests.swift
+++ b/Tests/Features/ReachableOperationTests.swift
@@ -50,7 +50,7 @@ class ReachableOperationTests: OperationTests {
     override func setUp() {
         super.setUp()
         reachability = TestableSystemReachability()
-        operation = ReachableOperation(reachability: reachability, operation: TestOperation())
+        operation = ReachableOperation(operation: TestOperation(), reachability: reachability)
     }
 
     func test__operation_executes_when_network_is_available() {
@@ -82,14 +82,14 @@ class ReachableOperationTests: OperationTests {
     }
 
     func test__via_wwan_connectivity() {
-        operation = ReachableOperation(connectivity: .ViaWWAN, reachability: reachability, operation: TestOperation())
+        operation = ReachableOperation(operation: TestOperation(), connectivity: .ViaWWAN, reachability: reachability)
         XCTAssertFalse(operation.checkStatus(.NotReachable))
         XCTAssertTrue(operation.checkStatus(.Reachable(.ViaWWAN)))
         XCTAssertTrue(operation.checkStatus(.Reachable(.ViaWiFi)))
     }
 
     func test__via_wifi_connectivity() {
-        operation = ReachableOperation(connectivity: .ViaWiFi, reachability: reachability, operation: TestOperation())
+        operation = ReachableOperation(operation: TestOperation(), connectivity: .ViaWiFi, reachability: reachability)
         XCTAssertFalse(operation.checkStatus(.NotReachable))
         XCTAssertFalse(operation.checkStatus(.Reachable(.ViaWWAN)))
         XCTAssertTrue(operation.checkStatus(.Reachable(.ViaWiFi)))

--- a/Tests/Features/ReachableOperationTests.swift
+++ b/Tests/Features/ReachableOperationTests.swift
@@ -50,7 +50,7 @@ class ReachableOperationTests: OperationTests {
     override func setUp() {
         super.setUp()
         reachability = TestableSystemReachability()
-        operation = ReachableOperation(operation: TestOperation(), reachability: reachability)
+        operation = ReachableOperation(reachability: reachability, operation: TestOperation())
     }
 
     func test__operation_executes_when_network_is_available() {
@@ -82,14 +82,14 @@ class ReachableOperationTests: OperationTests {
     }
 
     func test__via_wwan_connectivity() {
-        operation = ReachableOperation(operation: TestOperation(), connectivity: .ViaWWAN, reachability: reachability)
+        operation = ReachableOperation(connectivity: .ViaWWAN, reachability: reachability, operation: TestOperation())
         XCTAssertFalse(operation.checkStatus(.NotReachable))
         XCTAssertTrue(operation.checkStatus(.Reachable(.ViaWWAN)))
         XCTAssertTrue(operation.checkStatus(.Reachable(.ViaWiFi)))
     }
 
     func test__via_wifi_connectivity() {
-        operation = ReachableOperation(operation: TestOperation(), connectivity: .ViaWiFi, reachability: reachability)
+        operation = ReachableOperation(connectivity: .ViaWiFi, reachability: reachability, operation: TestOperation())
         XCTAssertFalse(operation.checkStatus(.NotReachable))
         XCTAssertFalse(operation.checkStatus(.Reachable(.ViaWWAN)))
         XCTAssertTrue(operation.checkStatus(.Reachable(.ViaWiFi)))


### PR DESCRIPTION
### Phase Three

- [x] Refactor `ReachableOperation`

Refactor `ReachableOperation`, to subclass `ComposedOperation`, and then `CloudKitOperation` should subclass `ReachableOperation`.

Given this, the `ReachableOperation` will manage errors/executing the operation when the app is online.

Execution inside of a `RetryOperation` will support errors/executing the operation in the face of errors from CloudKit. Which leaves `CloudKitOperation` to support the configuration of the underlying target operation.

### Capabilities - `AuthorizedFor` condition.

It seems a bit silly that consumers should be adding an `AutorizedFor(Capability.Cloud())` condition to their `CloudKitOperation` instances. Instead, it might make sense to support initializing `CloudKitOperation` with permissions (with a default) and a container id (with a default). This way, we can automatically add a condition.

- ~~[ ] Automatically add condition for authorized access to the container.~~
- ~~[ ] Automatically manage authorized condition when subsequently setting the container.~~

**Not easily possible** without introducing another generic type, as `Capability.Cloud` cannot be created in a unit test environment. Might be able to eventually do with with some re-factoring of the `_CloudCapability`.

### Greedy Batch Processing

There are some `CKOperation` types which have the concept of "more coming" with "result limits". This means that the operation can be configured to reduce the amount of processing that must be done any any single operation instance. This can the useful to mitigate the risk of data taking longer to get to the device and then consequently either not being an accurate representation any more, or bogging down the network. So, setting a reasonable batch size (`resultsLimit`) and then re-requesting if there are more results is a sensible approach.

The framework should have automatic support for this - essentially repeating itself until `moreComing` is false.

- [x] Greedy Batch Processing
    - [x] `CKFetchNotificationChangesOperation`
    - [x] `CKFetchRecordChangesOperation `

