### PR TITLE
Investigating bug/crash in GroupOperation #181

### DIFF
--- a/Operations.xcodeproj/project.pbxproj
+++ b/Operations.xcodeproj/project.pbxproj
@@ -235,6 +235,10 @@
 		65AE14971C34865E00F592D2 /* RetryOperationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65AE14961C34865E00F592D2 /* RetryOperationTests.swift */; };
 		65AE14981C34865E00F592D2 /* RetryOperationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65AE14961C34865E00F592D2 /* RetryOperationTests.swift */; };
 		65AE14991C34865E00F592D2 /* RetryOperationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65AE14961C34865E00F592D2 /* RetryOperationTests.swift */; };
+		65BB56D71C70F29500DF5211 /* ThreadSafety.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65BB56D61C70F29500DF5211 /* ThreadSafety.swift */; };
+		65BB56D81C70F29500DF5211 /* ThreadSafety.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65BB56D61C70F29500DF5211 /* ThreadSafety.swift */; };
+		65BB56D91C70F29500DF5211 /* ThreadSafety.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65BB56D61C70F29500DF5211 /* ThreadSafety.swift */; };
+		65BB56DA1C70F29500DF5211 /* ThreadSafety.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65BB56D61C70F29500DF5211 /* ThreadSafety.swift */; };
 		65C98C721C281EEC00BA76B7 /* FunctionalOperations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65C98C711C281EEC00BA76B7 /* FunctionalOperations.swift */; };
 		65C98C731C281EEC00BA76B7 /* FunctionalOperations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65C98C711C281EEC00BA76B7 /* FunctionalOperations.swift */; };
 		65C98C741C281EEC00BA76B7 /* FunctionalOperations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65C98C711C281EEC00BA76B7 /* FunctionalOperations.swift */; };
@@ -382,6 +386,7 @@
 		65A6BA7B1C220F09003A375D /* HealthCapability.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HealthCapability.swift; sourceTree = "<group>"; };
 		65A6BA7E1C220FBD003A375D /* HealthCapabilityTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HealthCapabilityTests.swift; sourceTree = "<group>"; };
 		65AE14961C34865E00F592D2 /* RetryOperationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RetryOperationTests.swift; sourceTree = "<group>"; };
+		65BB56D61C70F29500DF5211 /* ThreadSafety.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ThreadSafety.swift; sourceTree = "<group>"; };
 		65C98C711C281EEC00BA76B7 /* FunctionalOperations.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FunctionalOperations.swift; sourceTree = "<group>"; };
 		65C98C761C284EA600BA76B7 /* FunctionalOperationsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FunctionalOperationsTests.swift; sourceTree = "<group>"; };
 		65E4CDDC1C33422100B9F9D8 /* RetryOperation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RetryOperation.swift; sourceTree = "<group>"; };
@@ -512,6 +517,7 @@
 				65E4CDDC1C33422100B9F9D8 /* RetryOperation.swift */,
 				652616DF1C11F5EB00654091 /* SlientCondition.swift */,
 				652616E01C11F5EB00654091 /* Support.swift */,
+				65BB56D61C70F29500DF5211 /* ThreadSafety.swift */,
 				652616E11C11F5EB00654091 /* TimeoutObserver.swift */,
 			);
 			path = Shared;
