### PR TITLE
Make podspec dependencies more granular

### DIFF
--- a/Operations.podspec
+++ b/Operations.podspec
@@ -32,6 +32,12 @@ session Advanced NSOperations: https://developer.apple.com/videos/wwdc/2015/?id=
       'Sources/Features/Shared',
       'Sources/Features/iOS'
     ]
+    ss.ios.exclude_files = [
+      'Sources/Features/Shared/CloudCapability.swift',
+      'Sources/Features/Shared/CloudKitOperation.swift',			
+      'Sources/Features/iOS/PhotosCapability.swift',
+      'Sources/Features/iOS/PassbookCapability.swift'
+    ]
     ss.watchos.exclude_files = [
       'Sources/Core/iOS',
       'Sources/Features/iOS/LocationCapability.swift',
@@ -61,7 +67,9 @@ session Advanced NSOperations: https://developer.apple.com/videos/wwdc/2015/?id=
     ]
     ss.osx.exclude_files = [
       'Sources/Core/iOS',
-      'Sources/Features/iOS'
+      'Sources/Features/iOS',
+      'Sources/Features/Shared/CloudCapability.swift',
+      'Sources/Features/Shared/CloudKitOperation.swift'
     ]
   end
 
@@ -121,7 +129,47 @@ session Advanced NSOperations: https://developer.apple.com/videos/wwdc/2015/?id=
       'Sources/Extras/Contacts/iOS'
     ]
   end
-
+	
+  # Subspec which includes CloudKit functionality
+  s.subspec '+CloudKit' do |ss|
+    ss.platforms = { :ios => "8.0", :osx => "10.10" }
+    ss.dependency 'Operations/Standard'
+    ss.source_files = [
+      'Sources/Features/Shared/CloudCapability.swift',
+      'Sources/Features/Shared/CloudKitOperation.swift',			
+    ]
+  end
+	
+  # Subspec which includes CloudKit functionality
+  s.subspec '+CloudKit' do |ss|
+    ss.platforms = { :ios => "8.0", :osx => "10.10" }
+    ss.dependency 'Operations/Standard'
+    ss.frameworks = 'CloudKit'
+    ss.source_files = [
+      'Sources/Features/Shared/CloudCapability.swift',
+      'Sources/Features/Shared/CloudKitOperation.swift',			
+    ]
+  end
+	
+  # Subspec which includes Photos functionality
+  s.subspec '+Photos' do |ss|
+    ss.platforms = { :ios => "8.0" }
+    ss.dependency 'Operations/Standard'
+    ss.frameworks = 'Photos'
+    ss.source_files = [
+      'Sources/Features/iOS/PhotosCapability.swift'
+    ]
+  end
+	
+  # Subspec which includes Passbook functionality
+  s.subspec '+Passbook' do |ss|
+    ss.platforms = { :ios => "8.0" }
+    ss.dependency 'Operations/Standard'
+    ss.frameworks = 'Passbook'
+    ss.source_files = [
+      'Sources/Features/iOS/PassbookCapability.swift'
+    ]
+  end
 end
 
 

--- a/Operations.podspec
+++ b/Operations.podspec
@@ -132,19 +132,8 @@ session Advanced NSOperations: https://developer.apple.com/videos/wwdc/2015/?id=
 	
   # Subspec which includes CloudKit functionality
   s.subspec '+CloudKit' do |ss|
-    ss.platforms = { :ios => "8.0", :osx => "10.10" }
+    ss.platforms = { :ios => "8.0", :tvos => "9.0", :osx => "10.10" }
     ss.dependency 'Operations/Standard'
-    ss.source_files = [
-      'Sources/Features/Shared/CloudCapability.swift',
-      'Sources/Features/Shared/CloudKitOperation.swift',			
-    ]
-  end
-	
-  # Subspec which includes CloudKit functionality
-  s.subspec '+CloudKit' do |ss|
-    ss.platforms = { :ios => "8.0", :osx => "10.10" }
-    ss.dependency 'Operations/Standard'
-    ss.frameworks = 'CloudKit'
     ss.source_files = [
       'Sources/Features/Shared/CloudCapability.swift',
       'Sources/Features/Shared/CloudKitOperation.swift',			


### PR DESCRIPTION
Hi there,

Great lib! We're just starting using this, and noticed that in spite of the current use of subspecs, it would be nice to make them just a shade more granular. In particular, we'd rather not CloudKit unnecessarily, which is currently required in the Standard subspec.

In any case, please let me know what you think.

Thanks!