### PR TITLE
Operation Profiler

### DIFF
--- a/Operations.xcodeproj/project.pbxproj
+++ b/Operations.xcodeproj/project.pbxproj
@@ -693,13 +693,13 @@
 				652617151C11F5EB00654091 /* NetworkObserverTests.swift */,
 				652617161C11F5EB00654091 /* NoFailedDependenciesConditionTests.swift */,
 				652617171C11F5EB00654091 /* OperationTests.swift */,
+				6565FFE91C98C860008B5248 /* ProfilerTests.swift */,
 				65E4CDE61C33F97900B9F9D8 /* RepeatedOperationTests.swift */,
 				65691C9D1C21A29C00AF06B4 /* ResultInjectionTests.swift */,
 				65AE14961C34865E00F592D2 /* RetryOperationTests.swift */,
 				652617181C11F5EB00654091 /* SilentConditionTests.swift */,
 				652617191C11F5EB00654091 /* TimeoutObserverTests.swift */,
 				6526171A1C11F5EB00654091 /* UIOperationTests.swift */,
-				6565FFE91C98C860008B5248 /* ProfilerTests.swift */,
 			);
 			path = Core;
 			sourceTree = "<group>";

--- a/Operations.xcodeproj/project.pbxproj
+++ b/Operations.xcodeproj/project.pbxproj
@@ -238,6 +238,13 @@
 		6526197B1C11FE6D00654091 /* AddressBookConditionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6526171D1C11F5EB00654091 /* AddressBookConditionTests.swift */; };
 		6526197C1C11FE6D00654091 /* AddressBookTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6526171E1C11F5EB00654091 /* AddressBookTests.swift */; };
 		6526197D1C11FE6D00654091 /* ContactsOperationsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 652617201C11F5EB00654091 /* ContactsOperationsTests.swift */; };
+		6565FFE51C98B7AC008B5248 /* Profiler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6565FFE41C98B7AC008B5248 /* Profiler.swift */; };
+		6565FFE61C98B7AC008B5248 /* Profiler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6565FFE41C98B7AC008B5248 /* Profiler.swift */; };
+		6565FFE71C98B7AC008B5248 /* Profiler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6565FFE41C98B7AC008B5248 /* Profiler.swift */; };
+		6565FFE81C98B7AC008B5248 /* Profiler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6565FFE41C98B7AC008B5248 /* Profiler.swift */; };
+		6565FFEA1C98C860008B5248 /* ProfilerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6565FFE91C98C860008B5248 /* ProfilerTests.swift */; };
+		6565FFEB1C98C860008B5248 /* ProfilerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6565FFE91C98C860008B5248 /* ProfilerTests.swift */; };
+		6565FFEC1C98C860008B5248 /* ProfilerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6565FFE91C98C860008B5248 /* ProfilerTests.swift */; };
 		65691C9E1C21A29C00AF06B4 /* ResultInjectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65691C9D1C21A29C00AF06B4 /* ResultInjectionTests.swift */; };
 		65691C9F1C21A29C00AF06B4 /* ResultInjectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65691C9D1C21A29C00AF06B4 /* ResultInjectionTests.swift */; };
 		65691CA01C21A29C00AF06B4 /* ResultInjectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65691C9D1C21A29C00AF06B4 /* ResultInjectionTests.swift */; };
@@ -401,6 +408,8 @@
 		652617E91C11F72A00654091 /* Operations.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Operations.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		652617F21C11F72A00654091 /* OS X OperationsTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "OS X OperationsTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		652618561C11F84800654091 /* Extension Compatible.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = "Extension Compatible.xcconfig"; sourceTree = "<group>"; };
+		6565FFE41C98B7AC008B5248 /* Profiler.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Profiler.swift; sourceTree = "<group>"; };
+		6565FFE91C98C860008B5248 /* ProfilerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProfilerTests.swift; sourceTree = "<group>"; };
 		65691C9D1C21A29C00AF06B4 /* ResultInjectionTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ResultInjectionTests.swift; sourceTree = "<group>"; };
 		657DBA321C208830001E00F3 /* BlockObserverTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BlockObserverTests.swift; sourceTree = "<group>"; };
 		658158441C20DBAD0086FB2A /* ResultInjection.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ResultInjection.swift; sourceTree = "<group>"; };
@@ -534,6 +543,7 @@
 				652616DC1C11F5EB00654091 /* OperationCondition.swift */,
 				652616DD1C11F5EB00654091 /* OperationObserver.swift */,
 				652616DE1C11F5EB00654091 /* OperationQueue.swift */,
+				6565FFE41C98B7AC008B5248 /* Profiler.swift */,
 				650852301C8B23580058F8AA /* Repeatable.swift */,
 				65E4CDE11C33427500B9F9D8 /* RepeatedOperation.swift */,
 				658158441C20DBAD0086FB2A /* ResultInjection.swift */,
@@ -689,6 +699,7 @@
 				652617181C11F5EB00654091 /* SilentConditionTests.swift */,
 				652617191C11F5EB00654091 /* TimeoutObserverTests.swift */,
 				6526171A1C11F5EB00654091 /* UIOperationTests.swift */,
+				6565FFE91C98C860008B5248 /* ProfilerTests.swift */,
 			);
 			path = Core;
 			sourceTree = "<group>";
@@ -1153,6 +1164,7 @@
 				652618611C11F8FC00654091 /* BlockOperation.swift in Sources */,
 				652618621C11F8FC00654091 /* ComposedOperation.swift in Sources */,
 				652618AF1C11F91200654091 /* CalendarCapability.swift in Sources */,