@@ -1035,6 +1041,7 @@
 			files = (
 				652618701C11F8FC00654091 /* SlientCondition.swift in Sources */,
 				652618F61C11F9AA00654091 /* WebpageOperation.swift in Sources */,
+				65BB56D71C70F29500DF5211 /* ThreadSafety.swift in Sources */,
 				6526186F1C11F8FC00654091 /* OperationQueue.swift in Sources */,
 				652618B21C11F91200654091 /* CloudKitOperation.swift in Sources */,
 				652618DD1C11F98000654091 /* ContactsOperation.swift in Sources */,
@@ -1165,6 +1172,7 @@
 				652618731C11F8FD00654091 /* BlockCondition.swift in Sources */,
 				6526187B1C11F8FD00654091 /* Logging.swift in Sources */,
 				652618741C11F8FD00654091 /* BlockObserver.swift in Sources */,
+				65BB56D81C70F29500DF5211 /* ThreadSafety.swift in Sources */,
 				652618811C11F8FD00654091 /* OperationCondition.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1182,6 +1190,7 @@
 				652618991C11F8FE00654091 /* Support.swift in Sources */,
 				652618C51C11F91400654091 /* ReachabilityCondition.swift in Sources */,
 				652618D71C11F93F00654091 /* AlertOperation.swift in Sources */,
+				65BB56D91C70F29500DF5211 /* ThreadSafety.swift in Sources */,
 				652618891C11F8FE00654091 /* BlockOperation.swift in Sources */,
 				6526188A1C11F8FE00654091 /* ComposedOperation.swift in Sources */,
 				6526189A1C11F8FE00654091 /* TimeoutObserver.swift in Sources */,
@@ -1258,6 +1267,7 @@
 				652618AD1C11F8FF00654091 /* Support.swift in Sources */,
 				652618CD1C11F91500654091 /* ReachabilityCondition.swift in Sources */,
 				6526189D1C11F8FF00654091 /* BlockOperation.swift in Sources */,
+				65BB56DA1C70F29500DF5211 /* ThreadSafety.swift in Sources */,
 				6526189E1C11F8FF00654091 /* ComposedOperation.swift in Sources */,
 				652618C71C11F91500654091 /* CalendarCapability.swift in Sources */,
 				652618AE1C11F8FF00654091 /* TimeoutObserver.swift in Sources */,

--- a/Operations_ExtensionCompatible.xcodeproj/project.pbxproj
+++ b/Operations_ExtensionCompatible.xcodeproj/project.pbxproj
@@ -210,6 +210,9 @@
 		6584D25F1C6BF93900306EED /* RetryOperationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6584D24D1C6BF90E00306EED /* RetryOperationTests.swift */; };
 		6584D2601C6BF93A00306EED /* ResultInjectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6584D24C1C6BF90E00306EED /* ResultInjectionTests.swift */; };
 		6584D2611C6BF93A00306EED /* RetryOperationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6584D24D1C6BF90E00306EED /* RetryOperationTests.swift */; };
+		65BB56DC1C70FAB100DF5211 /* ThreadSafety.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65BB56DB1C70FAB100DF5211 /* ThreadSafety.swift */; };
+		65BB56DD1C70FAB700DF5211 /* ThreadSafety.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65BB56DB1C70FAB100DF5211 /* ThreadSafety.swift */; };
+		65BB56DE1C70FAB800DF5211 /* ThreadSafety.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65BB56DB1C70FAB100DF5211 /* ThreadSafety.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -340,6 +343,7 @@
 		6584D24C1C6BF90E00306EED /* ResultInjectionTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ResultInjectionTests.swift; sourceTree = "<group>"; };
 		6584D24D1C6BF90E00306EED /* RetryOperationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RetryOperationTests.swift; sourceTree = "<group>"; };
 		6584D2631C6BF95700306EED /* HealthCapabilityTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HealthCapabilityTests.swift; sourceTree = "<group>"; };
+		65BB56DB1C70FAB100DF5211 /* ThreadSafety.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ThreadSafety.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -465,6 +469,7 @@
 				6584D2371C6BF86200306EED /* RetryOperation.swift */,
 				6526174B1C11F61700654091 /* SlientCondition.swift */,
 				6526174C1C11F61700654091 /* Support.swift */,
+				65BB56DB1C70FAB100DF5211 /* ThreadSafety.swift */,
 				6526174D1C11F61700654091 /* TimeoutObserver.swift */,
 			);
 			path = Shared;
@@ -960,6 +965,7 @@
 				652619D61C12004C00654091 /* AddressBookUIOperations.swift in Sources */,
 				6526198A1C11FF5200654091 /* NoFailedDependenciesCondition.swift in Sources */,
 				652619CC1C12003F00654091 /* Reachability.swift in Sources */,
