### PR TITLE
Make background task execution default on iOS

### DIFF
--- a/Sources/Core/Shared/Operation.swift
+++ b/Sources/Core/Shared/Operation.swift
@@ -104,6 +104,15 @@ public class Operation: NSOperation {
     private(set) var conditions = [OperationCondition]()
     internal var waitForDependenciesOperation: NSOperation? = .None
 
+    #if os(iOS)
+    public var backgroundTaskExecutionEnabled: Bool = {
+        if #available(iOSApplicationExtension 8, *) {
+            return false
+        }
+        return true
+    }()
+    #endif
+
     private var _cancelled = false {
         willSet {
             willChangeValueForKey("Cancelled")
@@ -183,6 +192,15 @@ public class Operation: NSOperation {
         set {
             _log = newValue
         }
+    }
+
+    override init() {
+        super.init()
+        #if os(iOS)
+            if backgroundTaskExecutionEnabled {
+                addObserver(BackgroundObserver())
+            }
+        #endif
     }
 
     /**

--- a/Sources/Core/Shared/Operation.swift
+++ b/Sources/Core/Shared/Operation.swift
@@ -197,8 +197,10 @@ public class Operation: NSOperation {
     override init() {
         super.init()
         #if os(iOS)
-            if backgroundTaskExecutionEnabled {
-                addObserver(BackgroundObserver())
+            if #available(iOS 8, *) {
+                if backgroundTaskExecutionEnabled {
+                    addObserver(BackgroundObserver())
+                }
             }
         #endif
     }
@@ -396,8 +398,7 @@ public extension Operation {
         get {
             var _dependencies = super.dependencies
             guard let
-                waiter = waitForDependenciesOperation,
-                index = _dependencies.indexOf(waiter) else {
+                waiter = waitForDependenciesOperation, index = _dependencies.indexOf(waiter) else {
                     return _dependencies
             }
 

--- a/Sources/Core/Shared/Operation.swift
+++ b/Sources/Core/Shared/Operation.swift
@@ -104,15 +104,6 @@ public class Operation: NSOperation {
     private(set) var conditions = [OperationCondition]()
     internal var waitForDependenciesOperation: NSOperation? = .None
 
-    #if os(iOS)
-    public var backgroundTaskExecutionEnabled: Bool = {
-        if #available(iOSApplicationExtension 8, *) {
-            return false
-        }
-        return true
-    }()
-    #endif
-
     private var _cancelled = false {
         willSet {
             willChangeValueForKey("Cancelled")
@@ -192,17 +183,6 @@ public class Operation: NSOperation {
         set {
             _log = newValue
         }
-    }
-
-    override init() {
-        super.init()
-        #if os(iOS)
-            if #available(iOS 8, *) {
-                if backgroundTaskExecutionEnabled {
-                    addObserver(BackgroundObserver())
-                }
-            }
-        #endif
     }
 
     /**

--- a/Sources/Core/iOS/BackgroundObserver.swift
+++ b/Sources/Core/iOS/BackgroundObserver.swift
@@ -8,14 +8,14 @@
 
 import UIKit
 
-@available(iOSApplicationExtension 8, *)
+@available(iOS 8, *)
 public protocol BackgroundTaskApplicationInterface {
     var applicationState: UIApplicationState { get }
     func beginBackgroundTaskWithName(taskName: String?, expirationHandler handler: (() -> Void)?) -> UIBackgroundTaskIdentifier
     func endBackgroundTask(identifier: UIBackgroundTaskIdentifier)
 }
 
-@available(iOSApplicationExtension 8, *)
+@available(iOS 8, *)
 extension UIApplication: BackgroundTaskApplicationInterface { }
 
 /**
@@ -25,7 +25,7 @@ application enters the background.
 Attach a `BackgroundObserver` to an operation which must be completed even
 if the app goes in the background.
 */
-@available(iOSApplicationExtension 8, *)
+@available(iOS 8, *)
 public class BackgroundObserver {
 
     private var identifier: UIBackgroundTaskIdentifier? = .None

--- a/Sources/Core/iOS/BackgroundObserver.swift
+++ b/Sources/Core/iOS/BackgroundObserver.swift
@@ -8,12 +8,14 @@
 
 import UIKit
 
+@available(iOSApplicationExtension 8, *)
 public protocol BackgroundTaskApplicationInterface {
     var applicationState: UIApplicationState { get }
     func beginBackgroundTaskWithName(taskName: String?, expirationHandler handler: (() -> Void)?) -> UIBackgroundTaskIdentifier
     func endBackgroundTask(identifier: UIBackgroundTaskIdentifier)
 }
 
+@available(iOSApplicationExtension 8, *)
 extension UIApplication: BackgroundTaskApplicationInterface { }
 
 /**
@@ -23,55 +25,19 @@ application enters the background.
 Attach a `BackgroundObserver` to an operation which must be completed even
 if the app goes in the background.
 */
-public class BackgroundObserver: NSObject {
-
-    static let backgroundTaskName = "Background Operation Observer"
+@available(iOSApplicationExtension 8, *)
+public class BackgroundObserver {
 
     private var identifier: UIBackgroundTaskIdentifier? = .None
-    private let application: BackgroundTaskApplicationInterface
+    internal var application: BackgroundTaskApplicationInterface = UIApplication.sharedApplication()
 
     private var isInBackground: Bool {
         return application.applicationState == .Background
     }
 
-    /// Initialize a `BackgroundObserver`, takes no parameters.
-    public override convenience init() {
-        self.init(app: UIApplication.sharedApplication())
-    }
-
-    init(app: BackgroundTaskApplicationInterface) {
-        application = app
-
-        super.init()
-
-        let nc = NSNotificationCenter.defaultCenter()
-        nc.addObserver(self, selector: "didEnterBackground:", name: UIApplicationDidEnterBackgroundNotification, object: .None)
-        nc.addObserver(self, selector: "didBecomeActive:", name: UIApplicationDidBecomeActiveNotification, object: .None)
-
-        if isInBackground {
-            startBackgroundTask()
-        }
-    }
-
-    deinit {
-        NSNotificationCenter.defaultCenter().removeObserver(self)
-    }
-
-    @objc func didEnterBackground(notification: NSNotification) {
-        if isInBackground {
-            startBackgroundTask()
-        }
-    }
-
-    @objc func didBecomeActive(notification: NSNotification) {
-        if !isInBackground {
-            endBackgroundTask()
-        }
-    }
-
-    private func startBackgroundTask() {
+    private func startBackgroundTaskForOperation(operation: Operation) {
         if identifier == nil {
-            identifier = application.beginBackgroundTaskWithName(self.dynamicType.backgroundTaskName) {
+            identifier = application.beginBackgroundTaskWithName("Background Task for: \(operation.operationName)") {
                 self.endBackgroundTask()
             }
         }
@@ -82,6 +48,14 @@ public class BackgroundObserver: NSObject {
             application.endBackgroundTask(id)
             identifier = .None
         }
+    }
+}
+
+extension BackgroundObserver: OperationDidStartObserver {
+
+    /// Conforms to `OperationDidStartObserver`, will start a background task.
+    public func didStartOperation(operation: Operation) {
+        startBackgroundTaskForOperation(operation)
     }
 }
 


### PR DESCRIPTION
- [x] `BackgroundObserver` is automatic, not just when going to into the background.
- [ ] ~~It is added to `Operation` by default, but only on iOS.~~