+				6565FFE51C98B7AC008B5248 /* Profiler.swift in Sources */,
 				652618721C11F8FC00654091 /* TimeoutObserver.swift in Sources */,
 				652618631C11F8FC00654091 /* DelayOperation.swift in Sources */,
 				652618D11C11F93D00654091 /* NetworkObserver.swift in Sources */,
@@ -1215,6 +1227,7 @@
 				6526196D1C11FE6900654091 /* CalendarCapabilityTests.swift in Sources */,
 				652619201C11FC3D00654091 /* ComposedOperationTests.swift in Sources */,
 				652619281C11FC3D00654091 /* NoFailedDependenciesConditionTests.swift in Sources */,
+				6565FFEA1C98C860008B5248 /* ProfilerTests.swift in Sources */,
 				65C98C771C284EA600BA76B7 /* FunctionalOperationsTests.swift in Sources */,
 				652619251C11FC3D00654091 /* MutualExclusiveTests.swift in Sources */,
 				652619291C11FC3D00654091 /* OperationTests.swift in Sources */,
@@ -1273,6 +1286,7 @@
 				65BB56D81C70F29500DF5211 /* ThreadSafety.swift in Sources */,
 				652618811C11F8FD00654091 /* OperationCondition.swift in Sources */,
 				650852371C8B23950058F8AA /* Generators.swift in Sources */,
+				6565FFE61C98B7AC008B5248 /* Profiler.swift in Sources */,
 				650852411C8B2E460058F8AA /* CloudKitOperationExtensions.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1311,6 +1325,7 @@
 				6526188C1C11F8FE00654091 /* ExclusivityManager.swift in Sources */,
 				652618911C11F8FE00654091 /* MutuallyExclusive.swift in Sources */,
 				652618901C11F8FE00654091 /* LoggingObserver.swift in Sources */,
+				6565FFE71C98B7AC008B5248 /* Profiler.swift in Sources */,
 				6526188E1C11F8FE00654091 /* GroupOperation.swift in Sources */,
 				652618961C11F8FE00654091 /* OperationObserver.swift in Sources */,
 				652618C01C11F91400654091 /* Capability.swift in Sources */,
@@ -1333,6 +1348,7 @@
 				652619311C11FC3E00654091 /* GatedOperationTests.swift in Sources */,
 				652619331C11FC3E00654091 /* LoggingObserverTests.swift in Sources */,
 				6526193C1C11FC3E00654091 /* UIOperationTests.swift in Sources */,
+				6565FFEB1C98C860008B5248 /* ProfilerTests.swift in Sources */,
 				652619371C11FC3E00654091 /* NetworkObserverTests.swift in Sources */,
 				652619651C11FD9900654091 /* ReachabilityConditionTests.swift in Sources */,
 				65EE50C71C3C198600152774 /* CloudKitOperationTests.swift in Sources */,
@@ -1398,6 +1414,7 @@
 				6526189B1C11F8FF00654091 /* BlockCondition.swift in Sources */,
 				6508523E1C8B2E320058F8AA /* CloudKitInterface.swift in Sources */,
 				65E4CDE01C33422100B9F9D8 /* RetryOperation.swift in Sources */,
+				6565FFE81C98B7AC008B5248 /* Profiler.swift in Sources */,
 				65E4CDE51C33427500B9F9D8 /* RepeatedOperation.swift in Sources */,
 				652618A31C11F8FF00654091 /* Logging.swift in Sources */,
 				6526189C1C11F8FF00654091 /* BlockObserver.swift in Sources */,
@@ -1436,6 +1453,7 @@
 				65E4CDE91C33F97900B9F9D8 /* RepeatedOperationTests.swift in Sources */,
 				6526196B1C11FDF300654091 /* ContactsOperationsTests.swift in Sources */,
 				6526194B1C11FC3F00654091 /* TimeoutObserverTests.swift in Sources */,
