### PR TITLE
Don't refer to type to avoid (seemingly) deadlocks

### DIFF
--- a/Sources/Core/Shared/Logging.swift
+++ b/Sources/Core/Shared/Logging.swift
@@ -299,7 +299,7 @@ public extension NSOperation {
      set, this resorts to the class description.
     */
     var operationName: String {
-        return name ?? "\(self)"
+        return name ?? "<unnamed operation>"
     }
 }
 


### PR DESCRIPTION
Hi there,

Well this is an interesting one, perhaps?! It would seem that accessing a Swift type is not thread-safe. We are certainly seeing some deadlocks, and it would seem that changing this implementation (if just temporarily) is safer.

In any case, kinda weird and surprising, so keen to hear your input. Here's a deadlock stack trace:

```
  thread #1: tid = 0xda47b, 0x0000000183bed4bc libsystem_kernel.dylib`mach_msg_trap + 8, queue = 'com.apple.main-thread'
    frame #0: 0x0000000183bed4bc libsystem_kernel.dylib`mach_msg_trap + 8
    frame #1: 0x0000000183bed338 libsystem_kernel.dylib`mach_msg + 72
    frame #2: 0x000000018401cac0 CoreFoundation`__CFRunLoopServiceMachPort + 196
    frame #3: 0x000000018401a7c4 CoreFoundation`__CFRunLoopRun + 1032
    frame #4: 0x0000000183f49680 CoreFoundation`CFRunLoopRunSpecific + 384
    frame #5: 0x0000000185458088 GraphicsServices`GSEventRunModal + 180
    frame #6: 0x0000000188dc0d90 UIKit`UIApplicationMain + 204
    frame #7: 0x00000001001079cc <REDACTED>`main + 136 at AppDelegate.swift:12
    frame #8: 0x0000000183aea8b8 libdyld.dylib`start + 4

  thread #2: tid = 0xda4c5, 0x0000000183c07f90 libsystem_kernel.dylib`__psynch_mutexwait + 8, queue = 'NSOperationQueue 0x144770950 :: Group Operation (QOS: USER_INITIATED)', activity = 'send control actions', 2 messages
    frame #0: 0x0000000183c07f90 libsystem_kernel.dylib`__psynch_mutexwait + 8
    frame #1: 0x0000000183cd239c libsystem_pthread.dylib`_pthread_mutex_lock_wait + 96
    frame #2: 0x0000000100dbb39c libswiftCore.dylib`swift_conformsToProtocol + 440
    frame #3: 0x0000000100dbc158 libswiftCore.dylib`_conformsToProtocol(swift::OpaqueValue const*, swift::Metadata const*, swift::ProtocolDescriptor const*, swift::WitnessTable const**) + 220
    frame #4: 0x0000000100dba368 libswiftCore.dylib`_dynamicCastToExistential(swift::OpaqueValue*, swift::OpaqueValue*, swift::Metadata const*, swift::ExistentialTypeMetadata const*, swift::DynamicCastFlags) + 296
    frame #5: 0x0000000100db9a9c libswiftCore.dylib`swift_dynamicCast + 552
    frame #6: 0x0000000100424f30 Operations`Operations.Operation.($0=OperationObserverType @ 0x000000016e0867d8).(closure #1) + 140 at Operation.swift:461
    frame #7: 0x0000000100cdbcb0 libswiftCore.dylib`ext.Swift.Swift.SequenceType<A where A: Swift.SequenceType>.flatMap <A><B where A: Swift.SequenceType> (A)((A.Generator.Element) throws -> Swift.Optional<B>) throws -> Swift.Array<B> + 536
    frame #8: 0x00000001004212ec Operations`Operations.Operation.didStartObservers.getter : Swift.Array<Operations.OperationDidStartObserver>(self=0x000000014589d470) + 152 at Operation.swift:461
    frame #9: 0x0000000100421bbc Operations`Operations.Operation.main (self=0x000000014589d470)() -> () + 1208 at Operation.swift:505
    frame #10: 0x00000001004216e8 Operations`Operations.Operation.start (self=0x000000014589d470)() -> () + 48 at Operation.swift:490
    frame #11: 0x0000000100421ce0 Operations`@objc Operations.Operation.start (Operations.Operation)() -> () + 40 at Operation.swift:0
    frame #12: 0x0000000184a0e728 Foundation`__NSOQSchedule_f + 224
    frame #13: 0x0000000101d05bb0 libdispatch.dylib`_dispatch_client_callout + 16
    frame #14: 0x0000000101d126c8 libdispatch.dylib`_dispatch_queue_drain + 1036
    frame #15: 0x0000000101d098a0 libdispatch.dylib`_dispatch_queue_invoke + 464
    frame #16: 0x0000000101d147e0 libdispatch.dylib`_dispatch_root_queue_drain + 760
    frame #17: 0x0000000101d144d8 libdispatch.dylib`_dispatch_worker_thread3 + 132
    frame #18: 0x0000000183ccd470 libsystem_pthread.dylib`_pthread_wqthread + 1092

  thread #3: tid = 0xda4c6, 0x0000000183c094fc libsystem_kernel.dylib`kevent_qos + 8, queue = 'com.apple.libdispatch-manager'
    frame #0: 0x0000000183c094fc libsystem_kernel.dylib`kevent_qos + 8
    frame #1: 0x0000000101d1a270 libdispatch.dylib`_dispatch_mgr_invoke + 232
    frame #2: 0x0000000101d07e2c libdispatch.dylib`_dispatch_mgr_thread + 52

  thread #4: tid = 0xda4c7, 0x0000000183c07f90 libsystem_kernel.dylib`__psynch_mutexwait + 8, queue = 'NSManagedObjectContext 0x1445de220: Batch Operation Context', activity = 'send control actions'
    frame #0: 0x0000000183c07f90 libsystem_kernel.dylib`__psynch_mutexwait + 8
    frame #1: 0x0000000183cd239c libsystem_pthread.dylib`_pthread_mutex_lock_wait + 96
    frame #2: 0x0000000100dbb39c libswiftCore.dylib`swift_conformsToProtocol + 440
    frame #3: 0x0000000100dbc158 libswiftCore.dylib`_conformsToProtocol(swift::OpaqueValue const*, swift::Metadata const*, swift::ProtocolDescriptor const*, swift::WitnessTable const**) + 220
    frame #4: 0x0000000100dba368 libswiftCore.dylib`_dynamicCastToExistential(swift::OpaqueValue*, swift::OpaqueValue*, swift::Metadata const*, swift::ExistentialTypeMetadata const*, swift::DynamicCastFlags) + 296
    frame #5: 0x0000000100db9a9c libswiftCore.dylib`swift_dynamicCast + 552
    frame #6: 0x0000000100425574 Operations`Operations.Operation.($0=OperationObserverType @ 0x000000016e12e3b8).(closure #1) + 140 at Operation.swift:473
    frame #7: 0x0000000100cdbcb0 libswiftCore.dylib`ext.Swift.Swift.SequenceType<A where A: Swift.SequenceType>.flatMap <A><B where A: Swift.SequenceType> (A)((A.Generator.Element) throws -> Swift.Optional<B>) throws -> Swift.Array<B> + 536
    frame #8: 0x00000001004215b0 Operations`Operations.Operation.willFinishObservers.getter : Swift.Array<Operations.OperationWillFinishObserver>(self=0x0000000145893050) + 152 at Operation.swift:473
    frame #9: 0x000000010041d8f0 Operations`Operations.Operation.finish (receivedErrors=0 values, self=0x0000000145893050)(Swift.Array<Swift.ErrorType>) -> () + 1604 at Operation.swift:550
    frame #10: 0x000000010042282c Operations`Operations.Operation.finish (receivedError=nil, self=0x0000000145893050)(Swift.Optional<Swift.ErrorType>) -> () + 316 at Operation.swift:560
