### PR TITLE
Finish AlertOperation after call to handler

### DIFF
--- a/Sources/Core/iOS/AlertOperation.swift
+++ b/Sources/Core/iOS/AlertOperation.swift
@@ -89,8 +89,8 @@ public class AlertOperation<From: PresentingViewController>: Operation {
     public func addActionWithTitle(title: String, style: UIAlertActionStyle = .Default, handler: AlertOperation -> Void = { _ in }) {
         let action = UIAlertAction(title: title, style: style) { [weak self] _ in
             if let weakSelf = self {
-                weakSelf.finish()
                 handler(weakSelf)
+                weakSelf.finish()
             }
         }
         alert.addAction(action)


### PR DESCRIPTION
Is there a reason why it needed to be the other way around?

Currently I have a `GroupOperation` where the `AlertOperation` is the only one created at startup. Then depending on the option selected by the alert I add another operation to the group. 

However because finish is called before the alert handler, I get an error saying I can't add an operation to the group after it has finished