### PR TITLE
Refactor Observers, part 2

### DIFF
--- a/Sources/Core/Shared/BlockObserver.swift
+++ b/Sources/Core/Shared/BlockObserver.swift
@@ -195,8 +195,14 @@ public struct BlockObserver: OperationObserver {
     let willFinish: WillFinishObserver?
     let didFinish: DidFinishObserver?
 
+    /// - returns: the kind of the observer
+    public let kind: OperationObserverKind
+
     /// - returns: a block which is called when the observer is attached to an operation
     public var didAttachToOperation: DidAttachToOperationBlock? = .None
+
+    /// - returns: a block, called before the observer is detached from the operation.
+    public var willDetachFromOperation: WillDetachFromOperationBlock? = .None
 
     /**
      A `OperationObserver` which accepts three different blocks for start,
@@ -221,6 +227,15 @@ public struct BlockObserver: OperationObserver {
         self.didProduce = didProduce.map { ProducedOperationObserver(didProduce: $0) }
         self.willFinish = willFinish.map { WillFinishObserver(willFinish: $0) }
         self.didFinish = didFinish.map { DidFinishObserver(didFinish: $0) }
+        self.kind = {
+            var kind: OperationObserverKind = []
+            if didStart != nil { kind.insert(.DidStart) }
+            if didCancel != nil { kind.insert(.DidCancel) }
+            if didProduce != nil { kind.insert(.DidProduceOperation) }
+            if willFinish != nil { kind.insert(.WillFinish) }
+            if didFinish != nil { kind.insert(.DidFinish) }
+            return kind
+        }()
     }
 
     /// Conforms to `OperationObserver`, executes the optional startHandler.

--- a/Sources/Core/Shared/BlockObserver.swift
+++ b/Sources/Core/Shared/BlockObserver.swift
@@ -8,14 +8,19 @@
 
 import Foundation
 
+public typealias DidAttachToOperationBlock = (operation: Operation) -> Void
+
 /**
  StartedObserver is an observer which will execute a
  closure when the operation starts.
 */
 public struct StartedObserver: OperationDidStartObserver {
-    public typealias BlockType = Operation -> Void
+    public typealias BlockType = (operation: Operation) -> Void
 
     private let block: BlockType
+
+    /// - returns: a block which is called when the observer is attached to an operation
+    public var didAttachToOperation: DidAttachToOperationBlock? = .None
 
     /**
      Initialize the observer with a block.
@@ -29,7 +34,12 @@ public struct StartedObserver: OperationDidStartObserver {
 
     /// Conforms to `OperationDidStartObserver`, executes the block
     public func didStartOperation(operation: Operation) {
-        block(operation)
+        block(operation: operation)
+    }
+
+    /// Base OperationObserverType method
+    public func didAttachToOperation(operation: Operation) {
+        didAttachToOperation?(operation: operation)
     }
 }
 
@@ -39,9 +49,12 @@ public struct StartedObserver: OperationDidStartObserver {
  closure when the operation cancels.
  */
 public struct CancelledObserver: OperationDidCancelObserver {
-    public typealias BlockType = Operation -> Void
+    public typealias BlockType = (operation: Operation) -> Void
 
     private let block: BlockType
+
+    /// - returns: a block which is called when the observer is attached to an operation
+    public var didAttachToOperation: DidAttachToOperationBlock? = .None
 
     /**
      Initialize the observer with a block.
@@ -55,7 +68,12 @@ public struct CancelledObserver: OperationDidCancelObserver {
 
     /// Conforms to `OperationDidCancelObserver`, executes the block
     public func didCancelOperation(operation: Operation) {
-        block(operation)
+        block(operation: operation)
+    }
+
+    /// Base OperationObserverType method
+    public func didAttachToOperation(operation: Operation) {
+        didAttachToOperation?(operation: operation)
     }
 }
 
@@ -65,9 +83,12 @@ public struct CancelledObserver: OperationDidCancelObserver {
  closure when the operation produces another observer.
  */
 public struct ProducedOperationObserver: OperationDidProduceOperationObserver {
-    public typealias BlockType = (Operation, NSOperation) -> Void
+    public typealias BlockType = (operation: Operation, produced: NSOperation) -> Void
 
     private let block: BlockType
+
+    /// - returns: a block which is called when the observer is attached to an operation
+    public var didAttachToOperation: DidAttachToOperationBlock? = .None
 
     /**
      Initialize the observer with a block.
@@ -81,7 +102,12 @@ public struct ProducedOperationObserver: OperationDidProduceOperationObserver {
 
     /// Conforms to `OperationDidProduceOperationObserver`, executes the block
     public func operation(operation: Operation, didProduceOperation newOperation: NSOperation) {
-        block(operation, newOperation)
+        block(operation: operation, produced: newOperation)
+    }
+
+    /// Base OperationObserverType method
+    public func didAttachToOperation(operation: Operation) {
+        didAttachToOperation?(operation: operation)
     }
 }
 
@@ -91,9 +117,12 @@ public struct ProducedOperationObserver: OperationDidProduceOperationObserver {
  closure when the operation is about to finish.
  */
 public struct WillFinishObserver: OperationWillFinishObserver {
-    public typealias BlockType = (Operation, [ErrorType]) -> Void
+    public typealias BlockType = (operation: Operation, errors: [ErrorType]) -> Void
 
     private let block: BlockType
+
+    /// - returns: a block which is called when the observer is attached to an operation
+    public var didAttachToOperation: DidAttachToOperationBlock? = .None
 
     /**
      Initialize the observer with a block.
@@ -107,7 +136,12 @@ public struct WillFinishObserver: OperationWillFinishObserver {
 
     /// Conforms to `OperationWillFinishObserver`, executes the block
     public func willFinishOperation(operation: Operation, errors: [ErrorType]) {
-        block(operation, errors)
+        block(operation: operation, errors: errors)
+    }
+
+    /// Base OperationObserverType method
+    public func didAttachToOperation(operation: Operation) {
+        didAttachToOperation?(operation: operation)
     }
 }
 
@@ -117,9 +151,12 @@ public struct WillFinishObserver: OperationWillFinishObserver {
  closure when the operation did just finish.
  */
 public struct DidFinishObserver: OperationDidFinishObserver {
-    public typealias BlockType = (Operation, [ErrorType]) -> Void
+    public typealias BlockType = (operation: Operation, errors: [ErrorType]) -> Void
 
     private let block: BlockType
+
+    /// - returns: a block which is called when the observer is attached to an operation
+    public var didAttachToOperation: DidAttachToOperationBlock? = .None
 
     /**
      Initialize the observer with a block.
@@ -133,7 +170,12 @@ public struct DidFinishObserver: OperationDidFinishObserver {
 
     /// Conforms to `OperationDidFinishObserver`, executes the block
     public func didFinishOperation(operation: Operation, errors: [ErrorType]) {
-        block(operation, errors)
+        block(operation: operation, errors: errors)
+    }
+
+    /// Base OperationObserverType method
+    public func didAttachToOperation(operation: Operation) {
+        didAttachToOperation?(operation: operation)
     }
 }
 
@@ -152,6 +194,9 @@ public struct BlockObserver: OperationObserver {
     let didProduce: ProducedOperationObserver?
     let willFinish: WillFinishObserver?
     let didFinish: DidFinishObserver?
+
+    /// - returns: a block which is called when the observer is attached to an operation
+    public var didAttachToOperation: DidAttachToOperationBlock? = .None
 
     /**
      A `OperationObserver` which accepts three different blocks for start,
@@ -201,6 +246,11 @@ public struct BlockObserver: OperationObserver {
     /// Conforms to `OperationObserver`, executes the optional didFinish.
     public func didFinishOperation(operation: Operation, errors: [ErrorType]) {
         didFinish?.didFinishOperation(operation, errors: errors)
+    }
+
+    /// Base OperationObserverType method
+    public func didAttachToOperation(operation: Operation) {
+        didAttachToOperation?(operation: operation)
     }
 }
 

--- a/Sources/Core/Shared/BlockObserver.swift
+++ b/Sources/Core/Shared/BlockObserver.swift
@@ -196,13 +196,10 @@ public struct BlockObserver: OperationObserver {
     let didFinish: DidFinishObserver?
 
     /// - returns: the kind of the observer
-    public let kind: OperationObserverKind
+    public let events: OperationObserverEvents
 
     /// - returns: a block which is called when the observer is attached to an operation
     public var didAttachToOperation: DidAttachToOperationBlock? = .None
-
-    /// - returns: a block, called before the observer is detached from the operation.
-    public var willDetachFromOperation: WillDetachFromOperationBlock? = .None
 
     /**
      A `OperationObserver` which accepts three different blocks for start,
@@ -227,14 +224,14 @@ public struct BlockObserver: OperationObserver {
         self.didProduce = didProduce.map { ProducedOperationObserver(didProduce: $0) }
         self.willFinish = willFinish.map { WillFinishObserver(willFinish: $0) }
         self.didFinish = didFinish.map { DidFinishObserver(didFinish: $0) }
-        self.kind = {
-            var kind: OperationObserverKind = []
-            if didStart != nil { kind.insert(.DidStart) }
-            if didCancel != nil { kind.insert(.DidCancel) }
-            if didProduce != nil { kind.insert(.DidProduceOperation) }
-            if willFinish != nil { kind.insert(.WillFinish) }
-            if didFinish != nil { kind.insert(.DidFinish) }
-            return kind
+        self.events = {
+            var e: OperationObserverEvents = []
+            if didStart != nil { e.insert(.DidStart) }
+            if didCancel != nil { e.insert(.DidCancel) }
+            if didProduce != nil { e.insert(.DidProduceOperation) }
+            if willFinish != nil { e.insert(.WillFinish) }
+            if didFinish != nil { e.insert(.DidFinish) }
+            return e
         }()
     }
 

--- a/Sources/Core/Shared/LoggingObserver.swift
+++ b/Sources/Core/Shared/LoggingObserver.swift
@@ -24,7 +24,7 @@ public struct LoggingObserver: OperationObserver {
     let queue: dispatch_queue_t
 
     /// - returns: the kind of the observer
-    public let kind: OperationObserverKind = .All
+    public let events: OperationObserverEvents = .All
 
     /**
     Create a logging observer. Accepts as the final argument a block which receives a

--- a/Sources/Core/Shared/LoggingObserver.swift
+++ b/Sources/Core/Shared/LoggingObserver.swift
@@ -23,6 +23,9 @@ public struct LoggingObserver: OperationObserver {
     let logger: LoggerBlockType
     let queue: dispatch_queue_t
 
+    /// - returns: the kind of the observer
+    public let kind: OperationObserverKind = .All
+
     /**
     Create a logging observer. Accepts as the final argument a block which receives a
     `String` message to be logged. By default this just uses `print()`, but construct 

--- a/Sources/Core/Shared/OperationObserver.swift
+++ b/Sources/Core/Shared/OperationObserver.swift
@@ -20,6 +20,15 @@ public protocol OperationObserverType {
      - parameter operation: the observed `Operation`.
     */
     func didAttachToOperation(operation: Operation)
+
+    /**
+     Observer gets notified when it will be detached from 
+     the operation. This will happen after all relevant events
+     have been observed.
+
+     - parameter operation: the observed `Operation`.
+     */
+    func willDetachFromOperation(operation: Operation)
 }
 
 
@@ -27,11 +36,20 @@ public protocol OperationObserverType {
 public extension OperationObserverType {
 
     /**
-     Default implementation is a no-operation.
+     Default implementation of didAttachToOperation 
+     is a none-operation.
      
      - parameter operation: the observed `Operation`.
     */
     func didAttachToOperation(operation: Operation) { /* No operation */ }
+
+    /**
+    Default implementation of willDetachFromOperation
+    is a none-operation.
+
+    - parameter operation: the observed `Operation`.
+    */
+    func willDetachFromOperation(operation: Operation) { /* No operation */ }
 }
 
 

--- a/Sources/Core/Shared/OperationObserver.swift
+++ b/Sources/Core/Shared/OperationObserver.swift
@@ -8,11 +8,26 @@
 
 import Foundation
 
+public struct OperationObserverKind: OptionSetType {
+    public let rawValue: Int
+
+    static let DidStart = OperationObserverKind(rawValue: 1 << 1)
+    static let DidCancel = OperationObserverKind(rawValue: 1 << 2)
+    static let DidProduceOperation = OperationObserverKind(rawValue: 1 << 3)
+    static let WillFinish = OperationObserverKind(rawValue: 1 << 4)
+    static let DidFinish = OperationObserverKind(rawValue: 1 << 5)
+    static let All: OperationObserverKind = [ .DidStart, .DidCancel, .DidProduceOperation, .WillFinish, .DidFinish ]
+
+    public init(rawValue: Int) { self.rawValue = rawValue }
+}
+
 /**
  Types which conform to this protocol, can be attached to `Operation` subclasses before
  they are added to a queue.
  */
 public protocol OperationObserverType {
+
+    var kind: OperationObserverKind { get }
 
     /**
      Observer gets notified when it is attached to an operation.
@@ -68,6 +83,11 @@ public protocol OperationDidStartObserver: OperationObserverType {
     func didStartOperation(operation: Operation)
 }
 
+public extension OperationDidStartObserver {
+
+    /// - returns: the kind of the observer
+    var kind: OperationObserverKind { return .DidStart }
+}
 
 
 /**
@@ -82,6 +102,12 @@ public protocol OperationDidCancelObserver: OperationObserverType {
      - parameter operation: the observed `Operation`.
      */
     func didCancelOperation(operation: Operation)
+}
+
+public extension OperationDidCancelObserver {
+
+    /// - returns: the kind of the observer
+    var kind: OperationObserverKind { return .DidCancel }
 }
 
 
@@ -104,6 +130,12 @@ public protocol OperationDidProduceOperationObserver: OperationObserverType {
     func operation(operation: Operation, didProduceOperation newOperation: NSOperation)
 }
 
+public extension OperationDidProduceOperationObserver {
+
+    /// - returns: the kind of the observer
+    var kind: OperationObserverKind { return .DidProduceOperation }
+}
+
 
 
 /**
@@ -118,6 +150,12 @@ public protocol OperationWillFinishObserver: OperationObserverType {
      - parameter errors: an array of `ErrorType`s.
      */
     func willFinishOperation(operation: Operation, errors: [ErrorType])
+}
+
+public extension OperationWillFinishObserver {
+
+    /// - returns: the kind of the observer
+    var kind: OperationObserverKind { return .WillFinish }
 }
 
 
@@ -135,6 +173,12 @@ public protocol OperationDidFinishObserver: OperationObserverType {
      - parameter errors: an array of `ErrorType`s.
      */
     func didFinishOperation(operation: Operation, errors: [ErrorType])
+}
+
+public extension OperationDidFinishObserver {
+
+    /// - returns: the kind of the observer
+    var kind: OperationObserverKind { return .DidFinish }
 }
 
 

--- a/Sources/Core/Shared/OperationObserver.swift
+++ b/Sources/Core/Shared/OperationObserver.swift
@@ -8,15 +8,15 @@
 
 import Foundation
 
-public struct OperationObserverKind: OptionSetType {
+public struct OperationObserverEvents: OptionSetType {
     public let rawValue: Int
 
-    static let DidStart = OperationObserverKind(rawValue: 1 << 1)
-    static let DidCancel = OperationObserverKind(rawValue: 1 << 2)
-    static let DidProduceOperation = OperationObserverKind(rawValue: 1 << 3)
-    static let WillFinish = OperationObserverKind(rawValue: 1 << 4)
-    static let DidFinish = OperationObserverKind(rawValue: 1 << 5)
-    static let All: OperationObserverKind = [ .DidStart, .DidCancel, .DidProduceOperation, .WillFinish, .DidFinish ]
+    static let DidStart = OperationObserverEvents(rawValue: 1 << 1)
+    static let DidProduceOperation = OperationObserverEvents(rawValue: 1 << 2)
+    static let WillFinish = OperationObserverEvents(rawValue: 1 << 3)
+    static let DidFinish = OperationObserverEvents(rawValue: 1 << 4)
+    static let DidCancel = OperationObserverEvents(rawValue: 1 << 5)
+    static let All: OperationObserverEvents = [ .DidStart, .DidProduceOperation, .WillFinish, .DidFinish, .DidCancel ]
 
     public init(rawValue: Int) { self.rawValue = rawValue }
 }
@@ -27,7 +27,7 @@ public struct OperationObserverKind: OptionSetType {
  */
 public protocol OperationObserverType {
 
-    var kind: OperationObserverKind { get }
+    var events: OperationObserverEvents { get }
 
     /**
      Observer gets notified when it is attached to an operation.
@@ -35,15 +35,6 @@ public protocol OperationObserverType {
      - parameter operation: the observed `Operation`.
     */
     func didAttachToOperation(operation: Operation)
-
-    /**
-     Observer gets notified when it will be detached from 
-     the operation. This will happen after all relevant events
-     have been observed.
-
-     - parameter operation: the observed `Operation`.
-     */
-    func willDetachFromOperation(operation: Operation)
 }
 
 
@@ -57,14 +48,6 @@ public extension OperationObserverType {
      - parameter operation: the observed `Operation`.
     */
     func didAttachToOperation(operation: Operation) { /* No operation */ }
-
-    /**
-    Default implementation of willDetachFromOperation
-    is a none-operation.
-
-    - parameter operation: the observed `Operation`.
-    */
-    func willDetachFromOperation(operation: Operation) { /* No operation */ }
 }
 
 
@@ -86,7 +69,7 @@ public protocol OperationDidStartObserver: OperationObserverType {
 public extension OperationDidStartObserver {
 
     /// - returns: the kind of the observer
-    var kind: OperationObserverKind { return .DidStart }
+    var events: OperationObserverEvents { return .DidStart }
 }
 
 
@@ -107,7 +90,7 @@ public protocol OperationDidCancelObserver: OperationObserverType {
 public extension OperationDidCancelObserver {
 
     /// - returns: the kind of the observer
-    var kind: OperationObserverKind { return .DidCancel }
+    var events: OperationObserverEvents { return .DidCancel }
 }
 
 
@@ -133,7 +116,7 @@ public protocol OperationDidProduceOperationObserver: OperationObserverType {
 public extension OperationDidProduceOperationObserver {
 
     /// - returns: the kind of the observer
-    var kind: OperationObserverKind { return .DidProduceOperation }
+    var events: OperationObserverEvents { return .DidProduceOperation }
 }
 
 
@@ -155,7 +138,7 @@ public protocol OperationWillFinishObserver: OperationObserverType {
 public extension OperationWillFinishObserver {
 
     /// - returns: the kind of the observer
-    var kind: OperationObserverKind { return .WillFinish }
+    var events: OperationObserverEvents { return .WillFinish }
 }
 
 
@@ -178,7 +161,7 @@ public protocol OperationDidFinishObserver: OperationObserverType {
 public extension OperationDidFinishObserver {
 
     /// - returns: the kind of the observer
-    var kind: OperationObserverKind { return .DidFinish }
+    var events: OperationObserverEvents { return .DidFinish }
 }
 
 

--- a/Sources/Core/iOS/NetworkObserver.swift
+++ b/Sources/Core/iOS/NetworkObserver.swift
@@ -24,7 +24,7 @@ public class NetworkObserver: OperationDidStartObserver, OperationDidFinishObser
     let networkActivityIndicator: NetworkActivityIndicatorInterface
 
     /// - returns: the kind of the observer
-    public let kind: OperationObserverKind = [ .DidStart, .DidFinish ]
+    public let events: OperationObserverEvents = [ .DidStart, .DidFinish ]
 
     /// Initializer takes no parameters.
     public convenience init() {

--- a/Sources/Core/iOS/NetworkObserver.swift
+++ b/Sources/Core/iOS/NetworkObserver.swift
@@ -23,6 +23,9 @@ public class NetworkObserver: OperationDidStartObserver, OperationDidFinishObser
 
     let networkActivityIndicator: NetworkActivityIndicatorInterface
 
+    /// - returns: the kind of the observer
+    public let kind: OperationObserverKind = [ .DidStart, .DidFinish ]
+
     /// Initializer takes no parameters.
     public convenience init() {
         self.init(indicator: UIApplication.sharedApplication())

--- a/Tests/Core/BlockObserverTests.swift
+++ b/Tests/Core/BlockObserverTests.swift
@@ -9,10 +9,10 @@
 import XCTest
 @testable import Operations
 
-class BlockObserverTests: OperationTests {
+class BaseBlockObserverTests: OperationTests {
 
     var operation: TestOperation!
-    
+
     override func setUp() {
         super.setUp()
         operation = TestOperation()
@@ -22,7 +22,219 @@ class BlockObserverTests: OperationTests {
         operation = nil
         super.tearDown()
     }
-    
+}
+
+class StartedObserverTests: BaseBlockObserverTests {
+
+    var called_didAttachToOperation: Operation? = .None
+    var called_didStartOperation: Operation? = .None
+    var observer: StartedObserver!
+
+    override func setUp() {
+        super.setUp()
+        observer = StartedObserver { [unowned self] op in
+            self.called_didStartOperation = op
+        }
+        observer.didAttachToOperation = { [unowned self] op in
+            self.called_didAttachToOperation = op
+        }
+    }
+
+    func test__did_attach_block_is_called() {
+        operation.addObserver(observer)
+        XCTAssertEqual(called_didAttachToOperation, operation)
+    }
+
+    func test__observer_receives_did_starter() {
+        operation.addObserver(observer)
+
+        addCompletionBlockToTestOperation(operation)
+        runOperation(operation)
+        waitForExpectationsWithTimeout(3.0, handler: nil)
+
+        XCTAssertEqual(called_didStartOperation, operation)
+    }
+}
+
+class CancelledObserverTests: BaseBlockObserverTests {
+
+    var called_didAttachToOperation: Operation? = .None
+    var called_didCancelOperation: Operation? = .None
+    var observer: CancelledObserver!
+
+    override func setUp() {
+        super.setUp()
+        observer = CancelledObserver { [unowned self] op in
+            self.called_didCancelOperation = op
+        }
+        observer.didAttachToOperation = { [unowned self] op in
+            self.called_didAttachToOperation = op
+        }
+    }
+
+    func test__did_attach_block_is_called() {
+        operation.addObserver(observer)
+        XCTAssertEqual(called_didAttachToOperation, operation)
+    }
+
+    func test__cancel_before_adding_to_queue() {
+        operation.addObserver(observer)
+        operation.cancel()
+        XCTAssertEqual(called_didCancelOperation, operation)
+        XCTAssertTrue(operation.cancelled)
+    }
+
+    func test__cancel_after_adding_to_queue() {
+        operation.addObserver(observer)
+
+        addCompletionBlockToTestOperation(operation)
+        runOperation(operation)
+        operation.cancel()
+        waitForExpectationsWithTimeout(3.0, handler: nil)
+
+        XCTAssertEqual(called_didCancelOperation, operation)
+        XCTAssertTrue(operation.cancelled)
+    }
+}
+
+class ProducedOperationObserverTests: BaseBlockObserverTests {
+
+    var called_didAttachToOperation: Operation? = .None
+    var called_didProduceOperation: (Operation, NSOperation)? = .None
+    var observer: ProducedOperationObserver!
+    var produced: NSBlockOperation!
+
+    override func setUp() {
+        super.setUp()
+        produced = NSBlockOperation { }
+        operation = TestOperation(produced: produced)
+        observer = ProducedOperationObserver { [unowned self] op, produced in
+            self.called_didProduceOperation = (op, produced)
+        }
+        observer.didAttachToOperation = { [unowned self] op in
+            self.called_didAttachToOperation = op
+        }
+    }
+
+    func test__did_attach_block_is_called() {
+        operation.addObserver(observer)
+        XCTAssertEqual(called_didAttachToOperation, operation)
+    }
+
+    func test__did_produce_operation_block_is_called() {
+        operation.addObserver(observer)
+
+        addCompletionBlockToTestOperation(operation)
+        runOperation(operation)
+        waitForExpectationsWithTimeout(3.0, handler: nil)
+
+        XCTAssertEqual(called_didProduceOperation?.0, operation)
+        XCTAssertEqual(called_didProduceOperation?.1, produced)
+    }
+}
+
+class WillFinishObserverTests: BaseBlockObserverTests {
+
+    var called_didAttachToOperation: Operation? = .None
+    var called_willFinish: (Operation, [ErrorType])? = .None
+    var observer: WillFinishObserver!
+
+    override func setUp() {
+        super.setUp()
+        observer = WillFinishObserver { [unowned self] op, errors in
+            self.called_willFinish = (op, errors)
+        }
+        observer.didAttachToOperation = { [unowned self] op in
+            self.called_didAttachToOperation = op
+        }
+    }
+
+    func test__did_attach_block_is_called() {
+        operation.addObserver(observer)
+        XCTAssertEqual(called_didAttachToOperation, operation)
+    }
+
+    func test__will_finish_block_is_called() {
+        operation.addObserver(observer)
+
+        addCompletionBlockToTestOperation(operation)
+        runOperation(operation)
+        waitForExpectationsWithTimeout(3.0, handler: nil)
+
+        XCTAssertEqual(called_willFinish?.0, operation)
+        XCTAssertTrue(called_willFinish?.1.isEmpty ?? false)
+    }
+
+    func test__will_finish_block_with_errors() {
+        operation = TestOperation(error: TestOperation.Error.SimulatedError)
+        operation.addObserver(observer)
+
+        addCompletionBlockToTestOperation(operation)
+        runOperation(operation)
+        waitForExpectationsWithTimeout(3.0, handler: nil)
+
+        XCTAssertEqual(called_willFinish?.0, operation)
+        XCTAssertEqual(called_willFinish?.1.count ?? 0, 1)
+    }
+}
+
+class DidFinishObserverTests: BaseBlockObserverTests {
+
+    var called_didAttachToOperation: Operation? = .None
+    var called_didFinish: (Operation, [ErrorType])? = .None
+    var observer: DidFinishObserver!
+
+    override func setUp() {
+        super.setUp()
+        observer = DidFinishObserver { [unowned self] op, errors in
+            self.called_didFinish = (op, errors)
+        }
+        observer.didAttachToOperation = { [unowned self] op in
+            self.called_didAttachToOperation = op
+        }
+    }
+
+    func test__did_attach_block_is_called() {
+        operation.addObserver(observer)
+        XCTAssertEqual(called_didAttachToOperation, operation)
+    }
+
+    func test__did_finish_block_is_called() {
+        operation.addObserver(observer)
+
+        addCompletionBlockToTestOperation(operation)
+        runOperation(operation)
+        waitForExpectationsWithTimeout(3.0, handler: nil)
+
+        XCTAssertEqual(called_didFinish?.0, operation)
+        XCTAssertTrue(called_didFinish?.1.isEmpty ?? false)
+    }
+
+    func test__will_finish_block_with_errors() {
+        operation = TestOperation(error: TestOperation.Error.SimulatedError)
+        operation.addObserver(observer)
+
+        addCompletionBlockToTestOperation(operation)
+        runOperation(operation)
+        waitForExpectationsWithTimeout(3.0, handler: nil)
+
+        XCTAssertEqual(called_didFinish?.0, operation)
+        XCTAssertEqual(called_didFinish?.1.count ?? 0, 1)
+    }
+}
+
+class BlockObserverTests: BaseBlockObserverTests {
+
+    func test__did_attach_block_is_called() {
+        var called_didAttachToOperation: Operation? = .None
+        var observer = BlockObserver { _, _ in }
+        observer.didAttachToOperation = { op in
+            called_didAttachToOperation = op
+        }
+        operation.addObserver(observer)
+        XCTAssertEqual(called_didAttachToOperation, operation)
+    }
+
     func test__start_handler_is_executed() {
 
         var counter = 0

--- a/Tests/Core/GroupOperationTests.swift
+++ b/Tests/Core/GroupOperationTests.swift
@@ -103,7 +103,6 @@ class GroupOperationTests: OperationTests {
         }
 
         let group = GroupOperation(operations: operations)
-        group.log.severity = .Verbose
 
         let waiter = BlockOperation { }
         waiter.addDependency(group)


### PR DESCRIPTION
- [x] Add property for `didAttach` to all the block based observers.
- [x] Add labels to the closures used in the block based observers.
- [x] Added `events` option set property to Observer protocols. This isn't actually used yet, but figured it is actually quite handy to be able to inspect which events an observer is interested in without so much optional casting.

~~- [ ] Add `willDetachFromOperation` to the base protocol~~ - This is actually a little bit harder to figure out. Probably not worth the extra blocking calls to remove the observers. Especially as we'd have to figure out which ones are safe to remove.

~~- [ ] Prune observers from the `Operation` after their last event has been observed.~~

~~- [ ] Add property for `willDetach` to all the block based observers.~~