... REDACTED
    frame #16: 0x0000000185b65080 CoreData`developerSubmittedBlockToNSManagedObjectContextPerform + 196
    frame #17: 0x0000000101d05bb0 libdispatch.dylib`_dispatch_client_callout + 16
    frame #18: 0x0000000101d126c8 libdispatch.dylib`_dispatch_queue_drain + 1036
    frame #19: 0x0000000101d098a0 libdispatch.dylib`_dispatch_queue_invoke + 464
    frame #20: 0x0000000101d05bb0 libdispatch.dylib`_dispatch_client_callout + 16
    frame #21: 0x0000000101d14e10 libdispatch.dylib`_dispatch_root_queue_drain + 2344
    frame #22: 0x0000000101d144d8 libdispatch.dylib`_dispatch_worker_thread3 + 132
    frame #23: 0x0000000183ccd470 libsystem_pthread.dylib`_pthread_wqthread + 1092

  thread #7: tid = 0xda4d5, 0x0000000183bed4bc libsystem_kernel.dylib`mach_msg_trap + 8, name = 'com.apple.NSURLConnectionLoader'
    frame #0: 0x0000000183bed4bc libsystem_kernel.dylib`mach_msg_trap + 8
    frame #1: 0x0000000183bed338 libsystem_kernel.dylib`mach_msg + 72
    frame #2: 0x000000018401cac0 CoreFoundation`__CFRunLoopServiceMachPort + 196
    frame #3: 0x000000018401a7c4 CoreFoundation`__CFRunLoopRun + 1032
    frame #4: 0x0000000183f49680 CoreFoundation`CFRunLoopRunSpecific + 384
    frame #5: 0x00000001846b9434 CFNetwork`+[NSURLConnection(Loader) _resourceLoadLoop:] + 412
    frame #6: 0x0000000184a27c40 Foundation`__NSThread__start__ + 1000
    frame #7: 0x0000000183ccfb28 libsystem_pthread.dylib`_pthread_body + 156
    frame #8: 0x0000000183ccfa8c libsystem_pthread.dylib`_pthread_start + 156

