### PR TITLE
Reachable Operation - still has a bug

### DIFF
--- a/.ci/buildkite/pipeline.template.yml
+++ b/.ci/buildkite/pipeline.template.yml
@@ -2,13 +2,9 @@ steps:
   -
     name: ":fastlane: Build iOS Extension"
     command: .ci/scripts/build-ios-extension
-    # agents:
-    #   name: "$BUILDKITE_AGENT_META_DATA_NAME"
   -
     name: ":fastlane: Build OS X Extension"
     command: .ci/scripts/build-osx-extension
-    # agents:
-    #   name: "$BUILDKITE_AGENT_META_DATA_NAME"
   -
     name: ":fastlane: Test iOS"
     command: .ci/scripts/test-ios

--- a/.ci/buildkite/pipeline.template.yml
+++ b/.ci/buildkite/pipeline.template.yml
@@ -2,13 +2,13 @@ steps:
   -
     name: ":fastlane: Build iOS Extension"
     command: .ci/scripts/build-ios-extension
-    agents:
-      name: "$BUILDKITE_AGENT_META_DATA_NAME"
+    # agents:
+    #   name: "$BUILDKITE_AGENT_META_DATA_NAME"
   -
     name: ":fastlane: Build OS X Extension"
     command: .ci/scripts/build-osx-extension
-    agents:
-      name: "$BUILDKITE_AGENT_META_DATA_NAME"
+    # agents:
+    #   name: "$BUILDKITE_AGENT_META_DATA_NAME"
   -
     name: ":fastlane: Test iOS"
     command: .ci/scripts/test-ios

