### PR TITLE
Fix two bugs.

### DIFF
--- a/Sources/Core/Shared/ExclusivityManager.swift
+++ b/Sources/Core/Shared/ExclusivityManager.swift
@@ -21,7 +21,7 @@ internal class ExclusivityManager {
     }
 
     func addOperation(operation: NSOperation, category: String) {
-        dispatch_async(queue) {
+        dispatch_sync(queue) {
             self._addOperation(operation, category: category)
         }
     }

--- a/Tests/Core/MutualExclusiveTests.swift
+++ b/Tests/Core/MutualExclusiveTests.swift
@@ -86,4 +86,17 @@ class MutuallyExclusiveConditionWithDependencyTests: OperationTests {
         XCTAssertTrue(operation1.didExecute)
         XCTAssertTrue(operation2.didExecute)
     }
+
+    func test__mutually_exclusive_operations_can_be_executed() {
+        let operation1 = BlockOperation()
+        operation1.addCondition(MutuallyExclusive<BlockOperation>())
+        let operation2 = BlockOperation()
+        operation2.addCondition(MutuallyExclusive<BlockOperation>())
+
+        addCompletionBlockToTestOperation(operation1, withExpectation: expectationWithDescription("Test 1: \(__FUNCTION__)"))
+        addCompletionBlockToTestOperation(operation2, withExpectation: expectationWithDescription("Test 2: \(__FUNCTION__)"))
+
+        runOperations(operation1, operation2)
+        waitForExpectationsWithTimeout(3, handler: nil)
+    }
 }


### PR DESCRIPTION
1. Composed operation is clearly causing a retain cycle (composed op <-> target).
2. Mutually exclusive operations may not execute, please see the added test.