* thread #8: tid = 0xda4d9, 0x0000000183c07f90 libsystem_kernel.dylib`__psynch_mutexwait + 8, queue = 'com.apple.root.user-initiated-qos', activity = 'send control actions', 1 messages
    frame #0: 0x0000000183c07f90 libsystem_kernel.dylib`__psynch_mutexwait + 8
    frame #1: 0x0000000183cd239c libsystem_pthread.dylib`_pthread_mutex_lock_wait + 96
    frame #2: 0x0000000100dbb39c libswiftCore.dylib`swift_conformsToProtocol + 440
    frame #3: 0x0000000100dbc158 libswiftCore.dylib`_conformsToProtocol(swift::OpaqueValue const*, swift::Metadata const*, swift::ProtocolDescriptor const*, swift::WitnessTable const**) + 220
    frame #4: 0x0000000100dba368 libswiftCore.dylib`_dynamicCastToExistential(swift::OpaqueValue*, swift::OpaqueValue*, swift::Metadata const*, swift::ExistentialTypeMetadata const*, swift::DynamicCastFlags) + 296
    frame #5: 0x0000000100db9a9c libswiftCore.dylib`swift_dynamicCast + 552
    frame #6: 0x0000000100cbc384 libswiftCore.dylib`Swift._print_unlocked <A, B where B: Swift.OutputStreamType> (A, inout B) -> () + 140
    frame #7: 0x0000000100c9f470 libswiftCore.dylib`Swift.String.init <A> (Swift.String.Type)(stringInterpolationSegment : A) -> Swift.String + 64
  * frame #8: 0x0000000100410c6c Operations`ext.Operations.__ObjC.NSOperation.operationName.getter : Swift.String(self=0x000000014475c060) + 496 at Logging.swift:302
    frame #9: 0x0000000100410a48 Operations`@objc ext.Operations.__ObjC.NSOperation.operationName.getter : Swift.String + 40 at Logging.swift:0
    frame #10: 0x000000010041c730 Operations`Operations.Operation.log.getter : Operations.LoggerType(self=0x000000014475c060) + 76 at Operation.swift:180
    frame #11: 0x0000000100421ea0 Operations`Operations.Operation.produceOperation (operation=0x0000000145c1ed40, self=0x000000014475c060)(__ObjC.NSOperation) -> () + 368 at Operation.swift:520
