### PR TITLE
UIOperation does not finish

### DIFF
--- a/Sources/Core/iOS/UIOperation.swift
+++ b/Sources/Core/iOS/UIOperation.swift
@@ -129,7 +129,6 @@ public class UIOperation<C, From where C: UIViewController, From: PresentingView
 
     /// The `AnyObject` sender.
     public let sender: AnyObject?
-    let completion: (() -> Void)?
 
     /**
     Construct a `UIOperation` with the presented view controller, the presenting view controller display 
@@ -145,11 +144,11 @@ public class UIOperation<C, From where C: UIViewController, From: PresentingView
     - parameter sender: an optional `AnyObject` see docs for UIViewController.
     - parameter completion: an optional void block, see docs for UIViewController.
     */
-    public init(controller: C, displayControllerFrom from: ViewControllerDisplayStyle<From>, sender: AnyObject? = .None, completion: (() -> Void)? = .None) {
+    public init(controller: C, displayControllerFrom from: ViewControllerDisplayStyle<From>, sender: AnyObject? = .None) {
         self.controller = controller
         self.from = from
         self.sender = sender
-        self.completion = completion
+        super.init()
     }
 
     /**
@@ -159,7 +158,9 @@ public class UIOperation<C, From where C: UIViewController, From: PresentingView
     */
     public override func execute() {
         dispatch_async(Queue.Main.queue) {
-            self.from.displayController(self.controller, sender: self.sender, completion: self.completion)
+            self.from.displayController(self.controller, sender: self.sender) {
+                self.finish()
+            }
         }
     }
 }

--- a/Sources/Features/iOS/WebpageOperation.swift
+++ b/Sources/Features/iOS/WebpageOperation.swift
@@ -20,8 +20,8 @@ public class WebpageOperation<From: PresentingViewController>: Operation, SFSafa
 
     let operation: UIOperation<SFSafariViewController, From>
 
-    public init(url: NSURL, displayControllerFrom from: ViewControllerDisplayStyle<From>, sender: AnyObject? = .None, completion: (() -> Void)? = .None) {
-        operation = UIOperation(controller: SFSafariViewController(URL: url, entersReaderIfAvailable: true), displayControllerFrom: from, sender: sender, completion: completion)
+    public init(url: NSURL, displayControllerFrom from: ViewControllerDisplayStyle<From>, sender: AnyObject? = .None) {
+        operation = UIOperation(controller: SFSafariViewController(URL: url, entersReaderIfAvailable: true), displayControllerFrom: from, sender: sender)
         super.init()
         addCondition(MutuallyExclusive<UIViewController>())
     }

--- a/Tests/Core/UIOperationTests.swift
+++ b/Tests/Core/UIOperationTests.swift
@@ -131,7 +131,8 @@ class UIOperationTests: OperationTests {
         let expectation = expectationWithDescription("Test: \(__FUNCTION__)")
 
         var completionBlockDidRun = false
-        operation = TypeUnderTest(controller: presented, displayControllerFrom: .Present(presenter), sender: .None) {
+        operation = TypeUnderTest(controller: presented, displayControllerFrom: .Present(presenter), sender: .None)
+        operation.addCompletionBlock {
             completionBlockDidRun = true
             expectation.fulfill()
         }


### PR DESCRIPTION
`UIOperation` does not actually finish after it does the presentation. But it does accept a completion block. This is all a bit strange. There is no need for a completion block, and instead, it should just `finish()`.