### PR TITLE
Refactor Observers

### DIFF
--- a/Sources/Core/Shared/BlockObserver.swift
+++ b/Sources/Core/Shared/BlockObserver.swift
@@ -88,7 +88,7 @@ public struct ProducedOperationObserver: OperationDidProduceOperationObserver {
 
 /**
  WillFinishObserver is an observer which will execute a
- closure when the operation finishes.
+ closure when the operation is about to finish.
  */
 public struct WillFinishObserver: OperationWillFinishObserver {
     public typealias BlockType = (Operation, [ErrorType]) -> Void
@@ -114,7 +114,7 @@ public struct WillFinishObserver: OperationWillFinishObserver {
 
 /**
  DidFinishObserver is an observer which will execute a
- closure when the operation finishes.
+ closure when the operation did just finish.
  */
 public struct DidFinishObserver: OperationDidFinishObserver {
     public typealias BlockType = (Operation, [ErrorType]) -> Void

--- a/Sources/Core/Shared/BlockObserver.swift
+++ b/Sources/Core/Shared/BlockObserver.swift
@@ -87,7 +87,7 @@ public struct ProducedOperationObserver: OperationDidProduceOperationObserver {
 
 
 /**
- FinishedObserver is an observer which will execute a
+ WillFinishObserver is an observer which will execute a
  closure when the operation finishes.
  */
 public struct WillFinishObserver: OperationWillFinishObserver {
@@ -113,7 +113,7 @@ public struct WillFinishObserver: OperationWillFinishObserver {
 
 
 /**
- FinishedObserver is an observer which will execute a
+ DidFinishObserver is an observer which will execute a
  closure when the operation finishes.
  */
 public struct DidFinishObserver: OperationDidFinishObserver {

--- a/Sources/Core/Shared/BlockObserver.swift
+++ b/Sources/Core/Shared/BlockObserver.swift
@@ -28,7 +28,7 @@ public struct StartedObserver: OperationDidStartObserver {
     }
 
     /// Conforms to `OperationDidStartObserver`, executes the block
-    public func operationDidStart(operation: Operation) {
+    public func didStartOperation(operation: Operation) {
         block(operation)
     }
 }
@@ -54,10 +54,11 @@ public struct CancelledObserver: OperationDidCancelObserver {
     }
 
     /// Conforms to `OperationDidCancelObserver`, executes the block
-    public func operationDidCancel(operation: Operation) {
+    public func didCancelOperation(operation: Operation) {
         block(operation)
     }
 }
+
 
 /**
  ProducedOperationObserver is an observer which will execute a
@@ -84,11 +85,38 @@ public struct ProducedOperationObserver: OperationDidProduceOperationObserver {
     }
 }
 
+
 /**
  FinishedObserver is an observer which will execute a
  closure when the operation finishes.
  */
-public struct FinishedObserver: OperationDidFinishObserver {
+public struct WillFinishObserver: OperationWillFinishObserver {
+    public typealias BlockType = (Operation, [ErrorType]) -> Void
+
+    private let block: BlockType
+
+    /**
+     Initialize the observer with a block.
+
+     - parameter didStart: the `DidStartBlock`
+     - returns: an observer.
+     */
+    public init(willFinish: BlockType) {
+        self.block = willFinish
+    }
+
+    /// Conforms to `OperationWillFinishObserver`, executes the block
+    public func willFinishOperation(operation: Operation, errors: [ErrorType]) {
+        block(operation, errors)
+    }
+}
+
+
+/**
+ FinishedObserver is an observer which will execute a
+ closure when the operation finishes.
+ */
+public struct DidFinishObserver: OperationDidFinishObserver {
     public typealias BlockType = (Operation, [ErrorType]) -> Void
 
     private let block: BlockType
@@ -104,11 +132,13 @@ public struct FinishedObserver: OperationDidFinishObserver {
     }
 
     /// Conforms to `OperationDidFinishObserver`, executes the block
-    public func operationDidFinish(operation: Operation, errors: [ErrorType]) {
+    public func didFinishOperation(operation: Operation, errors: [ErrorType]) {
         block(operation, errors)
     }
 }
 
+@available(*, unavailable, renamed="DidFinishObserver")
+public typealias FinishedObserver = DidFinishObserver
 
 
 /**
@@ -120,7 +150,8 @@ public struct BlockObserver: OperationObserver {
     let didStart: StartedObserver?
     let didCancel: CancelledObserver?
     let didProduce: ProducedOperationObserver?
-    let didFinish: FinishedObserver?
+    let willFinish: WillFinishObserver?
+    let didFinish: DidFinishObserver?
 
     /**
      A `OperationObserver` which accepts three different blocks for start,
@@ -139,21 +170,22 @@ public struct BlockObserver: OperationObserver {
      - parameter produceHandler, a optional block of type (Operation, NSOperation) -> Void
      - parameter finishHandler, a optional block of type (Operation, [ErrorType]) -> Void
      */
-    public init(didStart: StartedObserver.BlockType? = .None, didCancel: CancelledObserver.BlockType? = .None, didProduce: ProducedOperationObserver.BlockType? = .None, didFinish: FinishedObserver.BlockType? = .None) {
+    public init(didStart: StartedObserver.BlockType? = .None, didCancel: CancelledObserver.BlockType? = .None, didProduce: ProducedOperationObserver.BlockType? = .None, willFinish: WillFinishObserver.BlockType? = .None, didFinish: DidFinishObserver.BlockType? = .None) {
         self.didStart = didStart.map { StartedObserver(didStart: $0) }
         self.didCancel = didCancel.map { CancelledObserver(didCancel: $0) }
         self.didProduce = didProduce.map { ProducedOperationObserver(didProduce: $0) }
-        self.didFinish = didFinish.map { FinishedObserver(didFinish: $0) }
+        self.willFinish = willFinish.map { WillFinishObserver(willFinish: $0) }
+        self.didFinish = didFinish.map { DidFinishObserver(didFinish: $0) }
     }
 
     /// Conforms to `OperationObserver`, executes the optional startHandler.
-    public func operationDidStart(operation: Operation) {
-        didStart?.operationDidStart(operation)
+    public func didStartOperation(operation: Operation) {
+        didStart?.didStartOperation(operation)
     }
 
     /// Conforms to `OperationObserver`, executes the optional cancellationHandler.
-    public func operationDidCancel(operation: Operation) {
-        didCancel?.operationDidCancel(operation)
+    public func didCancelOperation(operation: Operation) {
+        didCancel?.didCancelOperation(operation)
     }
 
     /// Conforms to `OperationObserver`, executes the optional produceHandler.
@@ -161,9 +193,14 @@ public struct BlockObserver: OperationObserver {
         didProduce?.operation(operation, didProduceOperation: newOperation)
     }
 
-    /// Conforms to `OperationObserver`, executes the optional finishHandler.
-    public func operationDidFinish(operation: Operation, errors: [ErrorType]) {
-        didFinish?.operationDidFinish(operation, errors: errors)
+    /// Conforms to `OperationObserver`, executes the optional willFinish.
+    public func willFinishOperation(operation: Operation, errors: [ErrorType]) {
+        willFinish?.willFinishOperation(operation, errors: errors)
+    }
+
+    /// Conforms to `OperationObserver`, executes the optional didFinish.
+    public func didFinishOperation(operation: Operation, errors: [ErrorType]) {
+        didFinish?.didFinishOperation(operation, errors: errors)
     }
 }
 

--- a/Sources/Core/Shared/ComposedOperation.swift
+++ b/Sources/Core/Shared/ComposedOperation.swift
@@ -36,7 +36,7 @@ public class ComposedOperation<T: NSOperation>: Operation, OperationDidFinishObs
         produceOperation(target)
     }
 
-    public func operationDidFinish(operation: Operation, errors: [ErrorType]) {
+    public func didFinishOperation(operation: Operation, errors: [ErrorType]) {
         if operation == target {
             finish(errors)
         }

--- a/Sources/Core/Shared/ExclusivityManager.swift
+++ b/Sources/Core/Shared/ExclusivityManager.swift
@@ -35,7 +35,7 @@ internal class ExclusivityManager {
     private func _addOperation(operation: NSOperation, category: String) {
         if let op = operation as? Operation {
             op.log.verbose(" >>> \(category)")
-            op.addObserver(FinishedObserver { [unowned self] op, _ in
+            op.addObserver(DidFinishObserver { [unowned self] op, _ in
                 self.removeOperation(op, category: category)
             })
         }

--- a/Sources/Core/Shared/GroupOperation.swift
+++ b/Sources/Core/Shared/GroupOperation.swift
@@ -118,7 +118,7 @@ public class GroupOperation: Operation {
 
     /**
      This method is called every time one of the groups child operations
-     finish.
+     is about to finish.
 
      Over-ride this method to enable the following sort of behavior:
     
@@ -152,9 +152,13 @@ public class GroupOperation: Operation {
      - parameter operation: the child `NSOperation` that has just finished.
      - parameter errors: an array of `ErrorType`s.
     */
-    public func operationDidFinish(operation: NSOperation, withErrors errors: [ErrorType]) {
+    public func willFinishOperation(operation: NSOperation, withErrors errors: [ErrorType]) {
         // no-op, subclasses can override for their own functionality.
     }
+
+    @available(*, unavailable, renamed="willFinishOperation")
+    public func operationDidFinish(operation: NSOperation, withErrors errors: [ErrorType]) { }
+
 }
 
 extension GroupOperation: OperationQueueDelegate {
@@ -182,7 +186,7 @@ extension GroupOperation: OperationQueueDelegate {
      operation is the finishing operation, we finish the group operation here. Else, the group is
      notified (using `operationDidFinish` that a child operation has finished.
     */
-    public func operationQueue(queue: OperationQueue, operationDidFinish operation: NSOperation, withErrors errors: [ErrorType]) {
+    public func operationQueue(queue: OperationQueue, willFinishOperation operation: NSOperation, withErrors errors: [ErrorType]) {
         if !errors.isEmpty {
             switch operation {
             case is GroupOperation:
@@ -194,12 +198,16 @@ extension GroupOperation: OperationQueueDelegate {
             }
         }
 
+        if operation !== finishingOperation {
+            willFinishOperation(operation, withErrors: errors)
+        }
+    }
+
+    public func operationQueue(queue: OperationQueue, didFinishOperation operation: NSOperation, withErrors errors: [ErrorType]) {
+
         if operation === finishingOperation {
             finish(aggregateErrors)
             queue.suspended = true
-        }
-        else {
-            operationDidFinish(operation, withErrors: errors)
         }
     }
 }

--- a/Sources/Core/Shared/LoggingObserver.swift
+++ b/Sources/Core/Shared/LoggingObserver.swift
@@ -46,7 +46,7 @@ public struct LoggingObserver: OperationObserver {
     
     - parameter operation: the `Operation` which has started.
     */
-    public func operationDidStart(operation: Operation) {
+    public func didStartOperation(operation: Operation) {
         log("\(operation.operationName): did start.")
     }
 
@@ -58,7 +58,7 @@ public struct LoggingObserver: OperationObserver {
 
      - parameter operation: the `Operation` which has started.
      */
-    public func operationDidCancel(operation: Operation) {
+    public func didCancelOperation(operation: Operation) {
         log("\(operation.operationName): did cancel.")
     }
 
@@ -87,6 +87,25 @@ public struct LoggingObserver: OperationObserver {
     }
 
     /**
+     Conforms to `OperationObserver`. The logger is sent a string which uses the
+     `name` parameter of the operation if provived. If there were errors, output
+     looks like
+
+     "My Operation: finsihed with error(s): [My Operation Error]."
+
+     or if no errors:
+
+     "My Operation: finsihed with no errors."
+
+     - parameter operation: the `Operation` that finished.
+     - parameter errors: an array of `ErrorType`, not that these will be printed out.
+     */
+    public func willFinishOperation(operation: Operation, errors: [ErrorType]) {
+        let detail = errors.count > 0 ? "error(s): \(errors)" : "no errors"
+        log("\(operation.operationName): will finish with \(detail).")
+    }
+
+    /**
     Conforms to `OperationObserver`. The logger is sent a string which uses the
     `name` parameter of the operation if provived. If there were errors, output
     looks like
@@ -100,9 +119,9 @@ public struct LoggingObserver: OperationObserver {
     - parameter operation: the `Operation` that finished.
     - parameter errors: an array of `ErrorType`, not that these will be printed out.
     */
-    public func operationDidFinish(operation: Operation, errors: [ErrorType]) {
+    public func didFinishOperation(operation: Operation, errors: [ErrorType]) {
         let detail = errors.count > 0 ? "error(s): \(errors)" : "no errors"
-        log("\(operation.operationName): finished with \(detail).")
+        log("\(operation.operationName): did finish with \(detail).")
     }
 
     private func log(message: String) {

--- a/Sources/Core/Shared/Operation.swift
+++ b/Sources/Core/Shared/Operation.swift
@@ -123,7 +123,7 @@ public class Operation: NSOperation {
             didChangeValueForKey("Cancelled")
 
             if _cancelled && !oldValue {
-                didCancelObservers.forEach { $0.operationDidCancel(self) }
+                didCancelObservers.forEach { $0.didCancelOperation(self) }
             }
         }
     }
@@ -296,6 +296,10 @@ public class Operation: NSOperation {
         return observers.flatMap { $0 as? OperationDidProduceOperationObserver }
     }
 
+    var willFinishObservers: [OperationWillFinishObserver] {
+        return observers.flatMap { $0 as? OperationWillFinishObserver }
+    }
+
     var didFinishObservers: [OperationDidFinishObserver] {
         return observers.flatMap { $0 as? OperationDidFinishObserver }
     }
@@ -317,7 +321,10 @@ public class Operation: NSOperation {
         default:
             assert(state < .Ready, "Cannot modify observers after operations has been ready, current state: \(state).")
         }
+        
         observers.append(observer)
+
+        observer.didAttachToOperation(self)
     }
 
     // MARK: - Dependencies
@@ -415,7 +422,7 @@ public class Operation: NSOperation {
         if _internalErrors.isEmpty && !cancelled {
             state = .Executing
             log.verbose("Will Execute")
-            didStartObservers.forEach { $0.operationDidStart(self) }
+            didStartObservers.forEach { $0.didStartOperation(self) }
             execute()
         }
         else {
@@ -503,15 +510,17 @@ public class Operation: NSOperation {
             finished(_internalErrors)
 
             if errors.isEmpty {
-                log.verbose("Did finish with no errors.")
+                log.verbose("Finishing with no errors.")
             }
             else {
-                log.verbose("Did finish with errors: \(_internalErrors).")
+                log.verbose("Finishing with errors: \(_internalErrors).")
             }
 
-            didFinishObservers.forEach { $0.operationDidFinish(self, errors: self._internalErrors) }
+            willFinishObservers.forEach { $0.willFinishOperation(self, errors: self._internalErrors) }
 
             state = .Finished
+
+            didFinishObservers.forEach { $0.didFinishOperation(self, errors: self._internalErrors) }
         }
     }
     

--- a/Sources/Core/Shared/OperationObserver.swift
+++ b/Sources/Core/Shared/OperationObserver.swift
@@ -31,9 +31,7 @@ public extension OperationObserverType {
      
      - parameter operation: the observed `Operation`.
     */
-    func didAttachToOperation(operation: Operation) {
-        operation.log.verbose("Did attach observer: \(self)")
-    }
+    func didAttachToOperation(operation: Operation) { /* No operation */ }
 }
 
 

--- a/Sources/Core/Shared/OperationObserver.swift
+++ b/Sources/Core/Shared/OperationObserver.swift
@@ -12,7 +12,29 @@ import Foundation
  Types which conform to this protocol, can be attached to `Operation` subclasses before
  they are added to a queue.
  */
-public protocol OperationObserverType { }
+public protocol OperationObserverType {
+
+    /**
+     Observer gets notified when it is attached to an operation.
+     
+     - parameter operation: the observed `Operation`.
+    */
+    func didAttachToOperation(operation: Operation)
+}
+
+
+
+public extension OperationObserverType {
+
+    /**
+     Default implementation just prints out a log.
+     
+     - parameter operation: the observed `Operation`.
+    */
+    func didAttachToOperation(operation: Operation) {
+        operation.log.verbose("Did attach observer: \(self)")
+    }
+}
 
 
 
@@ -25,9 +47,9 @@ public protocol OperationDidStartObserver: OperationObserverType {
     /**
      The operation started.
 
-     - parameter operaton: the observed `Operation`.
+     - parameter operation: the observed `Operation`.
      */
-    func operationDidStart(operation: Operation)
+    func didStartOperation(operation: Operation)
 }
 
 
@@ -41,9 +63,9 @@ public protocol OperationDidCancelObserver: OperationObserverType {
     /**
      The operation was cancelled.
 
-     - parameter operaton: the observed `Operation`.
+     - parameter operation: the observed `Operation`.
      */
-    func operationDidCancel(operation: Operation)
+    func didCancelOperation(operation: Operation)
 }
 
 
@@ -60,10 +82,26 @@ public protocol OperationDidProduceOperationObserver: OperationObserverType {
      queue. Note that this isn't necessarily an `Operation`, so be careful, if you
      intend to automatically start observing it.
 
-     - parameter operaton: the observed `Operation`.
+     - parameter operation: the observed `Operation`.
      - parameter newOperation: the produced `NSOperation`
      */
     func operation(operation: Operation, didProduceOperation newOperation: NSOperation)
+}
+
+
+
+/**
+ Types which confirm to this protocol, can be attached to `Operation` subclasses.
+ */
+public protocol OperationWillFinishObserver: OperationObserverType {
+
+    /**
+     The operation will finish. Any errors that were encountered are collected here.
+
+     - parameter operation: the observed `Operation`.
+     - parameter errors: an array of `ErrorType`s.
+     */
+    func willFinishOperation(operation: Operation, errors: [ErrorType])
 }
 
 
@@ -77,10 +115,10 @@ public protocol OperationDidFinishObserver: OperationObserverType {
     /**
      The operation did finish. Any errors that were encountered are collected here.
 
-     - parameter operaton: the observed `Operation`.
+     - parameter operation: the observed `Operation`.
      - parameter errors: an array of `ErrorType`s.
      */
-    func operationDidFinish(operation: Operation, errors: [ErrorType])
+    func didFinishOperation(operation: Operation, errors: [ErrorType])
 }
 
 
@@ -90,5 +128,5 @@ public protocol OperationDidFinishObserver: OperationObserverType {
  they are added to a queue. They will receive callbacks when the operation starts,
  produces a new operation, and finishes.
  */
-public protocol OperationObserver: OperationDidStartObserver, OperationDidCancelObserver, OperationDidProduceOperationObserver, OperationDidFinishObserver { }
+public protocol OperationObserver: OperationDidStartObserver, OperationDidCancelObserver, OperationDidProduceOperationObserver, OperationWillFinishObserver, OperationDidFinishObserver { }
 

--- a/Sources/Core/Shared/OperationObserver.swift
+++ b/Sources/Core/Shared/OperationObserver.swift
@@ -27,7 +27,7 @@ public protocol OperationObserverType {
 public extension OperationObserverType {
 
     /**
-     Default implementation just prints out a log.
+     Default implementation is a no-operation.
      
      - parameter operation: the observed `Operation`.
     */

--- a/Sources/Core/Shared/OperationQueue.swift
+++ b/Sources/Core/Shared/OperationQueue.swift
@@ -31,7 +31,16 @@ public protocol OperationQueueDelegate: class {
     - parameter operation: the `NSOperation` instance which finished.
     - parameter errors: an array of `ErrorType`s.
     */
-    func operationQueue(queue: OperationQueue, operationDidFinish operation: NSOperation, withErrors errors: [ErrorType])
+    func operationQueue(queue: OperationQueue, willFinishOperation operation: NSOperation, withErrors errors: [ErrorType])
+
+    /**
+     An operation has finished on the queue.
+
+     - parameter queue: the `OperationQueue`.
+     - parameter operation: the `NSOperation` instance which finished.
+     - parameter errors: an array of `ErrorType`s.
+     */
+    func operationQueue(queue: OperationQueue, didFinishOperation operation: NSOperation, withErrors errors: [ErrorType])
 }
 
 /**
@@ -61,10 +70,17 @@ public class OperationQueue: NSOperationQueue {
                 self?.addOperation($1)
             })
 
-            /// Add an observer to invove the did finish delegate method
-            operation.addObserver(FinishedObserver { [weak self] operation, errors in
+            /// Add an observer to invoke the will finish delegate method
+            operation.addObserver(WillFinishObserver { [weak self] operation, errors in
                 if let q = self {
-                    q.delegate?.operationQueue(q, operationDidFinish: operation, withErrors: errors)
+                    self?.delegate?.operationQueue(q, willFinishOperation: operation, withErrors: errors)
+                }
+            })
+
+            /// Add an observer to invoke the did finish delegate method
+            operation.addObserver(DidFinishObserver { [weak self] operation, errors in
+                if let q = self {
+                    self?.delegate?.operationQueue(q, didFinishOperation: operation, withErrors: errors)
                 }
             })
 
@@ -100,7 +116,7 @@ public class OperationQueue: NSOperationQueue {
 
             op.addCompletionBlock { [weak self, weak op] in
                 if let queue = self, let op = op {
-                    queue.delegate?.operationQueue(queue, operationDidFinish: op, withErrors: [])
+                    queue.delegate?.operationQueue(queue, didFinishOperation: op, withErrors: [])
                 }
             }
         }

--- a/Sources/Core/Shared/OperationQueue.swift
+++ b/Sources/Core/Shared/OperationQueue.swift
@@ -73,14 +73,14 @@ public class OperationQueue: NSOperationQueue {
             /// Add an observer to invoke the will finish delegate method
             operation.addObserver(WillFinishObserver { [weak self] operation, errors in
                 if let q = self {
-                    self?.delegate?.operationQueue(q, willFinishOperation: operation, withErrors: errors)
+                    q.delegate?.operationQueue(q, willFinishOperation: operation, withErrors: errors)
                 }
             })
 
             /// Add an observer to invoke the did finish delegate method
             operation.addObserver(DidFinishObserver { [weak self] operation, errors in
                 if let q = self {
-                    self?.delegate?.operationQueue(q, didFinishOperation: operation, withErrors: errors)
+                    q.delegate?.operationQueue(q, didFinishOperation: operation, withErrors: errors)
                 }
             })
 

--- a/Sources/Core/Shared/RepeatedOperation.swift
+++ b/Sources/Core/Shared/RepeatedOperation.swift
@@ -379,7 +379,7 @@ public class RepeatedOperation<T where T: NSOperation>: GroupOperation {
      say `Operation` instead of `MyOperation` (i.e. your specific 
      operation which should be repeated).
     */
-    public override func operationDidFinish(operation: NSOperation, withErrors errors: [ErrorType]) {
+    public override func willFinishOperation(operation: NSOperation, withErrors errors: [ErrorType]) {
         if let _ = operation as? DelayOperation { return }
         if let _ = operation as? T {
             addNextOperation()
@@ -559,7 +559,7 @@ public class RepeatableOperation<T: Operation>: Operation, OperationDidFinishObs
     }
 
     /// Implementation for OperationDidFinishObserver
-    public func operationDidFinish(operation: Operation, errors: [ErrorType]) {
+    public func didFinishOperation(operation: Operation, errors: [ErrorType]) {
         if self.operation == operation {
             finish(errors)
         }

--- a/Sources/Core/Shared/ResultInjection.swift
+++ b/Sources/Core/Shared/ResultInjection.swift
@@ -88,7 +88,7 @@ extension InjectionOperationType where Self: Operation {
      - returns: `self` - so that injections can be chained together.
     */
     public func injectResultFromDependency<T where T: Operation>(dep: T, block: (operation: Self, dependency: T, errors: [ErrorType]) -> Void) -> Self {
-        dep.addObserver(FinishedObserver { op, errors in
+        dep.addObserver(DidFinishObserver { op, errors in
             if let dep = op as? T {
                 block(operation: self, dependency: dep, errors: errors)
             }

--- a/Sources/Core/Shared/RetryOperation.swift
+++ b/Sources/Core/Shared/RetryOperation.swift
@@ -166,7 +166,7 @@ public class RetryOperation<T: NSOperation>: RepeatedOperation<T> {
         self.init(maxCount: max, delay: MapGenerator(strategy.generator()) { Delay.By($0) }, generator: generator, retry: retry)
     }
 
-    public override func operationDidFinish(operation: NSOperation, withErrors errors: [ErrorType]) {
+    public override func willFinishOperation(operation: NSOperation, withErrors errors: [ErrorType]) {
         if errors.isEmpty {
             retry.info = .None
         }

--- a/Sources/Core/Shared/TimeoutObserver.swift
+++ b/Sources/Core/Shared/TimeoutObserver.swift
@@ -34,7 +34,7 @@ public struct TimeoutObserver: OperationDidStartObserver {
     
     - parameter operation: the `Operation` which will be cancelled if the timeout is reached.
     */
-    public func operationDidStart(operation: Operation) {
+    public func didStartOperation(operation: Operation) {
         let when = dispatch_time(DISPATCH_TIME_NOW, Int64(timeout * Double(NSEC_PER_SEC)))
 
         dispatch_after(when, Queue.Default.queue) {

--- a/Sources/Core/iOS/BackgroundObserver.swift
+++ b/Sources/Core/iOS/BackgroundObserver.swift
@@ -88,7 +88,7 @@ public class BackgroundObserver: NSObject {
 extension BackgroundObserver: OperationDidFinishObserver {
 
     /// Conforms to `OperationDidFinishObserver`, will end any background task that has been started.
-    public func operationDidFinish(operation: Operation, errors: [ErrorType]) {
+    public func didFinishOperation(operation: Operation, errors: [ErrorType]) {
         endBackgroundTask()
     }
 }

--- a/Sources/Core/iOS/NetworkObserver.swift
+++ b/Sources/Core/iOS/NetworkObserver.swift
@@ -33,7 +33,7 @@ public class NetworkObserver: OperationDidStartObserver, OperationDidFinishObser
     }
 
     /// Conforms to `OperationObserver`, will start the network activity indicator.
-    public func operationDidStart(operation: Operation) {
+    public func didStartOperation(operation: Operation) {
         dispatch_async(Queue.Main.queue) {
             NetworkIndicatorController.sharedInstance.networkActivityIndicator = self.networkActivityIndicator
             NetworkIndicatorController.sharedInstance.networkActivityDidStart()
@@ -41,7 +41,7 @@ public class NetworkObserver: OperationDidStartObserver, OperationDidFinishObser
     }
 
     /// Conforms to `OperationObserver`, will stop the network activity indicator.
-    public func operationDidFinish(operation: Operation, errors: [ErrorType]) {
+    public func didFinishOperation(operation: Operation, errors: [ErrorType]) {
         dispatch_async(Queue.Main.queue) {
             NetworkIndicatorController.sharedInstance.networkActivityIndicator = self.networkActivityIndicator
             NetworkIndicatorController.sharedInstance.networkActivityDidEnd()

--- a/Sources/Extras/AddressBook/iOS/AddressBookUIOperations.swift
+++ b/Sources/Extras/AddressBook/iOS/AddressBookUIOperations.swift
@@ -65,7 +65,7 @@ public class AddressBookDisplayPersonViewController<F: PresentingViewController>
         super.init(operations: [ get ])
     }
 
-    public override func operationDidFinish(operation: NSOperation, withErrors errors: [ErrorType]) {
+    public override func willFinishOperation(operation: NSOperation, withErrors errors: [ErrorType]) {
         if errors.isEmpty && get == operation, let person = get.addressBookPerson {
             ui.controller.personViewDelegate = delegate
             ui.controller.displayedPerson = person.storage
@@ -97,7 +97,7 @@ public class AddressBookDisplayNewPersonViewController<F: PresentingViewControll
         super.init(operations: [ get ])
     }
 
-    public override func operationDidFinish(operation: NSOperation, withErrors errors: [ErrorType]) {
+    public override func willFinishOperation(operation: NSOperation, withErrors errors: [ErrorType]) {
         if errors.isEmpty && get == operation {
 
             ui.controller.newPersonViewDelegate = delegate

--- a/Sources/Extras/Contacts/iOS/ContactsUIOperations.swift
+++ b/Sources/Extras/Contacts/iOS/ContactsUIOperations.swift
@@ -41,7 +41,7 @@ final public class DisplayContactViewController<F: PresentingViewController>: Gr
         return vc
     }
 
-    public override func operationDidFinish(operation: NSOperation, withErrors errors: [ErrorType]) {
+    public override func willFinishOperation(operation: NSOperation, withErrors errors: [ErrorType]) {
         if errors.isEmpty && operation == get, let contact = get.contact {
             ui = UIOperation(controller: createViewControllerForContact(contact), displayControllerFrom: from, sender: sender)
             addOperation(ui!)

--- a/Sources/Features/Shared/CloudKitOperation.swift
+++ b/Sources/Features/Shared/CloudKitOperation.swift
@@ -783,11 +783,11 @@ public class BatchedCloudKitOperation<T where T: NSOperation, T: CKBatchedOperat
         super.init(generator: anyGenerator(tuple))
     }
 
-    public override func operationDidFinish(operation: NSOperation, withErrors errors: [ErrorType]) {
+    public override func willFinishOperation(operation: NSOperation, withErrors errors: [ErrorType]) {
         if errors.isEmpty, let cloudKitOperation = operation as? CloudKitOperation<T> {
             generator.more = enableBatchProcessing && cloudKitOperation.current.moreComing
         }
-        super.operationDidFinish(operation, withErrors: errors)
+        super.willFinishOperation(operation, withErrors: errors)
     }
 }
 

--- a/Sources/Features/iOS/LocationOperations.swift
+++ b/Sources/Features/iOS/LocationOperations.swift
@@ -320,7 +320,7 @@ public class _ReverseGeocodeUserLocationOperation<Geocoder, Manager where Geocod
         addCondition(MutuallyExclusive<ReverseGeocodeUserLocationOperation>())
     }
 
-    public override func operationDidFinish(operation: NSOperation, withErrors errors: [ErrorType]) {
+    public override func willFinishOperation(operation: NSOperation, withErrors errors: [ErrorType]) {
         if errors.isEmpty && userLocationOperation == operation && !operation.cancelled {
             if let location = location {
                 let reverseOp = _ReverseGeocodeOperation(geocoder: geocoder, location: location) { [unowned self] placemark in

--- a/Sources/Features/iOS/UserConfirmationCondition.swift
+++ b/Sources/Features/iOS/UserConfirmationCondition.swift
@@ -69,15 +69,9 @@ public class UserConfirmationCondition<From: PresentingViewController>: Operatio
     }
 }
 
-extension UserConfirmationCondition: OperationObserver {
+extension UserConfirmationCondition: OperationDidFinishObserver {
 
-    public func operationDidStart(operation: Operation) { /* No operation */ }
-
-    public func operationDidCancel(operation: Operation) { /* No operation */ }
-
-    public func operation(operation: Operation, didProduceOperation newOperation: NSOperation) { /* No operation */ }
-
-    public func operationDidFinish(operation: Operation, errors: [ErrorType]) {
+    public func didFinishOperation(operation: Operation, errors: [ErrorType]) {
         if operation == alert {
             alertOperationErrors = errors
         }

--- a/Tests/Core/BlockConditionTests.swift
+++ b/Tests/Core/BlockConditionTests.swift
@@ -30,7 +30,7 @@ class BlockConditionTests: OperationTests {
         operation.addCondition(BlockCondition { false })
 
         var receivedErrors = [ErrorType]()
-        operation.addObserver(FinishedObserver { _, errors in
+        operation.addObserver(DidFinishObserver { _, errors in
             receivedErrors = errors
             expectation.fulfill()
         })

--- a/Tests/Core/BlockObserverTests.swift
+++ b/Tests/Core/BlockObserverTests.swift
@@ -70,7 +70,20 @@ class BlockObserverTests: OperationTests {
         XCTAssertEqual(counter, 1)
     }
 
-    func test__finish_handler_is_executed() {
+    func test__will_finish_handler_is_executed() {
+        var counter = 0
+        operation.addObserver(BlockObserver(willFinish: { op, errors in
+            counter += 1
+        }))
+
+        addCompletionBlockToTestOperation(operation, withExpectation: expectationWithDescription("Test: \(__FUNCTION__)"))
+        runOperation(operation)
+        waitForExpectationsWithTimeout(3, handler: nil)
+
+        XCTAssertEqual(counter, 1)
+    }
+
+    func test__did_finish_handler_is_executed() {
 
         var counter = 0
         operation.addObserver(BlockObserver { op, errors in

--- a/Tests/Core/LoggingObserverTests.swift
+++ b/Tests/Core/LoggingObserverTests.swift
@@ -53,7 +53,7 @@ class LoggingObserverWithError: LoggingObserverTests {
         addCompletionBlockToTestOperation(operation, withExpectation: expectationWithDescription("Test: \(__FUNCTION__)"))
         runOperation(operation)
         waitForExpectationsWithTimeout(3, handler: nil)
-        XCTAssertTrue(receivedMessages.contains("Test Logging Operation: finished with error(s): [Operations.BlockCondition.Error.BlockConditionFailed]."))
+        XCTAssertTrue(receivedMessages.contains("Test Logging Operation: did finish with error(s): [Operations.BlockCondition.Error.BlockConditionFailed]."))
     }
 }
 

--- a/Tests/Core/NegatedConditionTests.swift
+++ b/Tests/Core/NegatedConditionTests.swift
@@ -17,7 +17,7 @@ class NegatedConditionTests: OperationTests {
         operation.addCondition(NegatedCondition(BlockCondition { true }))
 
         var receivedErrors = [ErrorType]()
-        operation.addObserver(FinishedObserver { _, errors in
+        operation.addObserver(DidFinishObserver { _, errors in
             receivedErrors = errors
             expectation.fulfill()
         })

--- a/Tests/Core/OperationTests.swift
+++ b/Tests/Core/OperationTests.swift
@@ -263,6 +263,15 @@ class BasicTests: OperationTests {
         XCTAssertTrue(operation.cancelled)
         XCTAssertTrue(operation.failed)
     }
+
+    func test__adding_array_of_operations() {
+        let operations = (0..<3).map { _ in BlockOperation {  } }
+        queue.addOperations(operations)
+    }
+
+    func test__adding_variable_argument_of_operations() {
+        queue.addOperations(BlockOperation { }, BlockOperation { })
+    }
 }
 
 class BlockOperationTests: OperationTests {

--- a/Tests/Core/RepeatedOperationTests.swift
+++ b/Tests/Core/RepeatedOperationTests.swift
@@ -355,7 +355,7 @@ class RepeatableRepeatedOperationTests: OperationTests {
         let operation = RepeatedOperation(maxCount: 10) {() -> RepeatableOperation<TestOperation> in
 
             let op = TestOperation(error: TestOperation.Error.SimulatedError)
-            op.addObserver(FinishedObserver { _, e in
+            op.addObserver(DidFinishObserver { _, e in
                 errors.appendContentsOf(e)
             })
 

--- a/Tests/Core/TimeoutObserverTests.swift
+++ b/Tests/Core/TimeoutObserverTests.swift
@@ -18,7 +18,7 @@ class TimeoutObserverTests: OperationTests {
         operation.addObserver(TimeoutObserver(timeout: 0.1))
 
         var receivedErrors: [ErrorType] = []
-        operation.addObserver(FinishedObserver { _, errors in
+        operation.addObserver(DidFinishObserver { _, errors in
             receivedErrors = errors
         })
 

--- a/Tests/Extras/AddressBook/AddressBookConditionTests.swift
+++ b/Tests/Extras/AddressBook/AddressBookConditionTests.swift
@@ -172,7 +172,7 @@ class AddressBookConditionTests: OperationTests {
         let operation = TestOperation()
         operation.addCondition(AddressBookCondition(registrar: registrar))
 
-        operation.addObserver(FinishedObserver { _, errors in
+        operation.addObserver(DidFinishObserver { _, errors in
             receivedErrors = errors
         })
 

--- a/Tests/Features/LocationOperationsTests.swift
+++ b/Tests/Features/LocationOperationsTests.swift
@@ -179,7 +179,7 @@ class UserLocationOperationTests: LocationOperationTests {
         let operation = _UserLocationOperation(manager: locationManager, accuracy: accuracy, completion: { _ in })
 
         var receivedErrors = [ErrorType]()
-        operation.addObserver(FinishedObserver { _, errors in
+        operation.addObserver(DidFinishObserver { _, errors in
             receivedErrors = errors
         })
 
@@ -262,7 +262,7 @@ class ReverseGeocodeOperationTests: LocationOperationTests {
         let operation = _ReverseGeocodeOperation(geocoder: geocoder, location: location, completion: { _ in })
 
         var receivedErrors = [ErrorType]()
-        operation.addObserver(FinishedObserver { _, errors in
+        operation.addObserver(DidFinishObserver { _, errors in
             receivedErrors = errors
         })
 

--- a/Tests/Features/RemoteNotificationConditionTests.swift
+++ b/Tests/Features/RemoteNotificationConditionTests.swift
@@ -54,7 +54,7 @@ class RemoteNotificationConditionTests: OperationTests {
 
         let expectation = expectationWithDescription("Test: \(__FUNCTION__)")
         var receivedErrors = [ErrorType]()
-        operation.addObserver(FinishedObserver { _, errors in
+        operation.addObserver(DidFinishObserver { _, errors in
             receivedErrors = errors
             expectation.fulfill()
         })

--- a/Tests/Features/UserNotificationConditionTests.swift
+++ b/Tests/Features/UserNotificationConditionTests.swift
@@ -68,7 +68,7 @@ class UserNotificationConditionTests: OperationTests {
         
         let expectation = expectationWithDescription("Test: \(__FUNCTION__)")
         var receivedErrors = [ErrorType]()
-        operation.addObserver(FinishedObserver { _, errors in
+        operation.addObserver(DidFinishObserver { _, errors in
             receivedErrors = errors
             expectation.fulfill()
         })


### PR DESCRIPTION
This is to address the points raised in #152 by @jshier. Plus a few things I've noticed subsequently while fixing bugs for v2.6.

- [x] Supports Will/Did Finish
        The reasoning behind this, is that typically, observers want to know when the operation did *actually* finish. This means that `XCTAssertTrue(operation.finished)` should pass. However... `GroupOperation` and its like, will often want to use this observer (or a similar event) to add new operations to the queue. Hence, it used to be posted before the state change. Now, we just have two observers, one before and one after.

- [x] Renames methods to a better Swift style
        For example, instead of `operationDidStart` it is `didStartOperation`. Changed consistently throughout including in `GroupOperation`, which now provides `willFinishOperation` instead of `operationDidFinish` - note that this takes the change above into account too.       

- [x] Adds and calls a method for did attach to operation.
        The base protocol defines `didAttachToOperation` and in an extension, we have a default implementation which currently just logs a `.Verbose` message. In a custom observer, this can be over-ridden as you like.

- [x] Make thread safe & remove asserts from `Operation` when adding an observer.