### PR TITLE
Refactoring Operation Observers, part 3

### DIFF
--- a/Sources/Core/Shared/BlockObserver.swift
+++ b/Sources/Core/Shared/BlockObserver.swift
@@ -195,9 +195,6 @@ public struct BlockObserver: OperationObserver {
     let willFinish: WillFinishObserver?
     let didFinish: DidFinishObserver?
 
-    /// - returns: the kind of the observer
-    public let events: OperationObserverEvents
-
     /// - returns: a block which is called when the observer is attached to an operation
     public var didAttachToOperation: DidAttachToOperationBlock? = .None
 
@@ -224,15 +221,6 @@ public struct BlockObserver: OperationObserver {
         self.didProduce = didProduce.map { ProducedOperationObserver(didProduce: $0) }
         self.willFinish = willFinish.map { WillFinishObserver(willFinish: $0) }
         self.didFinish = didFinish.map { DidFinishObserver(didFinish: $0) }
-        self.events = {
-            var e: OperationObserverEvents = []
-            if didStart != nil { e.insert(.DidStart) }
-            if didCancel != nil { e.insert(.DidCancel) }
-            if didProduce != nil { e.insert(.DidProduceOperation) }
-            if willFinish != nil { e.insert(.WillFinish) }
-            if didFinish != nil { e.insert(.DidFinish) }
-            return e
-        }()
     }
 
     /// Conforms to `OperationObserver`, executes the optional startHandler.

--- a/Sources/Core/Shared/LoggingObserver.swift
+++ b/Sources/Core/Shared/LoggingObserver.swift
@@ -23,9 +23,6 @@ public struct LoggingObserver: OperationObserver {
     let logger: LoggerBlockType
     let queue: dispatch_queue_t
 
-    /// - returns: the kind of the observer
-    public let events: OperationObserverEvents = .All
-
     /**
     Create a logging observer. Accepts as the final argument a block which receives a
     `String` message to be logged. By default this just uses `print()`, but construct 

--- a/Sources/Core/Shared/OperationObserver.swift
+++ b/Sources/Core/Shared/OperationObserver.swift
@@ -11,12 +11,12 @@ import Foundation
 public struct OperationObserverEvents: OptionSetType {
     public let rawValue: Int
 
-    static let DidStart = OperationObserverEvents(rawValue: 1 << 1)
-    static let DidProduceOperation = OperationObserverEvents(rawValue: 1 << 2)
-    static let WillFinish = OperationObserverEvents(rawValue: 1 << 3)
-    static let DidFinish = OperationObserverEvents(rawValue: 1 << 4)
-    static let DidCancel = OperationObserverEvents(rawValue: 1 << 5)
-    static let All: OperationObserverEvents = [ .DidStart, .DidProduceOperation, .WillFinish, .DidFinish, .DidCancel ]
+    public static let DidStart = OperationObserverEvents(rawValue: 1 << 1)
+    public static let DidProduceOperation = OperationObserverEvents(rawValue: 1 << 2)
+    public static let WillFinish = OperationObserverEvents(rawValue: 1 << 3)
+    public static let DidFinish = OperationObserverEvents(rawValue: 1 << 4)
+    public static let DidCancel = OperationObserverEvents(rawValue: 1 << 5)
+    public static let All: OperationObserverEvents = [ .DidStart, .DidProduceOperation, .WillFinish, .DidFinish, .DidCancel ]
 
     public init(rawValue: Int) { self.rawValue = rawValue }
 }

--- a/Sources/Core/Shared/OperationObserver.swift
+++ b/Sources/Core/Shared/OperationObserver.swift
@@ -8,26 +8,11 @@
 
 import Foundation
 
-public struct OperationObserverEvents: OptionSetType {
-    public let rawValue: Int
-
-    public static let DidStart = OperationObserverEvents(rawValue: 1 << 1)
-    public static let DidProduceOperation = OperationObserverEvents(rawValue: 1 << 2)
-    public static let WillFinish = OperationObserverEvents(rawValue: 1 << 3)
-    public static let DidFinish = OperationObserverEvents(rawValue: 1 << 4)
-    public static let DidCancel = OperationObserverEvents(rawValue: 1 << 5)
-    public static let All: OperationObserverEvents = [ .DidStart, .DidProduceOperation, .WillFinish, .DidFinish, .DidCancel ]
-
-    public init(rawValue: Int) { self.rawValue = rawValue }
-}
-
 /**
  Types which conform to this protocol, can be attached to `Operation` subclasses before
  they are added to a queue.
  */
 public protocol OperationObserverType {
-
-    var events: OperationObserverEvents { get }
 
     /**
      Observer gets notified when it is attached to an operation.
@@ -66,12 +51,6 @@ public protocol OperationDidStartObserver: OperationObserverType {
     func didStartOperation(operation: Operation)
 }
 
-public extension OperationDidStartObserver {
-
-    /// - returns: the kind of the observer
-    var events: OperationObserverEvents { return .DidStart }
-}
-
 
 /**
  Types which conform to this protocol, can be attached to `Operation` subclasses before
@@ -86,13 +65,6 @@ public protocol OperationDidCancelObserver: OperationObserverType {
      */
     func didCancelOperation(operation: Operation)
 }
-
-public extension OperationDidCancelObserver {
-
-    /// - returns: the kind of the observer
-    var events: OperationObserverEvents { return .DidCancel }
-}
-
 
 
 /**
@@ -113,13 +85,6 @@ public protocol OperationDidProduceOperationObserver: OperationObserverType {
     func operation(operation: Operation, didProduceOperation newOperation: NSOperation)
 }
 
-public extension OperationDidProduceOperationObserver {
-
-    /// - returns: the kind of the observer
-    var events: OperationObserverEvents { return .DidProduceOperation }
-}
-
-
 
 /**
  Types which confirm to this protocol, can be attached to `Operation` subclasses.
@@ -134,13 +99,6 @@ public protocol OperationWillFinishObserver: OperationObserverType {
      */
     func willFinishOperation(operation: Operation, errors: [ErrorType])
 }
-
-public extension OperationWillFinishObserver {
-
-    /// - returns: the kind of the observer
-    var events: OperationObserverEvents { return .WillFinish }
-}
-
 
 
 /**
@@ -157,13 +115,6 @@ public protocol OperationDidFinishObserver: OperationObserverType {
      */
     func didFinishOperation(operation: Operation, errors: [ErrorType])
 }
-
-public extension OperationDidFinishObserver {
-
-    /// - returns: the kind of the observer
-    var events: OperationObserverEvents { return .DidFinish }
-}
-
 
 
 /**

--- a/Sources/Core/iOS/NetworkObserver.swift
+++ b/Sources/Core/iOS/NetworkObserver.swift
@@ -23,9 +23,6 @@ public class NetworkObserver: OperationDidStartObserver, OperationDidFinishObser
 
     let networkActivityIndicator: NetworkActivityIndicatorInterface
 
-    /// - returns: the kind of the observer
-    public let events: OperationObserverEvents = [ .DidStart, .DidFinish ]
-
     /// Initializer takes no parameters.
     public convenience init() {
         self.init(indicator: UIApplication.sharedApplication())


### PR DESCRIPTION
- [x] Make the static types on `OperationObserverEvent` public
- [x] Remove the `events` property entirely.

Essentially, this got left in here from previous work, it's not used yet. Should be made correct, then removes.