+				65BB56DC1C70FAB100DF5211 /* ThreadSafety.swift in Sources */,
 				652619841C11FF5200654091 /* GatedOperation.swift in Sources */,
 				652619CB1C12003F00654091 /* NetworkOperation.swift in Sources */,
 				652619831C11FF5200654091 /* ExclusivityManager.swift in Sources */,
@@ -1049,6 +1055,7 @@
 				652619E21C12015A00654091 /* UserConfirmationCondition.swift in Sources */,
 				652619981C11FF5200654091 /* GatedOperation.swift in Sources */,
 				6584D23C1C6BF87C00306EED /* FunctionalOperations.swift in Sources */,
+				65BB56DD1C70FAB700DF5211 /* ThreadSafety.swift in Sources */,
 				652619DA1C12010300654091 /* UIOperation.swift in Sources */,
 				652619DB1C12012C00654091 /* Capability.swift in Sources */,
 				652619971C11FF5200654091 /* ExclusivityManager.swift in Sources */,
@@ -1113,6 +1120,7 @@
 				652619B81C11FF5300654091 /* Support.swift in Sources */,
 				652619E91C1201AF00654091 /* ReachabilityCondition.swift in Sources */,
 				652619A81C11FF5300654091 /* BlockOperation.swift in Sources */,
+				65BB56DE1C70FAB800DF5211 /* ThreadSafety.swift in Sources */,
 				652619A91C11FF5300654091 /* ComposedOperation.swift in Sources */,
 				6584D2411C6BF89000306EED /* ResultInjection.swift in Sources */,
 				652619E31C1201AF00654091 /* CalendarCapability.swift in Sources */,

--- a/Sources/Core/Shared/GroupOperation.swift
+++ b/Sources/Core/Shared/GroupOperation.swift
@@ -25,7 +25,6 @@ operations.
 public class GroupOperation: Operation {
 
     private let finishingOperation = NSBlockOperation { }
-
     public let queue = OperationQueue()
     public let operations: [NSOperation]
 
@@ -40,6 +39,7 @@ public class GroupOperation: Operation {
     public init(operations ops: [NSOperation]) {
         operations = ops
         super.init()
+        name = "Group Operation"
         queue.suspended = true
         queue.delegate = self
     }
@@ -97,7 +97,7 @@ public class GroupOperation: Operation {
                     op.log.severity = log.severity
                 }
             }
-            queue.addOperations(operations, waitUntilFinished: false)
+            queue.addOperations(operations)
         }
     }
 
