### PR TITLE
Reachabiility should pass when constrained to wifi only, and wifi is available

### DIFF
--- a/Sources/Features/Shared/ReachabilityCondition.swift
+++ b/Sources/Features/Shared/ReachabilityCondition.swift
@@ -44,7 +44,7 @@ public class ReachabilityCondition: OperationCondition {
     public func evaluateForOperation(operation: Operation, completion: OperationConditionResult -> Void) {
         reachability.reachabilityForURL(url) { status in
             switch (self.connectivity, status) {
-            case (.AnyConnectionKind, .Reachable(_)), (.ViaWWAN, .Reachable(_)):
+            case (.AnyConnectionKind, .Reachable(_)), (.ViaWWAN, .Reachable(_)), (.ViaWiFi, .Reachable(.ViaWiFi)):
                 completion(.Satisfied)
             case (.ViaWiFi, .Reachable(.ViaWWAN)):
                 completion(.Failed(Error.NotReachableWithConnectivity(self.connectivity)))

--- a/Tests/Features/ReachabilityConditionTests.swift
+++ b/Tests/Features/ReachabilityConditionTests.swift
@@ -98,6 +98,18 @@ class ReachabilityConditionTests: OperationTests {
 
         XCTAssertEqual(error, ReachabilityCondition.Error.NotReachableWithConnectivity(.ViaWiFi))
     }
+
+    func test__condition_succeeds_when_only_wifi_accepted_and_only_wifi_available() {
+        network.flags = [.Reachable]
+
+        let operation = TestOperation()
+        operation.addCondition(ReachabilityCondition(url: url, connectivity: .ViaWiFi, reachability: manager))
+
+        waitForOperation(operation)
+
+        XCTAssertTrue(operation.didExecute)
+        XCTAssertTrue(operation.finished)
+    }
     #endif
 }
 


### PR DESCRIPTION
Hi, again!

So another change related to the feature mentioned in https://github.com/danthorpe/Operations/pull/209: As stated there, we implement a `ReachabilityCondition` for WiFi only. We then test for throttling, and possibly have another condition for WWAN only.

In any case, I noticed that the pattern matching doesn't appear to accept the case where we want Wifi only, and only wifi is available. I think this is based on the idea that in the real world, we're more likely to have WWAN, although WiFi is higher priority. In any case, added this as a succeeding condition, including a test.

Not sure this is the most elegant matching, either: I don't claim to be the greatest Swift-er (yet!).

Please let me know what  you think.

Thanks!