### PR TITLE
Default argument for designated initializer due to internal type

### DIFF
--- a/Sources/Features/Shared/ReachabilityCondition.swift
+++ b/Sources/Features/Shared/ReachabilityCondition.swift
@@ -27,11 +27,7 @@ public class ReachabilityCondition: OperationCondition {
     let connectivity: Reachability.Connectivity
     let reachability: HostReachabilityType
 
-    public convenience init(url: NSURL, connectivity: Reachability.Connectivity = .AnyConnectionKind) {
-        self.init(url: url, connectivity: connectivity, reachability: ReachabilityManager(DeviceReachability()))
-    }
-
-    init(url: NSURL, connectivity: Reachability.Connectivity = .AnyConnectionKind, reachability: HostReachabilityType) {
+    public init(url: NSURL, connectivity: Reachability.Connectivity = .AnyConnectionKind, reachability: HostReachabilityType = ReachabilityManager(DeviceReachability())) {
         self.url = url
         self.connectivity = connectivity
         self.reachability = reachability


### PR DESCRIPTION
Hi there,

Thanks again for the great work on this library - it continues to impress us with its capabilities.

Minor one here, I think: we want to implement a throttling condition which will fail if we exceed a certain number of network operations *on cell connection* in a particular period. Therefore the logic (seemingly) is:

* `ReachabilityCondition` with `Connectivity.ViaWiFi`
* If this condition fails, we can assume we're on cell connection.
* Inspect the number of requests from a particular period to see if we've hit our threshold, and succeed/fail based on that.

This sort of condition composition doesn't appear to be supported (and would be great condition!), but for this simple usage, I can subclass `ReachabilityCondition`, and override `evaluateForOperation()`. Not super clean, but looks to be enough. Currently subclassing is an issue, though, because the designated initializer uses the internal type `HostReachabilityType`. Since we don't care about this argument, a better solution seems to be to drop the convenience initializer and just have a default argument here. Since the type is internal it can't be used.

In any case, if there's a better solution for the problem we're solving here, also very keen to hear about it.

Thanks!