### PR TITLE
Cancel Group Operation after cancelling Child Operations

### DIFF
--- a/Sources/Core/Shared/GroupOperation.swift
+++ b/Sources/Core/Shared/GroupOperation.swift
@@ -55,10 +55,10 @@ public class GroupOperation: Operation {
 
     /// Override of public method
     public override func cancel() {
-        super.cancel()
         queue.cancelAllOperations()
         queue.suspended = false
         operations.forEach { $0.cancel() }
+        super.cancel()
     }
 
     /**


### PR DESCRIPTION
Again, is there a reason it needs to be the other way around?

I have an instance where after one group operation finishes I need to look at the results of that group's child operations.
If the group operation is cancelled before the children, it finishes before the children have a chance to cancel and update their status.