### PR TITLE
Adding precondition to produceOperation method

### DIFF
--- a/Sources/Core/Shared/Operation.swift
+++ b/Sources/Core/Shared/Operation.swift
@@ -478,6 +478,7 @@ public class Operation: NSOperation {
     - parameter operation: a `NSOperation` instance.
     */
     public final func produceOperation(operation: NSOperation) {
+        precondition(state > .Initialized, "Cannot produce operation while not being scheduled on a queue.")
         log.verbose("Did produce \(operation.operationName)")
         didProduceOperationObservers.forEach { $0.operation(self, didProduceOperation: operation) }
     }


### PR DESCRIPTION
Calling produceOperation without being on a OperationQueue will silently fail. If you try to use produceOperation in an operation initializer this situation might happen.