### PR TITLE
Move HostReachabilityType dependency to a var, to allow for subclassing

### DIFF
--- a/Sources/Features/Shared/ReachabilityCondition.swift
+++ b/Sources/Features/Shared/ReachabilityCondition.swift
@@ -25,16 +25,11 @@ public class ReachabilityCondition: OperationCondition {
 
     let url: NSURL
     let connectivity: Reachability.Connectivity
-    let reachability: HostReachabilityType
+    var reachability: HostReachabilityType = ReachabilityManager(DeviceReachability())
 
-    public convenience init(url: NSURL, connectivity: Reachability.Connectivity = .AnyConnectionKind) {
-        self.init(url: url, connectivity: connectivity, reachability: ReachabilityManager(DeviceReachability()))
-    }
-
-    init(url: NSURL, connectivity: Reachability.Connectivity = .AnyConnectionKind, reachability: HostReachabilityType) {
+    public init(url: NSURL, connectivity: Reachability.Connectivity = .AnyConnectionKind) {
         self.url = url
         self.connectivity = connectivity
-        self.reachability = reachability
     }
 
     public func dependencyForOperation(operation: Operation) -> NSOperation? {

--- a/Tests/Features/ReachabilityConditionTests.swift
+++ b/Tests/Features/ReachabilityConditionTests.swift
@@ -23,17 +23,20 @@ class ReachabilityConditionTests: OperationTests {
     }
 
     func test__condition_name() {
-        let condition = ReachabilityCondition(url: url, reachability: manager)
+        let condition = ReachabilityCondition(url: url)
+        condition.reachability = manager
         XCTAssertEqual(condition.name, "Reachability")
     }
 
     func test__is_mutually_exclusivity() {
-        let condition = ReachabilityCondition(url: url, reachability: manager)
+        let condition = ReachabilityCondition(url: url)
+        condition.reachability = manager
         XCTAssertFalse(condition.isMutuallyExclusive)
     }
 
     func test__url() {
-        let condition = ReachabilityCondition(url: url, reachability: manager)
+        let condition = ReachabilityCondition(url: url)
+        condition.reachability = manager
         XCTAssertEqual(condition.url, url)
     }
 
@@ -41,7 +44,8 @@ class ReachabilityConditionTests: OperationTests {
     func test__condition_is_satisfied_when_host_is_reachable_via_wifi() {
 
         let operation = TestOperation()
-        let condition = ReachabilityCondition(url: url, reachability: manager)
+        let condition = ReachabilityCondition(url: url)
+        condition.reachability = manager
         operation.addCondition(condition)
 
         waitForOperation(operation)
@@ -54,7 +58,8 @@ class ReachabilityConditionTests: OperationTests {
 
         let expectation = expectationWithDescription("Test: \(__FUNCTION__)")
         let operation = TestOperation()
-        let condition = ReachabilityCondition(url: url, reachability: manager)
+        let condition = ReachabilityCondition(url: url)
+        condition.reachability = manager
 
         var conditionResult: OperationConditionResult = .Satisfied
         network.flags = []
@@ -79,7 +84,8 @@ class ReachabilityConditionTests: OperationTests {
         let expectation = expectationWithDescription("Test: \(__FUNCTION__)")
 
         let operation = TestOperation()
-        let condition = ReachabilityCondition(url: url, connectivity: .ViaWiFi, reachability: manager)
+        let condition = ReachabilityCondition(url: url, connectivity: .ViaWiFi)
+        condition.reachability = manager
         var conditionResult: OperationConditionResult = .Satisfied
 
         network.flags = [.Reachable, .IsWWAN]


### PR DESCRIPTION
Originally https://github.com/danthorpe/Operations/pull/208

Sorry for the noise. Turns out we *do* still need to do something, since we need to store properties. Another solution, which I suspect you won't like!, is to make the `reachability` property into an (internal) var, defaulting to `ReachabilityManager(DeviceReachability())`, and remove it from the initializer entirely. This is still testable, by setting the var.

Not super elegant, but I think this solves our immediate need. Please let me know what you think.

Thanks!