--- a/Sources/Features/Shared/Reachability.swift
+++ b/Sources/Features/Shared/Reachability.swift
@@ -148,8 +148,8 @@ class DeviceReachability: NetworkReachabilityType {
 
     typealias Error = Reachability.Error
 
-    private var __defaultRouteReachability: SCNetworkReachability? = .None
-    private var threadSafeProtector = Protector(false)
+    var __defaultRouteReachability: SCNetworkReachability? = .None
+    var threadSafeProtector = Protector(false)
     weak var delegate: NetworkReachabilityDelegate?
 
     var notifierIsRunning: Bool {

--- a/Sources/Features/Shared/Reachability.swift
+++ b/Sources/Features/Shared/Reachability.swift
@@ -16,9 +16,7 @@ public struct Reachability {
         case FailedToCreateDefaultRouteReachability
         case FailedToSetNotifierCallback
         case FailedToSetDispatchQueue
-        case FailedToScheduleNotifier
     }
-
 
     /// The kind of `Reachability` connectivity
     public enum Connectivity {
@@ -33,8 +31,6 @@ public struct Reachability {
 
     /// The ObserverBlockType
     public typealias ObserverBlockType = NetworkStatus -> Void
-
-    typealias ReachabilityDidChange = SCNetworkReachabilityFlags -> Void
 
     struct Observer {
         let connectivity: Connectivity
@@ -72,7 +68,6 @@ protocol HostReachabilityType: ReachabilityManagerType {
 
     func reachabilityForURL(url: NSURL, completion: Reachability.ObserverBlockType)
 }
-
 
 final class ReachabilityManager {
     typealias Status = Reachability.NetworkStatus

--- a/Sources/Features/Shared/ReachableOperation.swift
+++ b/Sources/Features/Shared/ReachableOperation.swift
@@ -34,7 +34,7 @@ public class ReachableOperation<T: NSOperation>: ComposedOperation<T> {
      - parameter connectivity: a `Reachability.Connectivity` value, defaults to `.AnyConnectionKind`.
     */
     public convenience init(_ op: T, connectivity: Reachability.Connectivity = .AnyConnectionKind) {
-        self.init(operation: op, connectivity: connectivity, reachability: ReachabilityManager(DeviceReachability()))
+        self.init(operation: op, connectivity: connectivity, reachability: ReachabilityManager.sharedInstance)
     }
 
     init(operation op: T, connectivity: Reachability.Connectivity = .AnyConnectionKind, reachability: SystemReachabilityType) {

--- a/Tests/Features/ReachabilityTests.swift
+++ b/Tests/Features/ReachabilityTests.swift
@@ -202,24 +202,8 @@ class ReachabilityManagerTests: XCTestCase {
 
 class SystemReachabilityManagerTests: ReachabilityManagerTests {
 
-    func test__whenConnected__delegate_is_set() {
-        manager.whenConnected(.AnyConnectionKind) { }
+    func test__delegate_is_set() {
         XCTAssertNotNil(network.delegate)
-    }
-
-    func test__whenConnected__block_is_set() {
-        manager.whenConnected(.AnyConnectionKind) { }
-        XCTAssertNotNil(manager.whenConnectedBlock)
-    }
-
-    func test__whenConnected__connectivity_is_set() {
-        manager.whenConnected(.ViaWiFi) { }
-        XCTAssertEqual(manager.connectivity, Reachability.Connectivity.ViaWiFi)
-    }
-
-    func test__whenConnected__notifier_on_queue_starts() {
-        manager.whenConnected(.AnyConnectionKind) { }
-        XCTAssertTrue(network.didStartNotifier)
     }
 
     func test__whenConnected__block_is_run() {
@@ -233,11 +217,6 @@ class SystemReachabilityManagerTests: ReachabilityManagerTests {
         waitForExpectationsWithTimeout(3.0, handler: nil)
         XCTAssertTrue(blockDidRun)
         XCTAssertTrue(network.didStopNotifier)
-    }
-
-    func test__network_delegate__returns_if_block_is_not_set() {
-        manager.reachabilityDidChange(.ConnectionAutomatic)
-        XCTAssertFalse(network.didStopNotifier)
     }
 }
 
@@ -294,6 +273,16 @@ class DeviceReachabilityTests: XCTestCase, NetworkReachabilityDelegate {
         device.delegate = self
     }
 
+    func test__notifierIsRunning_true_when_running() {
+        device.notifierIsRunning = true
+        XCTAssertTrue(device.notifierIsRunning)
+    }
+
+    func test__notifierIsRunning_false_when_not_running() {
+        device.notifierIsRunning = false
+        XCTAssertFalse(device.notifierIsRunning)
+    }
+
     func reachabilityDidChange(flags: SCNetworkReachabilityFlags) {
         delegateDidReceiveFlags = flags
         expectation?.fulfill()
@@ -316,5 +305,7 @@ class DeviceReachabilityTests: XCTestCase, NetworkReachabilityDelegate {
         waitForExpectationsWithTimeout(3, handler: nil)
         XCTAssertNotNil(delegateDidReceiveFlags)
     }
+
+
 }
 

--- a/Tests/Features/ReachabilityTests.swift
+++ b/Tests/Features/ReachabilityTests.swift
@@ -306,6 +306,15 @@ class DeviceReachabilityTests: XCTestCase, NetworkReachabilityDelegate {
         XCTAssertNotNil(delegateDidReceiveFlags)
     }
 
-
+    func test__creates_default_route_reachability() {
+        do {
+            XCTAssertNil(device.__defaultRouteReachability)
+            let _ = try device.defaultRouteReachability()
+            XCTAssertNotNil(device.__defaultRouteReachability)
+        }
+        catch {
+            XCTFail("Unexpected error thrown: \(error)")
+        }
+    }
 }
 


### PR DESCRIPTION
There is still a bug in `ReachableOperation`. It works correctly when the device is already online, however when offline, the operation does not execute when the device comes back online.

The most recent change here remove the private singleton which was holding all the "observers" instead making them all individual. But this is not going to work.

So, back to the drawing board and need to re-consider how this can be unit tested. Possibly move away from the function registered in the run loop - as it's hard to make this non-global.