### PR TITLE
Always create background tasks for background observer

### DIFF
--- a/Sources/Core/iOS/BackgroundObserver.swift
+++ b/Sources/Core/iOS/BackgroundObserver.swift
@@ -25,8 +25,6 @@ if the app goes in the background.
 */
 public class BackgroundObserver: NSObject {
 
-    static let backgroundTaskName = "Background Operation Observer"
-
     private var identifier: UIBackgroundTaskIdentifier? = .None
     private let application: BackgroundTaskApplicationInterface
 
@@ -41,37 +39,12 @@ public class BackgroundObserver: NSObject {
 
     init(app: BackgroundTaskApplicationInterface) {
         application = app
-
         super.init()
-
-        let nc = NSNotificationCenter.defaultCenter()
-        nc.addObserver(self, selector: "didEnterBackground:", name: UIApplicationDidEnterBackgroundNotification, object: .None)
-        nc.addObserver(self, selector: "didBecomeActive:", name: UIApplicationDidBecomeActiveNotification, object: .None)
-
-        if isInBackground {
-            startBackgroundTask()
-        }
     }
 
-    deinit {
-        NSNotificationCenter.defaultCenter().removeObserver(self)
-    }
-
-    @objc func didEnterBackground(notification: NSNotification) {
-        if isInBackground {
-            startBackgroundTask()
-        }
-    }
-
-    @objc func didBecomeActive(notification: NSNotification) {
-        if !isInBackground {
-            endBackgroundTask()
-        }
-    }
-
-    private func startBackgroundTask() {
+    private func startBackgroundTask(operation: Operation) {
         if identifier == nil {
-            identifier = application.beginBackgroundTaskWithName(self.dynamicType.backgroundTaskName) {
+            identifier = application.beginBackgroundTaskWithName("Background Operation Observer \(operation.operationName)") {
                 self.endBackgroundTask()
             }
         }
@@ -82,6 +55,12 @@ public class BackgroundObserver: NSObject {
             application.endBackgroundTask(id)
             identifier = .None
         }
+    }
+}
+
+extension BackgroundObserver: OperationDidStartObserver {
+    public func didStartOperation(operation: Operation) {
+        startBackgroundTask(operation)
     }
 }
 


### PR DESCRIPTION
Hi again :wink: 

Here's a suggested change: from reading [this](https://spin.atomicobject.com/2015/05/14/ios-background-task-reactivecocoa/) article, I started wondering if `BackgroundObserver()` shouldn't always generate a background task identifier if attached, and respond as before only to the operation finishing. There doesn't seem to be any harm in doing so, and essentially this observer can be freely attached to any operation that would want to progress in the background - and be sure it's been assigned an identifier. It does not appear that `beginBackgroundTaskWithName()` cares when the identifier is created.

Context: in our case we basically want *all* our operations to continue in the background for as long as possible, so I'm currently attaching this condition at the queue level.

Let me know what you think :+1: 