... REDACTED
    frame #18: 0x0000000101d05bf0 libdispatch.dylib`_dispatch_call_block_and_release + 24
    frame #19: 0x0000000101d05bb0 libdispatch.dylib`_dispatch_client_callout + 16
    frame #20: 0x0000000101d14e10 libdispatch.dylib`_dispatch_root_queue_drain + 2344
    frame #21: 0x0000000101d144d8 libdispatch.dylib`_dispatch_worker_thread3 + 132
    frame #22: 0x0000000183ccd470 libsystem_pthread.dylib`_pthread_wqthread + 1092

  thread #11: tid = 0xda4e0, 0x0000000183c08368 libsystem_kernel.dylib`__select + 8, name = 'com.apple.CFSocket.private'
    frame #0: 0x0000000183c08368 libsystem_kernel.dylib`__select + 8
    frame #1: 0x0000000184023028 CoreFoundation`__CFSocketManager + 648
    frame #2: 0x0000000183ccfb28 libsystem_pthread.dylib`_pthread_body + 156
    frame #3: 0x0000000183ccfa8c libsystem_pthread.dylib`_pthread_start + 156

  thread #14: tid = 0xda549, 0x0000000183c07f90 libsystem_kernel.dylib`__psynch_mutexwait + 8, queue = 'Core.AssetBatchProcessingQueue :: NSOperation 0x145aabf20 (QOS: USER_INITIATED)', activity = 'send control actions'
    frame #0: 0x0000000183c07f90 libsystem_kernel.dylib`__psynch_mutexwait + 8
    frame #1: 0x0000000183cd239c libsystem_pthread.dylib`_pthread_mutex_lock_wait + 96
    frame #2: 0x0000000100dbb39c libswiftCore.dylib`swift_conformsToProtocol + 440
    frame #3: 0x0000000100dbc158 libswiftCore.dylib`_conformsToProtocol(swift::OpaqueValue const*, swift::Metadata const*, swift::ProtocolDescriptor const*, swift::WitnessTable const**) + 220
    frame #4: 0x0000000100dba368 libswiftCore.dylib`_dynamicCastToExistential(swift::OpaqueValue*, swift::OpaqueValue*, swift::Metadata const*, swift::ExistentialTypeMetadata const*, swift::DynamicCastFlags) + 296
    frame #5: 0x0000000100db9a9c libswiftCore.dylib`swift_dynamicCast + 552
    frame #6: 0x0000000100cbc384 libswiftCore.dylib`Swift._print_unlocked <A, B where B: Swift.OutputStreamType> (A, inout B) -> () + 140
    frame #7: 0x0000000100c9f470 libswiftCore.dylib`Swift.String.init <A> (Swift.String.Type)(stringInterpolationSegment : A) -> Swift.String + 64
    frame #8: 0x00000001009a2ec4 Core`Core.CoreOperationQueue.addOperation (op=0x0000000145b25bf0, self=0x00000001445dba80)(__ObjC.NSOperation) -> () + 1684 at Queues.swift:55
    frame #9: 0x00000001009a442c Core`Core.AssetBatchProcessingQueue.addOperation (op=0x0000000145b25bf0, self=0x00000001445dba80)(__ObjC.NSOperation) -> () + 416 at Queues.swift:81
    frame #10: 0x0000000100428cd0 Operations`Operations.OperationQueue.addOperation (operation=0x0000000145b24fd0, self=0x00000001445dba80)(__ObjC.NSOperation) -> () + 3088 at OperationQueue.swift:117
    frame #11: 0x00000001009a2bc8 Core`Core.CoreOperationQueue.addOperation (op=0x0000000145b24fd0, self=0x00000001445dba80)(__ObjC.NSOperation) -> () + 920 at Queues.swift:54
    frame #12: 0x00000001009a442c Core`Core.AssetBatchProcessingQueue.addOperation (op=0x0000000145b24fd0, self=0x00000001445dba80)(__ObjC.NSOperation) -> () + 416 at Queues.swift:81
    frame #13: 0x0000000100429ea4 Operations`Operations.OperationQueue.(op=0x0000000145aabf20, produced=0x0000000145b24fd0, self=0x0000000145aac7d0) -> (__ObjC.NSOperation) -> ()).(closure #1) + 364 at OperationQueue.swift:77
    frame #14: 0x00000001003d8044 Operations`Operations.ProducedOperationObserver.operation (operation=0x0000000145aabf20, newOperation=0x0000000145b24fd0, self=Operations.ProducedOperationObserver @ 0x000000016e619cf0)(Operations.Operation, didProduceOperation : __ObjC.NSOperation) -> () + 128 at BlockObserver.swift:105
    frame #15: 0x00000001003d8184 Operations`protocol witness for Operations.OperationDidProduceOperationObserver.operation <A where A: Operations.OperationDidProduceOperationObserver> (A)(Operations.Operation, didProduceOperation : __ObjC.NSOperation) -> () in conformance Operations.ProducedOperationObserver : Operations.OperationDidProduceOperationObserver in Operations + 128 at BlockObserver.swift:104
    frame #16: 0x0000000100425924 Operations`Operations.Operation.($0=OperationDidProduceOperationObserver @ 0x000000016e619e08, self=0x0000000145aabf20, operation=0x0000000145b24fd0) -> (__ObjC.NSOperation) -> ()).(closure #1) + 148 at Operation.swift:521
    frame #17: 0x0000000100bee700 libswiftCore.dylib`ext.Swift.Swift.SequenceType<A where A: Swift.SequenceType>.forEach <A where A: Swift.SequenceType> (A)((A.Generator.Element) throws -> ()) throws -> () + 340
    frame #18: 0x000000010042209c Operations`Operations.Operation.produceOperation (operation=0x0000000145b24fd0, self=0x0000000145aabf20)(__ObjC.NSOperation) -> () + 876 at Operation.swift:521
