### PR TITLE
Use log.warning for all error cases

### DIFF
--- a/Sources/Core/Shared/GroupOperation.swift
+++ b/Sources/Core/Shared/GroupOperation.swift
@@ -112,7 +112,7 @@ public class GroupOperation: Operation {
      - parameter error: an ErrorType to append.
     */
     public final func aggregateError(error: ErrorType) {
-        log.verbose("Aggregated error: \(error)")
+        log.warning("Aggregated error: \(error)")
         _aggregateErrors.append(error)
     }
 

--- a/Sources/Core/Shared/Operation.swift
+++ b/Sources/Core/Shared/Operation.swift
@@ -247,7 +247,7 @@ public class Operation: NSOperation {
      */
     public func cancelWithErrors(errors: [ErrorType] = []) {
         if !errors.isEmpty {
-            log.verbose("Did cancel with errors: \(errors).")
+            log.warning("Did cancel with errors: \(errors).")
         }
         _internalErrors += errors
         cancel()
@@ -544,7 +544,7 @@ public extension Operation {
                 log.verbose("Finishing with no errors.")
             }
             else {
-                log.verbose("Finishing with errors: \(_internalErrors).")
+                log.warning("Finishing with errors: \(_internalErrors).")
             }
 
             willFinishObservers.forEach { $0.willFinishOperation(self, errors: self._internalErrors) }


### PR DESCRIPTION
Hi again ;)

A minor one: previously using `verbose` for all logging, which means that genuine error cases can get lost in a verbose log (currently we're looking at everything). Changed to `warning` for when there are errors. With coloured output this should mean that errors don't get lost in the log.

Subjective of course. Let us know what you think.