@@ -191,8 +191,8 @@ extension GroupOperation: OperationQueueDelegate {
         }
 
         if operation === finishingOperation {
-            queue.suspended = true
             finish(aggregateErrors)
+            queue.suspended = true
         }
         else {
             operationDidFinish(operation, withErrors: errors)

--- a/Sources/Core/Shared/OperationQueue.swift
+++ b/Sources/Core/Shared/OperationQueue.swift
@@ -125,10 +125,18 @@ public class OperationQueue: NSOperationQueue {
 public extension NSOperationQueue {
 
     /**
+     Add operations to the queue as an array
+     - parameters ops: a array of `NSOperation` instances.
+     */
+    func addOperations(ops: [NSOperation]) {
+        addOperations(ops, waitUntilFinished: false)
+    }
+
+    /**
      Add operations to the queue as a variadic parameter
      - parameters ops: a variadic array of `NSOperation` instances.
     */
     func addOperations(ops: NSOperation...) {
-        addOperations(ops, waitUntilFinished: false)
+        addOperations(ops)
     }
 }

--- a/Sources/Core/Shared/ThreadSafety.swift
+++ b/Sources/Core/Shared/ThreadSafety.swift
@@ -55,8 +55,27 @@ internal class Protector<T> {
         return lock.read { [unowned self] in block(self.ward) }
     }
 
-    func write(block: (inout T) -> Void, completion: (() -> Void)? = .None) {
+    func write(block: (inout T) -> Void) {
+        lock.write({ block(&self.ward) })
+    }
+
+    func write(block: (inout T) -> Void, completion: (() -> Void)) {
         lock.write({ block(&self.ward) }, completion: completion)
+    }
+}
+
+extension Protector where T: _ArrayType {
+
+    func append(newElement: T.Generator.Element) {
+        write({ (inout ward: T) in
+            ward.append(newElement)
+        })
+    }
+
+    func appendContentsOf<S : SequenceType where S.Generator.Element == T.Generator.Element>(newElements: S) {
+        write({ (inout ward: T) in
+            ward.appendContentsOf(newElements)
+        })
     }
 }
 

--- a/Sources/Core/Shared/ThreadSafety.swift
+++ b/Sources/Core/Shared/ThreadSafety.swift
@@ -1,0 +1,62 @@
+//
+//  ThreadSafety.swift
+//  Operations
+//
+//  Created by Daniel Thorpe on 14/02/2016.
+//
+//
+
+import Foundation
+
+protocol ReadWriteLock {
+    mutating func read<T>(block: () -> T) -> T
+    mutating func write(block: () -> Void, completion: (() -> Void)?)
+}
+
+extension ReadWriteLock {
+
+    mutating func write(block: () -> Void) {
+        write(block, completion: nil)
+    }
+}
+
+struct Lock: ReadWriteLock {
+
+    let queue = Queue.Initiated.concurrent("me.danthorpe.Operations.Lock")
+
+    mutating func read<T>(block: () -> T) -> T {
+        var object: T!
+        dispatch_sync(queue) {
+            object = block()
+        }
+        return object
+    }
+
+    mutating func write(block: () -> Void, completion: (() -> Void)?) {
+        dispatch_barrier_async(queue) {
+            block()
+            if let completion = completion {
+                dispatch_async(Queue.Main.queue, completion)
+            }
+        }
+    }
+}
+
+internal class Protector<T> {
+
+    private var lock: ReadWriteLock = Lock()
+    private var ward: T
+
+    init(_ ward: T) {
+        self.ward = ward
+    }
+
+    func read<U>(block: T -> U) -> U {
+        return lock.read { [unowned self] in block(self.ward) }
+    }
+
+    func write(block: (inout T) -> Void, completion: (() -> Void)? = .None) {
+        lock.write({ block(&self.ward) }, completion: completion)
+    }
+}
+

--- a/Tests/Core/GroupOperationTests.swift
+++ b/Tests/Core/GroupOperationTests.swift
@@ -92,7 +92,7 @@ class GroupOperationTests: OperationTests {
 
     func test__group_operation_exits_correctly_when_child_errors() {
 
-        let numberOfOperations = 10
+        let numberOfOperations = 10_000
         let operations = (0..<numberOfOperations).map { i -> Operation in
             let block = BlockOperation { (completion: BlockOperation.ContinuationBlockType) in
                 let error = NSError(domain: "me.danthorpe.Operations.Tests", code: -9_999, userInfo: nil)
@@ -103,7 +103,6 @@ class GroupOperationTests: OperationTests {
         }
 
         let group = GroupOperation(operations: operations)
-        group.queue.maxConcurrentOperationCount = 10
         group.log.severity = .Verbose
 
         let waiter = BlockOperation { }


### PR DESCRIPTION
This is to address the issue raised by @ansf in #181.

The basic issue is that the `aggregateErrors` property of `GroupOperation` is not thread safe. We do not need to create a huge group of operations to show this, just 10 will do it, and check that when the group finishes the number of errors is as expected.

This also highlights another issue with how the tests are often written. We add a `FinishedObserver` to the operation which is being tested. In it's block we fulfill the expectation. Then we wait for the expectations. The problem with this approach, is that the `FinishedObserver` is called as the `Operation` transitions from `.Finishing` to `.Finished` - so it's not *actually* finished. The reason it works like this, is so that it is possible to use the block to keep the operation "alive", which is exactly how `GroupOperation` works.

Therefore to handle this in tests, its best to make another operation, which depends on the group, and wait on this to finish. Possibly this is something which the `OperationTests` class could do automatically.

In general it might be beneficial to create `WillFinishObserver` and `DidFinishObserver` so that we can discern between these two states.