### PR TITLE
Fix race condition when cancelling group operation

### DIFF
--- a/Sources/Core/Shared/GroupOperation.swift
+++ b/Sources/Core/Shared/GroupOperation.swift
@@ -55,10 +55,10 @@ public class GroupOperation: Operation {
 
     /// Override of public method
     public override func cancel() {
+        super.cancel()
         queue.cancelAllOperations()
         queue.suspended = false
         operations.forEach { $0.cancel() }
-        super.cancel()
     }
 
     /**

--- a/Tests/Core/GroupOperationTests.swift
+++ b/Tests/Core/GroupOperationTests.swift
@@ -26,6 +26,37 @@ class GroupOperationTests: OperationTests {
             XCTAssertTrue(op.cancelled)
         }
     }
+    
+    func test__cancel_running_group_operation_race_condition() {
+        class SleepingGroupOperation: GroupOperation {
+            override func cancel() {
+                queue.cancelAllOperations()
+                queue.suspended = false
+                operations.forEach { $0.cancel() }
+                sleep(1)
+                super.cancel()
+            }
+        }
+        
+        let delay = DelayOperation(interval: 10)
+        let group = SleepingGroupOperation(operations: [delay])
+        
+        let expectation = expectationWithDescription("Test: \(__FUNCTION__)")
+        group.addObserver(BlockObserver { observedOperation, errors in
+            NSOperationQueue.mainQueue().addOperationWithBlock {
+                // Fails this assertion
+                XCTAssertTrue(observedOperation.cancelled)
+                expectation.fulfill()
+            }
+        })
+        
+        runOperation(group)
+        group.cancel()
+        
+        waitForExpectationsWithTimeout(5, handler: nil)
+        // Fails this assertion too
+        XCTAssertTrue(group.cancelled)
+    }
 
     func test__group_operations_are_performed_in_order() {
         let group = createGroupOperations()

--- a/Tests/Core/GroupOperationTests.swift
+++ b/Tests/Core/GroupOperationTests.swift
@@ -30,11 +30,11 @@ class GroupOperationTests: OperationTests {
     func test__cancel_running_group_operation_race_condition() {
         class SleepingGroupOperation: GroupOperation {
             override func cancel() {
+                super.cancel()
+                sleep(1)
                 queue.cancelAllOperations()
                 queue.suspended = false
                 operations.forEach { $0.cancel() }
-                sleep(1)
-                super.cancel()
             }
         }
         
@@ -44,7 +44,6 @@ class GroupOperationTests: OperationTests {
         let expectation = expectationWithDescription("Test: \(__FUNCTION__)")
         group.addObserver(BlockObserver { observedOperation, errors in
             NSOperationQueue.mainQueue().addOperationWithBlock {
-                // Fails this assertion
                 XCTAssertTrue(observedOperation.cancelled)
                 expectation.fulfill()
             }
@@ -54,7 +53,6 @@ class GroupOperationTests: OperationTests {
         group.cancel()
         
         waitForExpectationsWithTimeout(5, handler: nil)
-        // Fails this assertion too
         XCTAssertTrue(group.cancelled)
     }
 


### PR DESCRIPTION
Currently, there's a race condition in `GroupOperation` when cancelling. Since the group first cancels its composing operations before setting its own `_cancelled` flag, sometimes the internal queue will finish and the group operation will finish before `super.cancel()` is run, resulting in the `_cancelled` flag never being set.

Look at 431dd07 for a test proving the race condition exists by inserting a sleep between `queue.cancelAllOperations` and `super.cancel()`

This PR remedies the problem by calling `super` first and setting the groups own state before cancelling its children.