### PR TITLE
Remove Reachability from initializer in ReachableOperation

### DIFF
--- a/Sources/Features/Shared/CloudKitOperation.swift
+++ b/Sources/Features/Shared/CloudKitOperation.swift
@@ -13,12 +13,8 @@ import CloudKit
 
 public class OPRCKOperation<T where T: NSOperation, T: CKOperationType>: ReachableOperation<T> {
 
-    convenience init(operation: T) {
-        self.init(operation: operation, connectivity: .AnyConnectionKind, reachability: ReachabilityManager(DeviceReachability()))
-    }
-
-    override init(operation: T, connectivity: Reachability.Connectivity = .AnyConnectionKind, reachability: SystemReachabilityType) {
-        super.init(operation: operation, connectivity: connectivity, reachability: reachability)
+    override init(_ operation: T, connectivity: Reachability.Connectivity = .AnyConnectionKind) {
+        super.init(operation, connectivity: connectivity)
         name = "OPRCKOperation<\(T.self)>"
     }
 }
@@ -236,7 +232,11 @@ public final class CloudKitOperation<T where T: NSOperation, T: CKOperationType>
         let delay = MapGenerator(strategy.generator()) { Delay.By($0) }
 
         // Maps the generator to wrap the target operation.
-        let generator = MapGenerator(gen) { OPRCKOperation(operation: $0, connectivity: connectivity, reachability: reachability) }
+        let generator = MapGenerator(gen) { operation -> OPRCKOperation<T> in
+            let op = OPRCKOperation(operation, connectivity: connectivity)
+            op.reachability = reachability
+            return op
+        }
 
         // Creates a CloudKitRecovery object
         let _recovery = CloudKitRecovery<T>()

--- a/Sources/Features/Shared/ReachableOperation.swift
+++ b/Sources/Features/Shared/ReachableOperation.swift
@@ -19,12 +19,13 @@ import Foundation
 */
 public class ReachableOperation<T: NSOperation>: ComposedOperation<T> {
 
-    private let reachability: SystemReachabilityType
     private var token: String? = .None
     private var status: Reachability.NetworkStatus? = .None
 
     /// The required connectivity kind.
     public let connectivity: Reachability.Connectivity
+
+    internal var reachability: SystemReachabilityType = ReachabilityManager.sharedInstance
 
     /**
      Composes an operation to ensure that is will definitely be executed as soon as
@@ -33,13 +34,8 @@ public class ReachableOperation<T: NSOperation>: ComposedOperation<T> {
      - parameter [unlabeled] operation: any `NSOperation` type.
      - parameter connectivity: a `Reachability.Connectivity` value, defaults to `.AnyConnectionKind`.
     */
-    public convenience init(_ operation: T, connectivity: Reachability.Connectivity = .AnyConnectionKind) {
-        self.init(operation: operation, connectivity: connectivity, reachability: ReachabilityManager.sharedInstance)
-    }
-
-    init(operation: T, connectivity: Reachability.Connectivity = .AnyConnectionKind, reachability: SystemReachabilityType) {
+    public init(_ operation: T, connectivity: Reachability.Connectivity = .AnyConnectionKind) {
         self.connectivity = connectivity
-        self.reachability = reachability
         super.init(operation: operation)
         name = "Reachable Operation <\(operation.operationName)>"
     }

--- a/Tests/Features/CloudKitOperationTests.swift
+++ b/Tests/Features/CloudKitOperationTests.swift
@@ -338,7 +338,7 @@ class OPRCKOperationTests: CKTests {
     override func setUp() {
         super.setUp()
         target = TestCloudOperation()
-        operation = OPRCKOperation(operation: target)
+        operation = OPRCKOperation(target)
     }
 
     func test__get_countainer() {
@@ -368,7 +368,7 @@ class OPRCKDatabaseOperationTests: CKTests {
     override func setUp() {
         super.setUp()
         target = TestDatabaseOperation()
-        operation = OPRCKOperation(operation: target)
+        operation = OPRCKOperation(target)
     }
 
     func test__get_database() {
@@ -433,7 +433,8 @@ class OPRCKDiscoverAllContactsOperationTests: CKTests {
     override func setUp() {
         super.setUp()
         target = TestDiscoverAllContactsOperation(result: [])
-        operation = OPRCKOperation(operation: target, reachability: manager)
+        operation = OPRCKOperation(target)
+        operation.reachability = manager
     }
 
     func test__execution_after_cancellation() {
@@ -489,7 +490,8 @@ class OPRCKDiscoverUserInfosOperationTests: CKTests {
     override func setUp() {
         super.setUp()
         target = TestDiscoverUserInfosOperation(userInfosByEmailAddress: [:], userInfoByRecordID: [:])
-        operation = OPRCKOperation(operation: target, reachability: manager)
+        operation = OPRCKOperation(target)
+        operation.reachability = manager
     }
 
     func test__get_email_addresses() {
@@ -561,7 +563,8 @@ class OPRCKFetchNotificationChangesOperationTests: CKTests {
         super.setUp()
         token = "i'm a server token"
         target = TestFetchNotificationChangesOperation(token: token)
-        operation = OPRCKOperation(operation: target, reachability: manager)
+        operation = OPRCKOperation(target)
+        operation.reachability = manager
     }
 
     func test__get_set_notification_changed_block() {
@@ -618,7 +621,8 @@ class OPRCKMarkNotificationsReadOperationTests: CKTests {
         super.setUp()
         toMark = [ "this-is-an-id", "this-is-another-id" ]
         target = TestMarkNotificationsReadOperation(markIDsToRead: toMark)
-        operation = OPRCKOperation(operation: target, reachability: manager)
+        operation = OPRCKOperation(target)
+        operation.reachability = manager
     }
 
     func test__get_notification_id() {
@@ -666,7 +670,8 @@ class OPRCKModifyBadgeOperationTests: CKTests {
         super.setUp()
         badge = 9
         target = TestModifyBadgeOperation(value: badge)
-        operation = OPRCKOperation(operation: target, reachability: manager)
+        operation = OPRCKOperation(target)
+        operation.reachability = manager
     }
 
     func test__get_badge_value() {
@@ -712,7 +717,8 @@ class OPRCKFetchRecordChangesOperationTests: CKTests {
     override func setUp() {
         super.setUp()
         target = TestFetchRecordChangesOperation()
-        operation = OPRCKOperation(operation: target, reachability: manager)
+        operation = OPRCKOperation(target)
+        operation.reachability = manager
     }
 
     func test__get_record_zone_id() {
@@ -780,7 +786,8 @@ class OPRCKFetchRecordZonesOperationTests: CKTests {
     override func setUp() {
         super.setUp()
         target = TestFetchRecordZonesOperation()
-        operation = OPRCKOperation(operation: target, reachability: manager)
+        operation = OPRCKOperation(target)
+        operation.reachability = manager
     }
 
     func test__get_record_zone_ids() {
@@ -826,7 +833,8 @@ class OPRCKFetchRecordsOperationTests: CKTests {
     override func setUp() {
         super.setUp()
         target = TestFetchRecordsOperation()
-        operation = OPRCKOperation(operation: target, reachability: manager)
+        operation = OPRCKOperation(target)
+        operation.reachability = manager
     }
 
     func test__get_record_ids() {
@@ -894,7 +902,8 @@ class OPRCKFetchSubscriptionsOperationTests: CKTests {
     override func setUp() {
         super.setUp()
         target = TestFetchSubscriptionsOperation()
-        operation = OPRCKOperation(operation: target, reachability: manager)
+        operation = OPRCKOperation(target)
+        operation.reachability = manager
     }
 
     func test__get_subscription_ids() {
@@ -940,7 +949,8 @@ class OPRCKModifyRecordZonesOperationTests: CKTests {
     override func setUp() {
         super.setUp()
         target = TestModifyRecordZonesOperation()
-        operation = OPRCKOperation(operation: target, reachability: manager)
+        operation = OPRCKOperation(target)
+        operation.reachability = manager
     }
 
     func test__get_zones_to_save() {
@@ -998,7 +1008,8 @@ class OPRCKModifyRecordsOperationTests: CKTests {
     override func setUp() {
         super.setUp()
         target = TestModifyRecordsOperation()
-        operation = OPRCKOperation(operation: target, reachability: manager)
+        operation = OPRCKOperation(target)
+        operation.reachability = manager
     }
 
     func test__get_records_to_save() {
@@ -1108,7 +1119,8 @@ class OPRCKModifySubscriptionsOperationTests: CKTests {
     override func setUp() {
         super.setUp()
         target = TestModifySubscriptionsOperation()
-        operation = OPRCKOperation(operation: target, reachability: manager)
+        operation = OPRCKOperation(target)
+        operation.reachability = manager
     }
 
     func test__get_subscriptions_to_save() {
@@ -1166,7 +1178,8 @@ class OPRCKQueryOperationTests: CKTests {
     override func setUp() {
         super.setUp()
         target = TestQueryOperation()
-        operation = OPRCKOperation(operation: target, reachability: manager)
+        operation = OPRCKOperation(target)
+        operation.reachability = manager
     }
 
     func test__get_query() {
@@ -2334,7 +2347,8 @@ class CloudKitRecoveryTests: CKTests {
     override func setUp() {
         super.setUp()
         let target = TestDiscoverUserInfosOperation(userInfosByEmailAddress: [:], userInfoByRecordID: [:])
-        operation = OPRCKOperation(operation: target, reachability: manager)
+        operation = OPRCKOperation(target)
+        operation.reachability = manager
         recovery = CloudKitRecovery()
     }
 

--- a/Tests/Features/ReachabilityConditionTests.swift
+++ b/Tests/Features/ReachabilityConditionTests.swift
@@ -109,8 +109,9 @@ class ReachabilityConditionTests: OperationTests {
         network.flags = [.Reachable]
 
         let operation = TestOperation()
-        operation.addCondition(ReachabilityCondition(url: url, connectivity: .ViaWiFi, reachability: manager))
-
+        let condition = ReachabilityCondition(url: url, connectivity: .ViaWiFi)
+        condition.reachability = manager
+        operation.addCondition(condition)
         waitForOperation(operation)
 
         XCTAssertTrue(operation.didExecute)

--- a/Tests/Features/ReachableOperationTests.swift
+++ b/Tests/Features/ReachableOperationTests.swift
@@ -19,7 +19,8 @@ class ReachableOperationTests: OperationTests {
         super.setUp()
         network = TestableNetworkReachability()
         manager = ReachabilityManager(network)
-        operation = ReachableOperation(operation: TestOperation(), reachability: manager)
+        operation = ReachableOperation(TestOperation())
+        operation.reachability = manager
     }
 
     func test__operation_name() {


### PR DESCRIPTION
Having merged some PRs, `development` is currently broken - and in general, the reachability stuff needs a bit of TLC.