### PR TITLE
Inject results with WillFinishObserver to avoid race condition

### DIFF
--- a/Sources/Core/Shared/ResultInjection.swift
+++ b/Sources/Core/Shared/ResultInjection.swift
@@ -88,7 +88,7 @@ extension InjectionOperationType where Self: Operation {
      - returns: `self` - so that injections can be chained together.
     */
     public func injectResultFromDependency<T where T: Operation>(dep: T, block: (operation: Self, dependency: T, errors: [ErrorType]) -> Void) -> Self {
-        dep.addObserver(DidFinishObserver { [weak self] op, errors in
+        dep.addObserver(WillFinishObserver { [weak self] op, errors in
             if let strongSelf = self, dep = op as? T {
                 block(operation: strongSelf, dependency: dep, errors: errors)
             }


### PR DESCRIPTION
When injecting results using a `DidFinishObserver`, there is a race condition when the dependent operation becomes ready and executes *after* its dependency finishes but *before* the dependency's `DidFinishObserver` is triggered. This means the dependent operation occasionally executes before its dependency's result is injected and fails due to a missing `requirement`.

Switching this to a `WillFinishObserver` ensures that the result is injected before the dependency finishes, and before the dependent operation is allowed to execute.