+				6565FFEC1C98C860008B5248 /* ProfilerTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Sources/Core/Shared/Logging.swift
+++ b/Sources/Core/Shared/Logging.swift
@@ -191,6 +191,15 @@ public extension LoggerType {
     }
 }
 
+public protocol LogManagerType {
+
+    static var enabled: Bool { get set }
+
+    static var severity: LogSeverity { get set }
+
+    static var logger: LoggerBlockType { get set }
+}
+
 /**
  This is a simple class which owns a logging block. It can be subclassed
  if customization is required, but it is probably easier to customise the
@@ -225,15 +234,6 @@ class _Logger<Manager: LogManagerType>: LoggerType {
 }
 
 typealias Logger = _Logger<LogManager>
-
-protocol LogManagerType {
-
-    static var enabled: Bool { get set }
-
-    static var severity: LogSeverity { get set }
-
-    static var logger: LoggerBlockType { get set }
-}
 
 /**
  # LogManager

--- a/Sources/Core/Shared/Operation.swift
+++ b/Sources/Core/Shared/Operation.swift
@@ -117,6 +117,9 @@ public class Operation: NSOperation {
         }
     }
 
+    /// - returns: a unique String which can be used to identify the operation instance
+    public let identifier = NSUUID().UUIDString
+
     /// Access the internal errors collected by the Operation
     public var errors: [ErrorType] {
         return _internalErrors

--- a/Sources/Core/Shared/OperationObserver.swift
+++ b/Sources/Core/Shared/OperationObserver.swift
@@ -8,6 +8,21 @@
 
 import Foundation
 
+public enum OperationEvent: Int {
+    case Attached = 0, Started, Cancelled, Finished
+}
+
+extension OperationEvent: CustomStringConvertible {
+    public var description: String {
+        switch self {
+        case .Attached: return "Attached"
+        case .Started: return "Started"
+        case .Cancelled: return "Cancelled"
+        case .Finished: return "Finished"
+        }
+    }
+}
+
 /**
  Types which conform to this protocol, can be attached to `Operation` subclasses before
  they are added to a queue.

--- a/Sources/Core/Shared/OperationObserver.swift
+++ b/Sources/Core/Shared/OperationObserver.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 public enum OperationEvent: Int {
-    case Attached = 0, Started, Cancelled, Finished
+    case Attached = 0, Started, Cancelled, Produced, Finished
 }
 
 extension OperationEvent: CustomStringConvertible {
@@ -18,6 +18,7 @@ extension OperationEvent: CustomStringConvertible {
         case .Attached: return "Attached"
         case .Started: return "Started"
         case .Cancelled: return "Cancelled"
+        case .Produced: return "Produced"
         case .Finished: return "Finished"
         }
     }

--- a/Sources/Core/Shared/Profiler.swift
+++ b/Sources/Core/Shared/Profiler.swift
@@ -14,18 +14,11 @@ public protocol Identifiable {
     var identifier: String { get }
 }
 
-public extension Identifiable {
-
-    var hashValue: Int {
-        return identifier.hashValue
-    }
-}
-
 public func ==<T: Identifiable> (lhs: T, rhs: T) -> Bool {
     return lhs.identifier == rhs.identifier
 }
 
-public struct OperationIdentity: Identifiable, Equatable, Hashable {
+public struct OperationIdentity: Identifiable, Equatable {
     public let identifier: String
     public let name: String?
 }
@@ -144,7 +137,7 @@ struct PendingResult {
     }
 }
 
-public final class OperationProfiler: Identifiable, Equatable, Hashable {
+public final class OperationProfiler: Identifiable, Equatable {
 
     enum Reporter {
         case Parent(OperationProfiler)

--- a/Sources/Core/Shared/Profiler.swift
+++ b/Sources/Core/Shared/Profiler.swift
@@ -204,11 +204,9 @@ extension OperationProfiler: OperationProfilerReporter {
     public func profiler(profiler: OperationProfiler, finishedWithPerformanceMetrics performanceMetrics: [PerformanceMetric]) {
         let childIdentifier = profiler.identifier
 
-        // Update Pending Child with Finished Child
         dispatch_sync(queue) {
             if let (index, child) = self.indexOfProducedChildPendingWithIdentifier(childIdentifier, metrics: self.metrics) {
-                let finished: PerformanceMetric = .Produced(child.finishWithMetrics(performanceMetrics))
-                self.metrics[index] = finished
+                self.metrics[index] = .Produced(child.finishWithMetrics(performanceMetrics))
                 self.finish()
             }
         }
@@ -350,13 +348,6 @@ public extension OperationProfiler {
 
     convenience init(_ reporter: OperationProfilerReporter = OperationProfileLogger()) {
         self.init(reporters: [reporter])
-    }
-}
-
-extension ForwardIndexType {
-
-    var range: Range<Self> {
-        return Range(start: self, end: self)
     }
 }
 

--- a/Sources/Core/Shared/Profiler.swift
+++ b/Sources/Core/Shared/Profiler.swift
@@ -50,8 +50,8 @@ public enum PerformanceMetric {
             switch status {
             case .Pending(_):
                 return true
-            case .Finished(let metrics):
-                return metrics.filter { $0.pending }.count > 0
+            default:
+                return false
             }
         }
 
@@ -103,13 +103,10 @@ public enum PerformanceMetric {
     var pending: Bool {
         switch self {
         case .Produced(let child):
-            if case .Pending = child.status {
-                return true
-            }
+            return child.pending
         default:
-            break
+            return false
         }
-        return false
     }
 
     init?(event: OperationEvent, interval: NSTimeInterval) {
@@ -202,10 +199,8 @@ extension OperationProfiler.Reporter: OperationProfilerReporter {
 extension OperationProfiler: OperationProfilerReporter {
 
     public func profiler(profiler: OperationProfiler, finishedWithPerformanceMetrics performanceMetrics: [PerformanceMetric]) {
-        let childIdentifier = profiler.identifier
-
         dispatch_sync(queue) {
-            if let (index, child) = self.indexOfProducedChildPendingWithIdentifier(childIdentifier, metrics: self.metrics) {
+            if let (index, child) = self.indexOfProducedChildPendingWithIdentifier(profiler.identifier, metrics: self.metrics) {
                 self.metrics[index] = .Produced(child.finishWithMetrics(performanceMetrics))
                 self.finish()
             }

--- a/Sources/Core/Shared/Profiler.swift
+++ b/Sources/Core/Shared/Profiler.swift
@@ -1,0 +1,147 @@
+//
+//  Profiler.swift
+//  Operations
+//
+//  Created by Daniel Thorpe on 15/03/2016.
+//
+//
+
+import Foundation
+
+/**
+ - We will want to be able to track produced & grouped operations
+
+public typealias TimeIntervalToEvent = (interval: NSTimeInterval, event: OperationEvent)
+
+public enum PerformanceMetric {
+    case ElapsedTimeToEvent(TimeIntervalToEvent)
+    case Produced([PerformanceMetric])
+}
+
+*/
+
+public struct PerformanceMetric {
+    let interval: NSTimeInterval
+    let event: OperationEvent
+}
+
+extension PerformanceMetric: CustomStringConvertible {
+    public var description: String {
+        return "\(interval) \(event)"
+    }
+}
+
+public protocol OperationProfilerReporter: class {
+    func operation(operation: Operation, profiled: OperationProfiler, withPerformanceMetrics: [PerformanceMetric])
+}
+
+public class OperationProfiler {
+
+    let now: CFAbsoluteTime = CFAbsoluteTimeGetCurrent()
+    let queue = Queue.Utility.serial("me.danthorpe.Operations.Profiler")
+    var metrics: [PerformanceMetric] = []
+
+    let reporters: [OperationProfilerReporter]
+
+    public init(reporters: [OperationProfilerReporter]) {
+        self.reporters = reporters
+    }
+
+    func addMetricNow(time: CFAbsoluteTime = CFAbsoluteTimeGetCurrent(), forOperation operation: Operation, event: OperationEvent) {
+        dispatch_sync(queue) {
+            self.metrics.append(PerformanceMetric(interval: (time - self.now) as NSTimeInterval, event: event))
+        }
+    }
+
+    func finishOperation(operation: Operation) {
+        let report = reportOperation(operation, withMetrics: metrics)
+        dispatch_sync(queue) {
+            self.reporters.forEach(report)
+        }
+    }
+
+    func reportOperation(operation: Operation, withMetrics metrics: [PerformanceMetric]) -> OperationProfilerReporter -> Void {
+        return { $0.operation(operation, profiled: self, withPerformanceMetrics: metrics)  }
+    }
+}
+
+extension OperationProfiler: OperationObserverType {
+
+    public func didAttachToOperation(operation: Operation) {
+        addMetricNow(forOperation: operation, event: .Attached)
+    }
+}
+
+extension OperationProfiler: OperationDidStartObserver {
+
+    public func didStartOperation(operation: Operation) {
+        addMetricNow(forOperation: operation, event: .Started)
+    }
+}
+
+extension OperationProfiler: OperationDidCancelObserver {
+
+    public func didCancelOperation(operation: Operation) {
+        addMetricNow(forOperation: operation, event: .Cancelled)
+        finishOperation(operation)
+    }
+}
+
+extension OperationProfiler: OperationDidFinishObserver {
+
+    public func didFinishOperation(operation: Operation, errors: [ErrorType]) {
+        addMetricNow(forOperation: operation, event: .Finished)
+        finishOperation(operation)
+    }
+}
+
+struct PrintablePerformanceMetric: CustomStringConvertible {
+    let indentation: Int
+    let spacing: Int
+    let metric: PerformanceMetric
+
+    var description: String {
+        return "\(createIndentation())+\(metric.interval)\(createSpacing())\(metric.event)"
+    }
+
+    init(indentation: Int = 0, spacing: Int = 1, metric: PerformanceMetric) {
+        self.indentation = indentation
+        self.spacing = spacing
+        self.metric = metric
+    }
+
+    func createIndentation() -> String {
+        return String(count: indentation, repeatedValue: " " as UnicodeScalar)
+    }
+
+    func createSpacing() -> String {
+        return String(count: spacing, repeatedValue: " " as UnicodeScalar)
+    }
+}
+
+public class _OperationProfileLogger<Manager: LogManagerType>: _Logger<Manager>, OperationProfilerReporter {
+
+    public required init(severity: LogSeverity = Manager.severity, enabled: Bool = Manager.enabled, logger: LoggerBlockType = Manager.logger) {
+        super.init(severity: severity, enabled: enabled, logger: logger)
+    }
+
+    public func operation(operation: Operation, profiled: OperationProfiler, withPerformanceMetrics metrics: [PerformanceMetric]) {
+        operationName = operation.operationName
+        var output = ""
+        let printableMetrics = metrics.map { PrintablePerformanceMetric(metric: $0) }
+        for metric in printableMetrics {
+            output = "\(output)\n\t\(metric)"
+        }
+
+        info("finished with perfomance metrics:\(output)")
+    }
+}
+
+public typealias OperationProfileLogger = _OperationProfileLogger<LogManager>
+
+public extension OperationProfiler {
+
+    convenience init(_ reporter: OperationProfilerReporter = OperationProfileLogger()) {
+        self.init(reporters: [reporter])
+    }
+}