...REDACTED
    frame #24: 0x0000000183f5c370 CoreFoundation`__53-[__NSArrayM enumerateObjectsWithOptions:usingBlock:]_block_invoke + 132
    frame #25: 0x0000000183f5c208 CoreFoundation`-[__NSArrayM enumerateObjectsWithOptions:usingBlock:] + 212
    frame #26: 0x00000001009c6528 Core`Core.PhotoLibraryChangeSetProcessorOperation.execute (self=0x0000000145aabf20)() -> () + 2332 at PhotoLibraryChangeProcessorOperation.swift:103
    frame #27: 0x0000000100421c90 Operations`Operations.Operation.main (self=0x0000000145aabf20)() -> () + 1420 at Operation.swift:506
    frame #28: 0x00000001004216e8 Operations`Operations.Operation.start (self=0x0000000145aabf20)() -> () + 48 at Operation.swift:490
    frame #29: 0x0000000100421ce0 Operations`@objc Operations.Operation.start (Operations.Operation)() -> () + 40 at Operation.swift:0
    frame #30: 0x0000000184a0e728 Foundation`__NSOQSchedule_f + 224
    frame #31: 0x0000000101d05bb0 libdispatch.dylib`_dispatch_client_callout + 16
    frame #32: 0x0000000101d126c8 libdispatch.dylib`_dispatch_queue_drain + 1036
    frame #33: 0x0000000101d098a0 libdispatch.dylib`_dispatch_queue_invoke + 464
    frame #34: 0x0000000101d147e0 libdispatch.dylib`_dispatch_root_queue_drain + 760
    frame #35: 0x0000000101d144d8 libdispatch.dylib`_dispatch_worker_thread3 + 132
    frame #36: 0x0000000183ccd470 libsystem_pthread.dylib`_pthread_wqthread + 1092

  thread #17: tid = 0xda742, 0x0000000183c08b6c libsystem_kernel.dylib`__workq_kernreturn + 8
    frame #0: 0x0000000183c08b6c libsystem_kernel.dylib`__workq_kernreturn + 8
    frame #1: 0x0000000183ccd530 libsystem_pthread.dylib`_pthread_wqthread + 1284

  thread #18: tid = 0xda743, 0x0000000183c08b6c libsystem_kernel.dylib`__workq_kernreturn + 8
    frame #0: 0x0000000183c08b6c libsystem_kernel.dylib`__workq_kernreturn + 8
    frame #1: 0x0000000183ccd530 libsystem_pthread.dylib`_pthread_wqthread + 1284
```