### PR TITLE
Support will add child operation observer in GroupOperation

### DIFF
--- a/Sources/Core/Shared/BlockObserver.swift
+++ b/Sources/Core/Shared/BlockObserver.swift
@@ -182,7 +182,6 @@ public struct DidFinishObserver: OperationDidFinishObserver {
 @available(*, unavailable, renamed="DidFinishObserver")
 public typealias FinishedObserver = DidFinishObserver
 
-
 /**
  A `OperationObserver` which accepts three different blocks for start,
  produce and finish.

--- a/Sources/Core/Shared/GroupOperation.swift
+++ b/Sources/Core/Shared/GroupOperation.swift
@@ -191,9 +191,10 @@ extension GroupOperation: OperationQueueDelegate {
         assert(!finishingOperation.executing, "Cannot add new operations to a group after the group has started to finish.")
         assert(!finishingOperation.finished, "Cannot add new operations to a group after the group has completed.")
 
-        willAddChildOperationObservers.forEach { $0.groupOperation(self, willAddChildOperation: operation) }
-
         if operation !== finishingOperation {
+
+            willAddChildOperationObservers.forEach { $0.groupOperation(self, willAddChildOperation: operation) }
+
             finishingOperation.addDependency(operation)
         }
     }
@@ -220,5 +221,39 @@ extension GroupOperation: OperationQueueDelegate {
             finish(aggregateErrors)
             queue.suspended = true
         }
+    }
+}
+
+/**
+ WillAddChildObserver is an observer which will execute a
+ closure when the group operation it is attaches to adds a
+ child operation to its queue.
+ */
+public struct WillAddChildObserver: GroupOperationWillAddChildObserver {
+    public typealias BlockType = (group: GroupOperation, child: NSOperation) -> Void
+
+    private let block: BlockType
+
+    /// - returns: a block which is called when the observer is attached to an operation
+    public var didAttachToOperation: DidAttachToOperationBlock? = .None
+
+    /**
+     Initialize the observer with a block.
+
+     - parameter willAddChild: the `WillAddChildObserver.BlockType`
+     - returns: an observer.
+     */
+    public init(willAddChild: BlockType) {
+        self.block = willAddChild
+    }
+
+    /// Conforms to GroupOperationWillAddChildObserver
+    public func groupOperation(group: GroupOperation, willAddChildOperation child: NSOperation) {
+        block(group: group, child: child)
+    }
+
+    /// Base OperationObserverType method
+    public func didAttachToOperation(operation: Operation) {
+        didAttachToOperation?(operation: operation)
     }
 }

--- a/Tests/Core/GroupOperationTests.swift
+++ b/Tests/Core/GroupOperationTests.swift
@@ -179,4 +179,26 @@ class GroupOperationTests: OperationTests {
         XCTAssertTrue(group.finished)
         XCTAssertEqual(group.aggregateErrors.count, 1)
     }
+    
+    func test__will_add_child_observer__gets_called() {
+        let child1 = TestOperation()
+        let group = GroupOperation(operations: [child1])
+        
+        var blockCalledWith: (GroupOperation, NSOperation)? = .None
+        let observer = WillAddChildObserver { group, child in
+            blockCalledWith = (group, child)
+        }
+        group.addObserver(observer)
+        
+        addCompletionBlockToTestOperation(group)
+        runOperation(group)
+        waitForExpectationsWithTimeout(3, handler: nil)
+        
+        guard let (observedGroup, observedChild) = blockCalledWith else {
+            XCTFail("Observer not called"); return
+        }
+        
+        XCTAssertEqual(group, observedGroup)
+        XCTAssertEqual(child1, observedChild)
+    }
 }


### PR DESCRIPTION
`GroupOperation` will inform an observer when new operations are going to be added to its queue. This would be a direct reflection of the `OperationQueueDelegate`, but it can be used like a regular observer.