### PR TITLE
Refactor RepeatedOperation initializers

### DIFF
--- a/Sources/Core/Shared/RepeatedOperation.swift
+++ b/Sources/Core/Shared/RepeatedOperation.swift
@@ -495,17 +495,17 @@ public protocol Repeatable {
     func shouldRepeat(count: Int) -> Bool
 }
 
-class RepeatingGenerator<G: GeneratorType where G.Element: Repeatable>: GeneratorType {
+public class RepeatableGenerator<G: GeneratorType where G.Element: Repeatable>: GeneratorType {
 
     private var generator: G
     private var count: Int = 0
     private var current: G.Element?
 
-    init(_ generator: G) {
+    public init(_ generator: G) {
         self.generator = generator
     }
 
-    func next() -> G.Element? {
+    public func next() -> G.Element? {
         if let current = current {
             guard current.shouldRepeat(count) else {
                 return nil
@@ -528,7 +528,7 @@ extension RepeatedOperation where T: Repeatable {
      ```
     */
     public convenience init(maxCount max: Int? = .None, strategy: WaitStrategy = .Fixed(0.1), body: () -> T?) {
-        self.init(maxCount: max, strategy: strategy, generator: RepeatingGenerator(anyGenerator(body)))
+        self.init(maxCount: max, strategy: strategy, generator: RepeatableGenerator(anyGenerator(body)))
     }
 }
 

--- a/Sources/Core/Shared/RepeatedOperation.swift
+++ b/Sources/Core/Shared/RepeatedOperation.swift
@@ -287,13 +287,7 @@ public class RepeatedOperation<T where T: NSOperation>: GroupOperation {
     internal private(set) var configure: T -> Void = { _ in }
 
     static func createPayloadGeneratorWithMaxCount(max: Int? = .None, generator gen: AnyGenerator<Payload>) -> AnyGenerator<Payload> {
-        switch max {
-        case .Some(let max):
-            // Subtract 1 to account for the 1st attempt
-            return anyGenerator(FiniteGenerator(gen, limit: max - 1))
-        case .None:
-            return gen
-        }
+        return max.map { anyGenerator(FiniteGenerator(gen, limit: $0 - 1)) } ?? gen
     }
     
     /**

--- a/Sources/Core/Shared/RepeatedOperation.swift
+++ b/Sources/Core/Shared/RepeatedOperation.swift
@@ -527,8 +527,8 @@ extension RepeatedOperation where T: Repeatable {
      let operation = RepeatedOperation { MyRepeatableOperation() }
      ```
     */
-    public convenience init(strategy: WaitStrategy = .Fixed(0.1), maxCount max: Int? = .None, body: () -> T?) {
-        self.init(strategy: strategy, maxCount: max, generator: RepeatingGenerator(anyGenerator(body)))
+    public convenience init(maxCount max: Int? = .None, strategy: WaitStrategy = .Fixed(0.1), body: () -> T?) {
+        self.init(maxCount: max, strategy: strategy, generator: RepeatingGenerator(anyGenerator(body)))
     }
 }
 

--- a/Sources/Core/Shared/RetryOperation.swift
+++ b/Sources/Core/Shared/RetryOperation.swift
@@ -166,7 +166,7 @@ public class RetryOperation<T: NSOperation>: RepeatedOperation<T> {
         let delay = MapGenerator(strategy.generator()) { Delay.By($0) }
         let tuple = TupleGenerator(primary: generator, secondary: delay)
         retry = RetryGenerator(generator: anyGenerator(tuple), retry: block)
-        super.init(maxCount: max, generator: anyGenerator(generator))
+        super.init(maxCount: max, generator: anyGenerator(retry))
         name = "Retry Operation <\(T.self)>"
     }
 

--- a/Tests/Core/RepeatedOperationTests.swift
+++ b/Tests/Core/RepeatedOperationTests.swift
@@ -344,7 +344,7 @@ class RepeatingTestOperation: TestOperation, Repeatable {
 class RepeatableRepeatedOperationTests: OperationTests {
 
     func test__repeated_operation_repeats() {
-        let operation = RepeatedOperation { return RepeatingTestOperation() }
+        let operation = RepeatedOperation { RepeatingTestOperation() }
 
         addCompletionBlockToTestOperation(operation, withExpectation: expectationWithDescription("Test: \(__FUNCTION__)"))
         runOperation(operation)
@@ -354,7 +354,7 @@ class RepeatableRepeatedOperationTests: OperationTests {
     }
 
     func test__repeated_with_max_number_of_attempts() {
-        let operation = RepeatedOperation(maxCount: 2) { return RepeatingTestOperation() }
+        let operation = RepeatedOperation(maxCount: 2) { RepeatingTestOperation() }
 
         addCompletionBlockToTestOperation(operation, withExpectation: expectationWithDescription("Test: \(__FUNCTION__)"))
         runOperation(operation)
@@ -366,7 +366,7 @@ class RepeatableRepeatedOperationTests: OperationTests {
     func test__repeatable_operation() {
 
         var errors: [ErrorType] = []
-        let operation = RepeatedOperation(maxCount: 10) {() -> RepeatableOperation<TestOperation> in
+        let operation = RepeatedOperation(maxCount: 10) { () -> RepeatableOperation<TestOperation> in
 
             let op = TestOperation(error: TestOperation.Error.SimulatedError)
             op.addObserver(DidFinishObserver { _, e in
@@ -391,19 +391,5 @@ class RepeatableRepeatedOperationTests: OperationTests {
         XCTAssertTrue(op.cancelled)
     }
 }
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 
 

--- a/Tests/Core/RepeatedOperationTests.swift
+++ b/Tests/Core/RepeatedOperationTests.swift
@@ -253,6 +253,8 @@ class FibonacciWaitGeneratorTests: WaitStrategyIntervalTests {
     }
 }
 
+// MARK: - Repeated Operation
+
 class RepeatedOperationTests: OperationTests {
 
     var operation: RepeatedOperation<TestOperation>!
@@ -271,6 +273,18 @@ class RepeatedOperationTests: OperationTests {
 
     func test__custom_generator_without_delay() {
         operation = RepeatedOperation(maxCount: 2, generator: anyGenerator { (.None, TestOperation() )})
+
+        addCompletionBlockToTestOperation(operation, withExpectation: expectationWithDescription("Test: \(__FUNCTION__)"))
+        runOperation(operation)
+        waitForExpectationsWithTimeout(3, handler: nil)
+
+        XCTAssertTrue(operation.finished)
+        XCTAssertEqual(operation.count, 2)
+        XCTAssertEqual(operation.aggregateErrors.count, 0)
+    }
+
+    func test__init_separate_delay_generator_and_item_generator() {
+        operation = RepeatedOperation(maxCount: 2, delay: anyGenerator { Delay.By(0.1) }, generator: anyGenerator { TestOperation() })
 
         addCompletionBlockToTestOperation(operation, withExpectation: expectationWithDescription("Test: \(__FUNCTION__)"))
         runOperation(operation)

--- a/Tests/Core/RetryOperationTests.swift
+++ b/Tests/Core/RetryOperationTests.swift
@@ -118,9 +118,9 @@ class RetryOperationTests: OperationTests {
         XCTAssertEqual(operation.count, 3)
         XCTAssertEqual(didRunBlockCount, 2)
         XCTAssertNotNil(retryErrors)
-        XCTAssertEqual(retryErrors!.count, 1)
+        XCTAssertEqual(retryErrors?.count ?? 0, 1)
         XCTAssertNotNil(retryAggregateErrors)
-        XCTAssertEqual(retryAggregateErrors!.count, 2)
+        XCTAssertEqual(retryAggregateErrors?.count ?? 0, 2)
         XCTAssertEqual(retryCount, 2)
     }
 
@@ -147,9 +147,9 @@ class RetryOperationTests: OperationTests {
         XCTAssertEqual(operation.count, 1)
         XCTAssertEqual(didRunBlockCount, 1)
         XCTAssertNotNil(retryErrors)
-        XCTAssertEqual(retryErrors!.count, 1)
+        XCTAssertEqual(retryErrors?.count ?? 0, 1)
         XCTAssertNotNil(retryAggregateErrors)
-        XCTAssertEqual(retryAggregateErrors!.count, 1)
+        XCTAssertEqual(retryAggregateErrors?.count ?? 0, 1)
         XCTAssertEqual(retryCount, 1)
     }
 }


### PR DESCRIPTION
At the moment, it's very tricky to subclass `RepeatedOperation` from outside the module.

- [x] Remove `convenience` initializers - as these cannot be used by subclasses.
- [x] Try to minimize the messy initialization code.
- [x] Unify / Cleanup / ~~Remove~~ the `Repeatable` & `RepeatedOperation` stuff - I think this has got a bit confused since it was first written.

This is to address issues raised in #199. 