### PR TITLE
Add UIOperation finishing to AlertOperation action callback

### DIFF
--- a/Sources/Core/Shared/Operation.swift
+++ b/Sources/Core/Shared/Operation.swift
@@ -478,6 +478,7 @@ public class Operation: NSOperation {
     - parameter operation: a `NSOperation` instance.
     */
     public final func produceOperation(operation: NSOperation) {
+        precondition(state > .Initialized, "Cannot produce operation while not being scheduled on a queue.")
         log.verbose("Did produce \(operation.operationName)")
         didProduceOperationObservers.forEach { $0.operation(self, didProduceOperation: operation) }
     }

--- a/Sources/Core/iOS/AlertOperation.swift
+++ b/Sources/Core/iOS/AlertOperation.swift
@@ -89,6 +89,7 @@ public class AlertOperation<From: PresentingViewController>: Operation {
             if let weakSelf = self {
                 handler(weakSelf)
             }
+            self?.ui.finish()
             self?.finish()
         }
         alert.addAction(action)


### PR DESCRIPTION
The UIOperation inside the AlertOperation doesn't finish. This causes two bugs: 1) The group operation which contains an AlertOperation is never finished 2) The UIOperation never releases the PresentingViewController