--- a/Sources/Core/Shared/Profiler.swift
+++ b/Sources/Core/Shared/Profiler.swift
@@ -44,11 +44,6 @@ public extension Operation {
     }
 }
 
-enum ProfilerError: ErrorType {
-    case ResultStillPending
-    case ResultNotAvailable
-}
-
 public protocol OperationProfilerReporter {
     func finishedProfilingWithResult(result: ProfileResult)
 }
@@ -84,16 +79,16 @@ func == <T: Equatable>(lhs: PendingValue<T>, rhs: PendingValue<T>) -> Bool {
 }
 
 public struct ProfileResult {
-    let identity: OperationIdentity
-    let created: NSTimeInterval
-    let attached: NSTimeInterval
-    let started: NSTimeInterval
-    let cancelled: NSTimeInterval?
-    let finished: NSTimeInterval?
-    let children: [ProfileResult]
+    public let identity: OperationIdentity
+    public let created: NSTimeInterval
+    public let attached: NSTimeInterval
+    public let started: NSTimeInterval
+    public let cancelled: NSTimeInterval?
+    public let finished: NSTimeInterval?
+    public let children: [ProfileResult]
 }
 
-public struct PendingResult: Identifiable, Equatable, Hashable {
+struct PendingResult {
 
     let created: NSTimeInterval
     let identity: PendingValue<OperationIdentity>
@@ -102,10 +97,6 @@ public struct PendingResult: Identifiable, Equatable, Hashable {
     let cancelled: PendingValue<NSTimeInterval>
     let finished: PendingValue<NSTimeInterval>
     let children: [ProfileResult]
-
-    public var identifier: String {
-        return identity.value?.identifier ?? "Pending Result Identifier"
-    }
 
     var pending: Bool {
         return identity.pending || attached.pending || started.pending || (cancelled.pending && finished.pending)
@@ -158,20 +149,6 @@ public final class OperationProfiler: Identifiable, Equatable, Hashable {
     enum Reporter {
         case Parent(OperationProfiler)
         case Reporters([OperationProfilerReporter])
-    }
-
-    struct State {
-        var result: PendingResult
-        var children: [OperationIdentity]
-
-        static func create() -> State {
-            return State(
-                // Pending Results, including finished children
-                result: PendingResult(created: CFAbsoluteTimeGetCurrent() as NSTimeInterval, identity: .Pending, attached: .Pending, started: .Pending, cancelled: .Pending, finished: .Pending, children: []),
-                // The ientities of pending children
-                children: []
-            )
-        }
     }
 
     public let identifier = NSUUID().UUIDString

--- a/Sources/Core/Shared/ThreadSafety.swift
+++ b/Sources/Core/Shared/ThreadSafety.swift
@@ -10,6 +10,7 @@ import Foundation
 
 protocol ReadWriteLock {
     mutating func read<T>(block: () -> T) -> T
+    mutating func read<T>(block: () throws -> T) rethrows -> T
     mutating func write(block: () -> Void, completion: (() -> Void)?)
 }
 
@@ -28,6 +29,14 @@ struct Lock: ReadWriteLock {
         var object: T!
         dispatch_sync(queue) {
             object = block()
+        }
+        return object
+    }
+
+    mutating func read<T>(block: () throws -> T) rethrows -> T {
+        var object: T!
+        try dispatch_sync(queue) {
+            object = try block()
         }
         return object
     }
@@ -55,6 +64,10 @@ internal class Protector<T> {
         return lock.read { [unowned self] in block(self.ward) }
     }
 
+    func read<U>(block: T throws -> U) throws -> U {
+        return try lock.read { [unowned self] in try block(self.ward) }
+    }
+
     func write(block: (inout T) -> Void) {
         lock.write({ block(&self.ward) })
     }
@@ -77,4 +90,31 @@ extension Protector where T: _ArrayType {
             ward.appendContentsOf(newElements)
         })
     }
+}
+
+public func dispatch_sync(queue: dispatch_queue_t, _ block: () throws -> Void) rethrows {
+    var failure: ErrorType? = .None
+
+    let catcher = {
+        do {
+            try block()
+        }
+        catch {
+            failure = error
+        }
+    }
+
+    dispatch_sync(queue, catcher)
+
+    if let failure = failure {
+        try { throw failure }()
+    }
+}
+
+public func dispatch_sync<T>(queue: dispatch_queue_t, _ block: () throws -> T) rethrows -> T {
+    var result: T!
+    try dispatch_sync(queue) {
+        result = try block()
+    }
+    return result
 }

--- a/Tests/Core/ProfilerTests.swift
+++ b/Tests/Core/ProfilerTests.swift
@@ -13,7 +13,7 @@ class ProfilerTests: OperationTests {
 
     func test_does_it_work() {
         LogManager.severity = .Info
-        let operation = TestOperation()
+        let operation = TestOperation(delay: 1)
         operation.addObserver(OperationProfiler())
         waitForOperation(operation)
         LogManager.severity = .Fatal

--- a/Tests/Core/ProfilerTests.swift
+++ b/Tests/Core/ProfilerTests.swift
@@ -35,24 +35,102 @@ class ProfilerTests: OperationTests {
 
 class PendingResultTests: XCTestCase {
 
-    var result: PendingResult! = nil
+    let created = CFAbsoluteTimeGetCurrent() as NSTimeInterval
+    var elapsed: NSTimeInterval!
+    var now: NSTimeInterval!
+    var identity: OperationIdentity!
+    var result: PendingResult!
 
     override func setUp() {
         super.setUp()
-        result = PendingResult(created: CFAbsoluteTimeGetCurrent() as NSTimeInterval, identity: .Pending, attached: .Pending, started: .Pending, cancelled: .Pending, finished: .Pending, children: [])
+        elapsed = 10.0
+        now = created + 10.0
+        identity = OperationIdentity(identifier: "Hello World", name: .None)
+        result = PendingResult(created: created, identity: .Pending, attached: .Pending, started: .Pending, cancelled: .Pending, finished: .Pending, children: [])
     }
 
     override func tearDown() {
         result = nil
+        identity = nil
         super.tearDown()
     }
 
-    func test_identifier_with_pending_identity() {
+    func test_identifier__with_pending_identity() {
         XCTAssertEqual(result.identifier, "Pending Result Identifier")
     }
 
-    func test_identifier_with_identity() {
-        result = result.setIdentity(OperationIdentity(identifier: "Hello World", name: .None))
+    func test_identifier__with_identity() {
+        result = result.setIdentity(identity)
         XCTAssertEqual(result.identifier, "Hello World")
     }
+
+    func test_pending__with_pending_identity() {
+        XCTAssertTrue(result.pending)
+    }
+
+    func test_pending__with_identity() {
+        XCTAssertTrue(result.setIdentity(identity).pending)
+    }
+
+    func test_pending__with_identity_attached_started() {
+        XCTAssertTrue(result.setIdentity(identity).attach().start().pending)
+    }
+
+    func test_pending__with_identity_attached_started_cancelled() {
+        XCTAssertFalse(result.setIdentity(identity).attach().start().cancel().pending)
+    }
+
+    func test_pending__with_identity_attached_started_finished() {
+        XCTAssertFalse(result.setIdentity(identity).attach().start().finish().pending)
+    }
+
+    func test_set_identity__when_already_set() {
+        result = result.setIdentity(identity).setIdentity(OperationIdentity(identifier: "Goodbye!", name: .None))
+        XCTAssertEqual(result.identifier, "Hello World")
+    }
+
+    func test_attach__when_pending() {
+        result = result.attach(now)
+        XCTAssertEqual(result.attached.value, elapsed)
+    }
+
+    func test_attach__when_already_set() {
+        result = result.attach()
+        XCTAssertNotEqual(result.attached, PendingValue<NSTimeInterval>.Pending)
+        XCTAssertEqual(result.attached, result.attach(0.0).attached)
+    }
+
+    func test_start__when_pending() {
+        result = result.start(now)
+        XCTAssertEqual(result.started.value, elapsed)
+    }
+
+    func test_start__when_already_set() {
+        result = result.start()
+        XCTAssertNotEqual(result.started, PendingValue<NSTimeInterval>.Pending)
+        XCTAssertEqual(result.started, result.start(0.0).started)
+    }
+
+    func test_cancel__when_pending() {
+        result = result.cancel(now)
+        XCTAssertEqual(result.cancelled.value, elapsed)
+    }
+
+    func test_cancel__when_already_set() {
+        result = result.cancel()
+        XCTAssertNotEqual(result.cancelled, PendingValue<NSTimeInterval>.Pending)
+        XCTAssertEqual(result.cancelled, result.cancel(0.0).cancelled)
+    }
+
+    func test_finish__when_pending() {
+        result = result.finish(now)
+        XCTAssertEqual(result.finished.value, elapsed)
+    }
+
+    func test_finish__when_already_set() {
+        result = result.finish()
+        XCTAssertNotEqual(result.finished, PendingValue<NSTimeInterval>.Pending)
+        XCTAssertEqual(result.finished, result.finish(0.0).finished)
+    }
+
 }

--- a/Tests/Core/ProfilerTests.swift
+++ b/Tests/Core/ProfilerTests.swift
@@ -11,11 +11,56 @@ import XCTest
 
 class ProfilerTests: OperationTests {
 
-    func test_does_it_work() {
+    override func setUp() {
+        super.setUp()
         LogManager.severity = .Info
-        let operation = TestOperation(delay: 1)
-        operation.addObserver(OperationProfiler())
-        waitForOperation(operation)
-        LogManager.severity = .Fatal
     }
+
+    override func tearDown() {
+        LogManager.severity = .Fatal
+        super.tearDown()
+    }
+
+    func test_does_it_work() {
+        let first = TestOperation(delay: 0.1)
+        first.name = "One"
+        first.addObserver(OperationProfiler())
+
+        addCompletionBlockToTestOperation(first)
+        runOperation(first)
+        waitForExpectationsWithTimeout(3, handler: nil)
+    }
+
+    func test_does_it_work_produce_one() {
+        let second = TestOperation(delay: 0.2)
+        second.name = "Two"
+
+        let first = TestOperation(delay: 0.1, produced: second)
+        first.name = "One"
+        first.addObserver(OperationProfiler())
+
+        addCompletionBlockToTestOperation(second)
+        addCompletionBlockToTestOperation(first)
+        runOperation(first)
+        waitForExpectationsWithTimeout(3, handler: nil)
+    }
+
+    func test_does_it_work_produce_two() {
+        let third = TestOperation(delay: 0.3)
+        third.name = "Three"
+
+        let second = TestOperation(delay: 0.2, produced: third)
+        second.name = "Two"
+
+        let first = TestOperation(delay: 0.1, produced: second)
+        first.name = "One"
+        first.addObserver(OperationProfiler())
+
+        addCompletionBlockToTestOperation(third)
+        addCompletionBlockToTestOperation(second)
+        addCompletionBlockToTestOperation(first)
+        runOperation(first)
+        waitForExpectationsWithTimeout(3, handler: nil)
+    }
+
 }

--- a/Tests/Core/ProfilerTests.swift
+++ b/Tests/Core/ProfilerTests.swift
@@ -1,0 +1,21 @@
+//
+//  ProfilerTests.swift
+//  Operations
+//
+//  Created by Daniel Thorpe on 15/03/2016.
+//
+//
+
+import XCTest
+@testable import Operations
+
+class ProfilerTests: OperationTests {
+
+    func test_does_it_work() {
+        LogManager.severity = .Info
+        let operation = TestOperation()
+        operation.addObserver(OperationProfiler())
+        waitForOperation(operation)
+        LogManager.severity = .Fatal
+    }
+}

--- a/Tests/Core/ProfilerTests.swift
+++ b/Tests/Core/ProfilerTests.swift
@@ -32,12 +32,19 @@ class ProfilerTests: OperationTests {
     }
 }
 
+class PendingValueTests: XCTestCase {
+
+    func test__equality_pending() {
+        XCTAssertEqual(PendingValue<Int>.Pending, PendingValue<Int>.Pending)
+    }
+}
 
 class PendingResultTests: XCTestCase {
 
     let created = CFAbsoluteTimeGetCurrent() as NSTimeInterval
     var elapsed: NSTimeInterval!
     var now: NSTimeInterval!
+    var child: ProfileResult!
     var identity: OperationIdentity!
     var result: PendingResult!
 
@@ -45,6 +52,7 @@ class PendingResultTests: XCTestCase {
         super.setUp()
         elapsed = 10.0
         now = created + 10.0
+        child = ProfileResult(identity: OperationIdentity(identifier: "Child", name: .None), created: 0, attached: 1, started: 2, cancelled: .None, finished: 3, children: [])
         identity = OperationIdentity(identifier: "Hello World", name: .None)
         result = PendingResult(created: created, identity: .Pending, attached: .Pending, started: .Pending, cancelled: .Pending, finished: .Pending, children: [])
     }
@@ -55,82 +63,115 @@ class PendingResultTests: XCTestCase {
         super.tearDown()
     }
 
-    func test_identifier__with_pending_identity() {
-        XCTAssertEqual(result.identifier, "Pending Result Identifier")
-    }
-
-    func test_identifier__with_identity() {
-        result = result.setIdentity(identity)
-        XCTAssertEqual(result.identifier, "Hello World")
-    }
-
-    func test_pending__with_pending_identity() {
+    func test__pending__with_pending_identity() {
         XCTAssertTrue(result.pending)
     }
 
-    func test_pending__with_identity() {
+    func test__pending__with_identity() {
         XCTAssertTrue(result.setIdentity(identity).pending)
     }
 
-    func test_pending__with_identity_attached_started() {
+    func test__pending__with_identity_attached_started() {
         XCTAssertTrue(result.setIdentity(identity).attach().start().pending)
     }
 
-    func test_pending__with_identity_attached_started_cancelled() {
+    func test__pending__with_identity_attached_started_cancelled() {
         XCTAssertFalse(result.setIdentity(identity).attach().start().cancel().pending)
     }
 
-    func test_pending__with_identity_attached_started_finished() {
+    func test__pending__with_identity_attached_started_finished() {
         XCTAssertFalse(result.setIdentity(identity).attach().start().finish().pending)
     }
 
-    func test_set_identity__when_already_set() {
+    func test__set_identity__when_already_set() {
         result = result.setIdentity(identity).setIdentity(OperationIdentity(identifier: "Goodbye!", name: .None))
-        XCTAssertEqual(result.identifier, "Hello World")
+        XCTAssertEqual(result.identity.value?.identifier, "Hello World")
     }
 
-    func test_attach__when_pending() {
+    func test__attach__when_pending() {
         result = result.attach(now)
         XCTAssertEqual(result.attached.value, elapsed)
     }
 
-    func test_attach__when_already_set() {
+    func test__attach__when_already_set() {
         result = result.attach()
         XCTAssertNotEqual(result.attached, PendingValue<NSTimeInterval>.Pending)
         XCTAssertEqual(result.attached, result.attach(0.0).attached)
     }
 
-    func test_start__when_pending() {
+    func test__start__when_pending() {
         result = result.start(now)
         XCTAssertEqual(result.started.value, elapsed)
     }
 
-    func test_start__when_already_set() {
+    func test__start__when_already_set() {
         result = result.start()
         XCTAssertNotEqual(result.started, PendingValue<NSTimeInterval>.Pending)
         XCTAssertEqual(result.started, result.start(0.0).started)
     }
 
-    func test_cancel__when_pending() {
+    func test__cancel__when_pending() {
         result = result.cancel(now)
         XCTAssertEqual(result.cancelled.value, elapsed)
     }
 
-    func test_cancel__when_already_set() {
+    func test__cancel__when_already_set() {
         result = result.cancel()
         XCTAssertNotEqual(result.cancelled, PendingValue<NSTimeInterval>.Pending)
         XCTAssertEqual(result.cancelled, result.cancel(0.0).cancelled)
     }
 
-    func test_finish__when_pending() {
+    func test__finish__when_pending() {
         result = result.finish(now)
         XCTAssertEqual(result.finished.value, elapsed)
     }
 
-    func test_finish__when_already_set() {
+    func test__finish__when_already_set() {
         result = result.finish()
         XCTAssertNotEqual(result.finished, PendingValue<NSTimeInterval>.Pending)
         XCTAssertEqual(result.finished, result.finish(0.0).finished)
     }
 
+    func test__add_child() {
+        result = result.addChild(child)
+        XCTAssertEqual(result.children.count, 1)
+        XCTAssertEqual(result.children[0].finished, 3)
+    }
+
+    func test__create_result_when_pending() {
+        XCTAssertNil(result.createResult())
+    }
+
+    func test__create_result__finished__cancelled_is_none() {
+        let profileResult = result.setIdentity(identity).attach().start().finish().createResult()
+        XCTAssertNil(profileResult?.cancelled)
+    }
+
+    func test__create_result__cancelled__finish_is_none() {
+        let profileResult = result.setIdentity(identity).attach().start().cancel().createResult()
+        XCTAssertNil(profileResult?.finished)
+    }
+
+    func test__create_result__with_children() {
+        let profileResult = result.setIdentity(identity).attach().start().finish().addChild(child).createResult()
+        XCTAssertEqual(profileResult?.children.count ?? 0, 1)
+    }
+
 }
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/Tests/Core/ProfilerTests.swift
+++ b/Tests/Core/ProfilerTests.swift
@@ -311,7 +311,32 @@ class PrintableProfileResultTests: XCTestCase {
         printable = PrintableProfileResult(result: result)
         XCTAssertEqual(printable.description, "+0.1 Attached\n+0.2 Started\n-> Spawned Data Operation #Child 1 with profile results\n  +0.1 Attached\n  +0.2 Started\n  -> Spawned Unnamed Operation #Child 2 with profile results\n    +0.1 Attached\n    +0.2 Started\n    +0.3 Finished\n  +0.3 Finished\n+0.3 Finished\n")
     }
+}
 
+class ProfileLoggerTests: XCTestCase {
+
+    var result: ProfileResult!
+    var reporter: OperationProfileLogger!
+
+    override func setUp() {
+        super.setUp()
+        LogManager.severity = .Notice
+        result = ProfileResult(identity: OperationIdentity(identifier: "Testing", name: "MyOperation"), created: CFAbsoluteTimeGetCurrent() as NSTimeInterval, attached: 0.1, started: 0.2, cancelled: .None, finished: 0.3, children: [])
+    }
+
+    override func tearDown() {
+        result = nil
+        LogManager.severity = .Warning
+        super.tearDown()
+    }
+
+    func test__reporter_logs_name() {
+        reporter = OperationProfileLogger { message, severity, _, _, _ in
+            XCTAssertTrue(message.hasPrefix("MyOperation #Testing finished profiling with results:\n"))
+            XCTAssertEqual(severity, LogSeverity.Info)
+        }
+        reporter.finishedProfilingWithResult(result)
+    }
 
 }
 

--- a/Tests/Core/ProfilerTests.swift
+++ b/Tests/Core/ProfilerTests.swift
@@ -9,58 +9,50 @@
 import XCTest
 @testable import Operations
 
+class TestableProfileReporter: OperationProfilerReporter {
+    var didProfileResult: ProfileResult? = .None
+
+    func finishedProfilingWithResult(result: ProfileResult) {
+        didProfileResult = result
+    }
+}
+
 class ProfilerTests: OperationTests {
+
+    var reporter: TestableProfileReporter!
 
     override func setUp() {
         super.setUp()
-        LogManager.severity = .Info
+        reporter = TestableProfileReporter()
     }
 
     override func tearDown() {
-        LogManager.severity = .Fatal
+        reporter = nil
+        super.tearDown()
+    }
+}
+
+
+class PendingResultTests: XCTestCase {
+
+    var result: PendingResult! = nil
+
+    override func setUp() {
+        super.setUp()
+        result = PendingResult(created: CFAbsoluteTimeGetCurrent() as NSTimeInterval, identity: .Pending, attached: .Pending, started: .Pending, cancelled: .Pending, finished: .Pending, children: [])
+    }
+
+    override func tearDown() {
+        result = nil
         super.tearDown()
     }
 
-    func test_does_it_work() {
-        let first = TestOperation(delay: 0.1)
-        first.name = "One"
-        first.addObserver(OperationProfiler())
-
-        addCompletionBlockToTestOperation(first)
-        runOperation(first)
-        waitForExpectationsWithTimeout(3, handler: nil)
+    func test_identifier_with_pending_identity() {
+        XCTAssertEqual(result.identifier, "Pending Result Identifier")
     }
 
-    func test_does_it_work_produce_one() {
-        let second = TestOperation(delay: 0.2)
-        second.name = "Two"
-
-        let first = TestOperation(delay: 0.1, produced: second)
-        first.name = "One"
-        first.addObserver(OperationProfiler())
-
-        addCompletionBlockToTestOperation(second)
-        addCompletionBlockToTestOperation(first)
-        runOperation(first)
-        waitForExpectationsWithTimeout(3, handler: nil)
+    func test_identifier_with_identity() {
+        result = result.setIdentity(OperationIdentity(identifier: "Hello World", name: .None))
+        XCTAssertEqual(result.identifier, "Hello World")
     }
-
-    func test_does_it_work_produce_two() {
-        let third = TestOperation(delay: 0.3)
-        third.name = "Three"
-
-        let second = TestOperation(delay: 0.2, produced: third)
-        second.name = "Two"
-
-        let first = TestOperation(delay: 0.1, produced: second)
-        first.name = "One"
-        first.addObserver(OperationProfiler())
-
-        addCompletionBlockToTestOperation(third)
-        addCompletionBlockToTestOperation(second)
-        addCompletionBlockToTestOperation(first)
-        runOperation(first)
-        waitForExpectationsWithTimeout(3, handler: nil)
-    }
-
 }


### PR DESCRIPTION
This is an idea prompted by some stuff done by @itsthejb in his fork.

The aim is to provide a way to extract performance metrics from `Operation` instances in a way which is amenable to feeding into analytics and tooling. The purpose for this might be to provide end-to-end integration metrics or for full system diagnostics, or even just to set some idea of the performance of a particular `Operation`.

Now, I hasten to add, that there is a strong argument that shipping apps should not include any kind of performance metrics code. The flip side of the coin, especially if you have an app which is getting 10k-100k or more DAUs is that it is very tricky to diagnose performance problems across all of your user's environments. From different devices, to networks, carriers and countless others. The reality is that performance tests in your unit test bundle will not help diagnose or report the real world performance of your application.

So, here is the idea. We have `OperationProfiler` which itself is just an `OperationObserverType`. It's job is simply to record the timing split between all the events the Operation encounters, so it's a little bit like the deprecated `OperationLogger`.

However, it will be initialized (or is type constrained) so that when the operation finishes, it will report the metrics to a logger. For example, the profiling could just be sent onto the console. More likely however, framework consumers would have their own logger for this information, to e.g. store it and then send it into their analytics systems. The framework will not provide these, just the profiler, and a specialized logger.
 