### PR TITLE
Refactor Capabilities

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,6 +1,5 @@
 excluded:
   - Tests
-use_nested_configs: true
 disabled_rules:
   - valid_docs
   - statement_position

--- a/Sources/Core/Shared/Logging.swift
+++ b/Sources/Core/Shared/Logging.swift
@@ -74,9 +74,9 @@ public protocol LoggerType {
 
      - parameter message: a `String`, the message to log.
      - parameter severity: a `LogSeverity`, the level of the message.
-     - parameter file: a `String`, containing the file (make it default to __FILE__)
-     - parameter function: a `String`, containing the function (make it default to __FUNCTION__)
-     - parameter line: a `Int`, containing the line number (make it default to __LINE__)
+     - parameter file: a `String`, containing the file (make it default to #file)
+     - parameter function: a `String`, containing the function (make it default to #function)
+     - parameter line: a `Int`, containing the line number (make it default to #line)
     */
     func log(@autoclosure message: () -> String, severity: LogSeverity, file: String, function: String, line: Int)
 }
@@ -117,9 +117,9 @@ public extension LoggerType {
 
      - parameter message: a `String`, the message to log.
      - parameter severity: a `LogSeverity`, the level of the message.
-     - parameter file: a `String`, containing the file (make it default to __FILE__)
-     - parameter function: a `String`, containing the function (make it default to __FUNCTION__)
-     - parameter line: a `Int`, containing the line number (make it default to __LINE__)
+     - parameter file: a `String`, containing the file (make it default to #file)
+     - parameter function: a `String`, containing the function (make it default to #function)
+     - parameter line: a `Int`, containing the line number (make it default to #line)
     */
     func log(@autoclosure message: () -> String, severity: LogSeverity, file: String = #file, function: String = #function, line: Int = #line) {
         if LogManager.enabled && enabled && severity >= minimumLogSeverity {
@@ -134,9 +134,9 @@ public extension LoggerType {
      Send a .Verbose log message.
 
      - parameter message: a `String`, the message to log.
-     - parameter file: a `String`, containing the file (make it default to __FILE__)
-     - parameter function: a `String`, containing the function (make it default to __FUNCTION__)
-     - parameter line: a `Int`, containing the line number (make it default to __LINE__)
+     - parameter file: a `String`, containing the file (make it default to #file)
+     - parameter function: a `String`, containing the function (make it default to #function)
+     - parameter line: a `Int`, containing the line number (make it default to #line)
     */
     func verbose(@autoclosure message: () -> String, file: String = #file, function: String = #function, line: Int = #line) {
         log(message, severity: .Verbose, file: file, function: function, line: line)
@@ -146,9 +146,9 @@ public extension LoggerType {
      Send a .Notice log message.
 
      - parameter message: a `String`, the message to log.
-     - parameter file: a `String`, containing the file (make it default to __FILE__)
-     - parameter function: a `String`, containing the function (make it default to __FUNCTION__)
-     - parameter line: a `Int`, containing the line number (make it default to __LINE__)
+     - parameter file: a `String`, containing the file (make it default to #file)
+     - parameter function: a `String`, containing the function (make it default to #function)
+     - parameter line: a `Int`, containing the line number (make it default to #line)
      */
     func notice(@autoclosure message: () -> String, file: String = #file, function: String = #function, line: Int = #line) {
         log(message, severity: .Notice, file: file, function: function, line: line)
@@ -158,9 +158,9 @@ public extension LoggerType {
      Send a .Info log message.
 
      - parameter message: a `String`, the message to log.
-     - parameter file: a `String`, containing the file (make it default to __FILE__)
-     - parameter function: a `String`, containing the function (make it default to __FUNCTION__)
-     - parameter line: a `Int`, containing the line number (make it default to __LINE__)
+     - parameter file: a `String`, containing the file (make it default to #file)
+     - parameter function: a `String`, containing the function (make it default to #function)
+     - parameter line: a `Int`, containing the line number (make it default to #line)
      */
     func info(@autoclosure message: () -> String, file: String = #file, function: String = #function, line: Int = #line) {
         log(message, severity: .Info, file: file, function: function, line: line)
@@ -170,9 +170,9 @@ public extension LoggerType {
      Send a .Warning log message.
 
      - parameter message: a `String`, the message to log.
-     - parameter file: a `String`, containing the file (make it default to __FILE__)
-     - parameter function: a `String`, containing the function (make it default to __FUNCTION__)
-     - parameter line: a `Int`, containing the line number (make it default to __LINE__)
+     - parameter file: a `String`, containing the file (make it default to #file)
+     - parameter function: a `String`, containing the function (make it default to #function)
+     - parameter line: a `Int`, containing the line number (make it default to #line)
      */
     func warning(@autoclosure message: () -> String, file: String = #file, function: String = #function, line: Int = #line) {
         log(message, severity: .Warning, file: file, function: function, line: line)
@@ -182,9 +182,9 @@ public extension LoggerType {
      Send a .Fatal log message.
 
      - parameter message: a `String`, the message to log.
-     - parameter file: a `String`, containing the file (make it default to __FILE__)
-     - parameter function: a `String`, containing the function (make it default to __FUNCTION__)
-     - parameter line: a `Int`, containing the line number (make it default to __LINE__)
+     - parameter file: a `String`, containing the file (make it default to #file)
+     - parameter function: a `String`, containing the function (make it default to #function)
+     - parameter line: a `Int`, containing the line number (make it default to #line)
      */
     func fatal(@autoclosure message: () -> String, file: String = #file, function: String = #function, line: Int = #line) {
         log(message, severity: .Fatal, file: file, function: function, line: line)

--- a/Sources/Core/Shared/Logging.swift
+++ b/Sources/Core/Shared/Logging.swift
@@ -121,7 +121,7 @@ public extension LoggerType {
      - parameter function: a `String`, containing the function (make it default to __FUNCTION__)
      - parameter line: a `Int`, containing the line number (make it default to __LINE__)
     */
-    func log(@autoclosure message: () -> String, severity: LogSeverity, file: String = __FILE__, function: String = __FUNCTION__, line: Int = __LINE__) {
+    func log(@autoclosure message: () -> String, severity: LogSeverity, file: String = #file, function: String = #function, line: Int = #line) {
         if LogManager.enabled && enabled && severity >= minimumLogSeverity {
             let _message = messageWithOperationName(message())
             dispatch_async(LogManager.queue) {
@@ -138,7 +138,7 @@ public extension LoggerType {
      - parameter function: a `String`, containing the function (make it default to __FUNCTION__)
      - parameter line: a `Int`, containing the line number (make it default to __LINE__)
     */
-    func verbose(@autoclosure message: () -> String, file: String = __FILE__, function: String = __FUNCTION__, line: Int = __LINE__) {
+    func verbose(@autoclosure message: () -> String, file: String = #file, function: String = #function, line: Int = #line) {
         log(message, severity: .Verbose, file: file, function: function, line: line)
     }
 
@@ -150,7 +150,7 @@ public extension LoggerType {
      - parameter function: a `String`, containing the function (make it default to __FUNCTION__)
      - parameter line: a `Int`, containing the line number (make it default to __LINE__)
      */
-    func notice(@autoclosure message: () -> String, file: String = __FILE__, function: String = __FUNCTION__, line: Int = __LINE__) {
+    func notice(@autoclosure message: () -> String, file: String = #file, function: String = #function, line: Int = #line) {
         log(message, severity: .Notice, file: file, function: function, line: line)
     }
 
@@ -162,7 +162,7 @@ public extension LoggerType {
      - parameter function: a `String`, containing the function (make it default to __FUNCTION__)
      - parameter line: a `Int`, containing the line number (make it default to __LINE__)
      */
-    func info(@autoclosure message: () -> String, file: String = __FILE__, function: String = __FUNCTION__, line: Int = __LINE__) {
+    func info(@autoclosure message: () -> String, file: String = #file, function: String = #function, line: Int = #line) {
         log(message, severity: .Info, file: file, function: function, line: line)
     }
 
@@ -174,7 +174,7 @@ public extension LoggerType {
      - parameter function: a `String`, containing the function (make it default to __FUNCTION__)
      - parameter line: a `Int`, containing the line number (make it default to __LINE__)
      */
-    func warning(@autoclosure message: () -> String, file: String = __FILE__, function: String = __FUNCTION__, line: Int = __LINE__) {
+    func warning(@autoclosure message: () -> String, file: String = #file, function: String = #function, line: Int = #line) {
         log(message, severity: .Warning, file: file, function: function, line: line)
     }
 
@@ -186,7 +186,7 @@ public extension LoggerType {
      - parameter function: a `String`, containing the function (make it default to __FUNCTION__)
      - parameter line: a `Int`, containing the line number (make it default to __LINE__)
      */
-    func fatal(@autoclosure message: () -> String, file: String = __FILE__, function: String = __FUNCTION__, line: Int = __LINE__) {
+    func fatal(@autoclosure message: () -> String, file: String = #file, function: String = #function, line: Int = #line) {
         log(message, severity: .Fatal, file: file, function: function, line: line)
     }
 }

--- a/Sources/Core/Shared/Operation.swift
+++ b/Sources/Core/Shared/Operation.swift
@@ -435,8 +435,8 @@ public extension Operation {
 public extension Operation {
 
     private func evaluateConditions() {
-        assert(state == .Pending, "\(__FUNCTION__) was called out of order.")
-        assert(cancelled == false, "\(__FUNCTION__) was called on cancelled operation: \(operationName).")
+        assert(state == .Pending, "\(#function) was called out of order.")
+        assert(cancelled == false, "\(#function) was called on cancelled operation: \(operationName).")
         state = .EvaluatingConditions
         evaluateOperationConditions(conditions, operation: self) { errors in
             self._internalErrors.appendContentsOf(errors)

--- a/Sources/Core/Shared/Repeatable.swift
+++ b/Sources/Core/Shared/Repeatable.swift
@@ -70,7 +70,7 @@ extension RepeatedOperation where T: Repeatable {
      ```
      */
     public convenience init(maxCount max: Int? = .None, strategy: WaitStrategy = .Fixed(0.1), body: () -> T?) {
-        self.init(maxCount: max, strategy: strategy, generator: RepeatableGenerator(anyGenerator(body)))
+        self.init(maxCount: max, strategy: strategy, generator: RepeatableGenerator(AnyGenerator(body: body)))
     }
 }
 

--- a/Sources/Core/Shared/RepeatedOperation.swift
+++ b/Sources/Core/Shared/RepeatedOperation.swift
@@ -137,7 +137,7 @@ public class RepeatedOperation<T where T: NSOperation>: GroupOperation {
     internal private(set) var configure: T -> Void = { _ in }
 
     static func createPayloadGeneratorWithMaxCount(max: Int? = .None, generator gen: AnyGenerator<Payload>) -> AnyGenerator<Payload> {
-        return max.map { anyGenerator(FiniteGenerator(gen, limit: $0 - 1)) } ?? gen
+        return max.map { AnyGenerator(FiniteGenerator(gen, limit: $0 - 1)) } ?? gen
     }
 
     /**
@@ -178,7 +178,7 @@ public class RepeatedOperation<T where T: NSOperation>: GroupOperation {
         }
 
         current = operation
-        generator = RepeatedOperation<T>.createPayloadGeneratorWithMaxCount(max, generator: anyGenerator(tuple))
+        generator = RepeatedOperation<T>.createPayloadGeneratorWithMaxCount(max, generator: AnyGenerator(tuple))
 
         super.init(operations: [])
         name = "Repeated Operation <\(T.self)>"
@@ -224,7 +224,7 @@ public class RepeatedOperation<T where T: NSOperation>: GroupOperation {
         }
 
         current = operation
-        generator = RepeatedOperation<T>.createPayloadGeneratorWithMaxCount(max, generator: anyGenerator(tuple))
+        generator = RepeatedOperation<T>.createPayloadGeneratorWithMaxCount(max, generator: AnyGenerator(tuple))
 
         super.init(operations: [])
         name = "Repeated Operation <\(T.self)>"

--- a/Sources/Core/Shared/ResultInjection.swift
+++ b/Sources/Core/Shared/ResultInjection.swift
@@ -109,7 +109,7 @@ extension InjectionOperationType where Self: Operation {
  an operation conforming to `AutomaticInjectionOperationType`.
 */
 public protocol ResultOperationType: class {
-    typealias Result
+    associatedtype Result
 
     /// - returns: the `Result`, note that this can be an `Thing?` if needed.
     var result: Result { get }
@@ -121,7 +121,7 @@ public protocol ResultOperationType: class {
  conforming to `ResultOperationType`.
  */
 public protocol AutomaticInjectionOperationType: InjectionOperationType {
-    typealias Requirement
+    associatedtype Requirement
 
     /// - returns: the `Requirement`, note must be mutable, and
     /// can be `Thing?` if needed.

--- a/Sources/Core/Shared/RetryOperation.swift
+++ b/Sources/Core/Shared/RetryOperation.swift
@@ -106,7 +106,7 @@ public class RetryOperation<T: NSOperation>: RepeatedOperation<T> {
     */
     public init(maxCount max: Int? = .None, generator: AnyGenerator<Payload>, retry block: Handler) {
         retry = RetryGenerator(generator: generator, retry: block)
-        super.init(maxCount: max, generator: anyGenerator(retry))
+        super.init(maxCount: max, generator: AnyGenerator(retry))
         name = "Retry Operation <\(T.self)>"
     }
 
@@ -124,8 +124,8 @@ public class RetryOperation<T: NSOperation>: RepeatedOperation<T> {
      */
     public init<D, G where D: GeneratorType, D.Element == Delay, G: GeneratorType, G.Element == T>(maxCount max: Int? = .None, delay: D, generator: G, retry block: Handler) {
         let tuple = TupleGenerator(primary: generator, secondary: delay)
-        retry = RetryGenerator(generator: anyGenerator(tuple), retry: block)
-        super.init(maxCount: max, generator: anyGenerator(retry))
+        retry = RetryGenerator(generator: AnyGenerator(tuple), retry: block)
+        super.init(maxCount: max, generator: AnyGenerator(retry))
         name = "Retry Operation <\(T.self)>"
     }
 
@@ -165,8 +165,8 @@ public class RetryOperation<T: NSOperation>: RepeatedOperation<T> {
     public init<G where G: GeneratorType, G.Element == T>(maxCount max: Int? = 5, strategy: WaitStrategy = .Fixed(0.1), _ generator: G, retry block: Handler = { $1 }) {
         let delay = MapGenerator(strategy.generator()) { Delay.By($0) }
         let tuple = TupleGenerator(primary: generator, secondary: delay)
-        retry = RetryGenerator(generator: anyGenerator(tuple), retry: block)
-        super.init(maxCount: max, generator: anyGenerator(retry))
+        retry = RetryGenerator(generator: AnyGenerator(tuple), retry: block)
+        super.init(maxCount: max, generator: AnyGenerator(retry))
         name = "Retry Operation <\(T.self)>"
     }
 

--- a/Sources/Core/iOS/BackgroundObserver.swift
+++ b/Sources/Core/iOS/BackgroundObserver.swift
@@ -45,8 +45,8 @@ public class BackgroundObserver: NSObject {
         super.init()
 
         let nc = NSNotificationCenter.defaultCenter()
-        nc.addObserver(self, selector: "didEnterBackground:", name: UIApplicationDidEnterBackgroundNotification, object: .None)
-        nc.addObserver(self, selector: "didBecomeActive:", name: UIApplicationDidBecomeActiveNotification, object: .None)
+        nc.addObserver(self, selector: #selector(BackgroundObserver.didEnterBackground(_:)), name: UIApplicationDidEnterBackgroundNotification, object: .None)
+        nc.addObserver(self, selector: #selector(BackgroundObserver.didBecomeActive(_:)), name: UIApplicationDidBecomeActiveNotification, object: .None)
 
         if isInBackground {
             startBackgroundTask()

--- a/Sources/Extras/AddressBook/.swiftlint.yml
+++ b/Sources/Extras/AddressBook/.swiftlint.yml
@@ -5,6 +5,6 @@ disabled_rules:
   - type_name    
   - file_length
   - type_body_length
-  - variable_name_min_length
+  - variable_name
   - force_cast
   - nesting

--- a/Sources/Extras/AddressBook/iOS/AddressBook.swift
+++ b/Sources/Extras/AddressBook/iOS/AddressBook.swift
@@ -11,9 +11,11 @@ import AddressBook
 
 // swiftlint:disable file_length
 // swiftlint:disable type_body_length
-// swiftlint:disable variable_name_min_length
+// swiftlint:disable variable_name
 // swiftlint:disable force_cast
 // swiftlint:disable nesting
+// swiftlint:disable cyclomatic_complexity
+
 
 // MARK: - AddressBook System Wrapper
 
@@ -34,7 +36,7 @@ and it lacked the necessary hooks for testability.
 // MARK: - PropertyType
 
 public protocol PropertyType {
-    typealias ValueType
+    associatedtype ValueType
 
     @available(iOS, deprecated=9.0)
     var id: ABPropertyID { get }
@@ -82,10 +84,10 @@ public protocol AddressBookExternalChangeObserver { }
 
 public protocol AddressBookType {
 
-    typealias RecordStorage
-    typealias PersonStorage
-    typealias GroupStorage
-    typealias SourceStorage
+    associatedtype RecordStorage
+    associatedtype PersonStorage
+    associatedtype GroupStorage
+    associatedtype SourceStorage
 
     func requestAccess(completion: (AddressBookPermissionRegistrarError?) -> Void)
 
@@ -136,7 +138,7 @@ public protocol AddressBookType {
 // MARK: - StorageType
 
 public protocol StorageType {
-    typealias Storage
+    associatedtype Storage
 
     var storage: Storage { get }
 
@@ -162,8 +164,8 @@ public protocol AddressBookRecordType: StorageType {
 // MARK: - AddressBook_PersonType
 
 public protocol AddressBook_PersonType: AddressBookRecordType {
-    typealias GroupStorage
-    typealias SourceStorage
+    associatedtype GroupStorage
+    associatedtype SourceStorage
 }
 
 // MARK: - AddressBookPersonType
@@ -176,8 +178,8 @@ public protocol AddressBookPersonType: AddressBook_PersonType {
 // MARK: - AddressBook_GroupType
 
 public protocol AddressBook_GroupType: AddressBookRecordType {
-    typealias PersonStorage
-    typealias SourceStorage
+    associatedtype PersonStorage
+    associatedtype SourceStorage
 }
 
 // MARK: - AddressBookGroupType
@@ -194,8 +196,8 @@ public protocol AddressBookGroupType: AddressBook_GroupType {
 // MARK: - AddressBook_SourceType
 
 public protocol AddressBook_SourceType: AddressBookRecordType {
-    typealias PersonStorage
-    typealias GroupStorage
+    associatedtype PersonStorage
+    associatedtype GroupStorage
 }
 
 // MARK: - AddressBookSourceType
@@ -842,7 +844,8 @@ public struct LabeledValue<Value: MultiValueRepresentable>: CustomStringConverti
     static func read(multiValue: ABMultiValueRef) -> [LabeledValue<Value>] {
         assert(AddressBook.PropertyKind(rawValue: ABMultiValueGetPropertyType(multiValue)) == Value.propertyKind, "ABMultiValueRef has incompatible property kind.")
         let count: Int = ABMultiValueGetCount(multiValue)
-        return (0..<count).reduce([LabeledValue<Value>]()) { (var acc, index) in
+        return (0..<count).reduce([LabeledValue<Value>]()) { (acc, index) in
+            var acc = acc
             let representation: CFTypeRef = ABMultiValueCopyValueAtIndex(multiValue, index).takeRetainedValue()
             if let value = Value(multiValueRepresentation: representation), unmanagedLabel = ABMultiValueCopyLabelAtIndex(multiValue, index) {
                 let label = unmanagedLabel.takeRetainedValue() as String
@@ -1165,8 +1168,9 @@ public struct SystemAddressBookRegistrar: AddressBookPermissionRegistrar {
     }
 }
 
+// swiftlint:enable cyclomatic_complexity
 // swiftlint:enable nesting
 // swiftlint:enable force_cast
-// swiftlint:enable variable_name_min_length
+// swiftlint:enable variable_name
 // swiftlint:disable type_body_length
 // swiftlint:disable file_length

--- a/Sources/Extras/Contacts/Shared/Contacts.swift
+++ b/Sources/Extras/Contacts/Shared/Contacts.swift
@@ -36,7 +36,7 @@ public protocol ContactSaveRequestType {
 
 @available(iOS 9.0, OSX 10.11, *)
 public protocol ContactStoreType {
-    typealias SaveRequest: ContactSaveRequestType
+    associatedtype SaveRequest: ContactSaveRequestType
 
     init()
     func opr_authorizationStatusForEntityType(entityType: CNEntityType) -> CNAuthorizationStatus

--- a/Sources/Features/Shared/CalendarCapability.swift
+++ b/Sources/Features/Shared/CalendarCapability.swift
@@ -86,7 +86,7 @@ extension EKAuthorizationStatus: AuthorizationStatusType {
 
  - see: Capability.Calendar
 */
-public class _EventsCapability<Registrar: EventsCapabilityRegistrarType>: NSObject, CapabilityType {
+public class EventsCapability: CapabilityType {
 
     /// - returns: a String, the name of the capability
     public let name: String
@@ -94,7 +94,7 @@ public class _EventsCapability<Registrar: EventsCapabilityRegistrarType>: NSObje
     /// - returns: the EKEntityType, the required type of the capability
     public let requirement: EKEntityType
 
-    let registrar: Registrar
+    internal var registrar: EventsCapabilityRegistrarType = EKEventStore()
 
     /**
      Initialize the capability. By default, it requires access to .Event.
@@ -102,11 +102,9 @@ public class _EventsCapability<Registrar: EventsCapabilityRegistrarType>: NSObje
      - parameter requirement: the required EKEntityType, defaults to .Event
      - parameter registrar: the registrar to use. Defauls to creating a Registrar.
     */
-    public required init(_ requirement: EKEntityType = .Event, registrar: Registrar = Registrar()) {
+    public required init(_ requirement: EKEntityType = .Event) {
         self.name = "Events"
         self.requirement = requirement
-        self.registrar = registrar
-        super.init()
     }
 
     /// - returns: true, EventKit is always available
@@ -186,7 +184,7 @@ public extension Capability {
      queue.addOperation(operation)
      ```
     */
-    typealias Calendar = _EventsCapability<EKEventStore>
+    typealias Calendar = EventsCapability
 }
 
 @available(*, unavailable, renamed="AuthorizedFor(Capability.Calendar())")

--- a/Sources/Features/Shared/Capability.swift
+++ b/Sources/Features/Shared/Capability.swift
@@ -20,10 +20,10 @@ import Foundation
 public protocol CapabilityType {
 
     /// A type which performs the registration of capability permissions.
-    typealias Registrar: CapabilityRegistrarType
+    associatedtype Registrar: CapabilityRegistrarType
 
     /// A type which indicates the current status of the capability
-    typealias Status: AuthorizationStatusType
+    associatedtype Status: AuthorizationStatusType
 
     /// - returns: a String, the name of the capability
     var name: String { get }
@@ -88,7 +88,7 @@ public protocol CapabilityType {
 public protocol AuthorizationStatusType {
 
     /// A generic type for the requirement
-    typealias Requirement
+    associatedtype Requirement
 
     /**
      Given the current authorization status (i.e. self)

--- a/Sources/Features/Shared/Capability.swift
+++ b/Sources/Features/Shared/Capability.swift
@@ -19,9 +19,6 @@ import Foundation
 */
 public protocol CapabilityType {
 
-    /// A type which performs the registration of capability permissions.
-    associatedtype Registrar: CapabilityRegistrarType
-
     /// A type which indicates the current status of the capability
     associatedtype Status: AuthorizationStatusType
 
@@ -45,9 +42,8 @@ public protocol CapabilityType {
      to support injection & unit testing.
 
      - parameter requirement: the needed Status.Requirement
-     - parameter registrar: the registrar item.
     */
-    init(_ requirement: Status.Requirement, registrar: Registrar)
+    init(_ requirement: Status.Requirement)
 
     /**
      Query the capability to see if it's available on the device.

--- a/Sources/Features/Shared/CloudKitInterface.swift
+++ b/Sources/Features/Shared/CloudKitInterface.swift
@@ -16,43 +16,43 @@ import CloudKit
 public protocol CKOperationType: class {
 
     /// The type of the CloudKit Container
-    typealias Container
+    associatedtype Container
 
     /// The type of the CloudKit ServerChangeToken
-    typealias ServerChangeToken
+    associatedtype ServerChangeToken
 
     /// The type of the CloudKit Notification
-    typealias Notification
+    associatedtype Notification
 
     /// The type of the CloudKit RecordZone
-    typealias RecordZone
+    associatedtype RecordZone
 
     /// The type of the CloudKit Record
-    typealias Record
+    associatedtype Record
 
     /// The type of the CloudKit Subscription
-    typealias Subscription
+    associatedtype Subscription
 
     /// The type of the CloudKit RecordSavePolicy
-    typealias RecordSavePolicy
+    associatedtype RecordSavePolicy
 
     /// The type of the CloudKit DiscoveredUserInfo
-    typealias DiscoveredUserInfo
+    associatedtype DiscoveredUserInfo
 
     /// The type of the CloudKit Query
-    typealias Query
+    associatedtype Query
 
     /// The type of the CloudKit QueryCursor
-    typealias QueryCursor
+    associatedtype QueryCursor
 
     /// The type of the CloudKit RecordZoneID
-    typealias RecordZoneID: Hashable
+    associatedtype RecordZoneID: Hashable
 
     /// The type of the CloudKit NotificationID
-    typealias NotificationID: Hashable
+    associatedtype NotificationID: Hashable
 
     /// The type of the CloudKit RecordID
-    typealias RecordID: Hashable
+    associatedtype RecordID: Hashable
 
     /// - returns the CloudKit Container
     var container: Container? { get set }
@@ -65,7 +65,7 @@ public protocol CKOperationType: class {
 public protocol CKDatabaseOperationType: CKOperationType {
 
     /// The type of the CloudKit Database
-    typealias Database
+    associatedtype Database
 
     /// - returns: the CloudKit Database
     var database: Database? { get set }

--- a/Sources/Features/Shared/CloudKitOperation.swift
+++ b/Sources/Features/Shared/CloudKitOperation.swift
@@ -218,11 +218,11 @@ public final class CloudKitOperation<T where T: NSOperation, T: CKOperationType>
     }
 
     public convenience init(_ body: () -> T?) {
-        self.init(generator: anyGenerator(body), connectivity: .AnyConnectionKind, reachability: ReachabilityManager(DeviceReachability()))
+        self.init(generator: AnyGenerator(body: body), connectivity: .AnyConnectionKind, reachability: ReachabilityManager(DeviceReachability()))
     }
 
     convenience init(connectivity: Reachability.Connectivity = .AnyConnectionKind, reachability: SystemReachabilityType, _ body: () -> T?) {
-        self.init(generator: anyGenerator(body), connectivity: .AnyConnectionKind, reachability: reachability)
+        self.init(generator: AnyGenerator(body: body), connectivity: .AnyConnectionKind, reachability: reachability)
     }
 
     init<G where G: GeneratorType, G.Element == T>(generator gen: G, connectivity: Reachability.Connectivity = .AnyConnectionKind, reachability: SystemReachabilityType) {
@@ -276,7 +276,7 @@ class CloudKitOperationGenerator<T where T: NSOperation, T: CKOperationType>: Ge
     var more: Bool = true
 
     init<G where G: GeneratorType, G.Element == T>(generator: G, connectivity: Reachability.Connectivity = .AnyConnectionKind, reachability: SystemReachabilityType) {
-        self.generator = anyGenerator(generator)
+        self.generator = AnyGenerator(generator)
         self.connectivity = connectivity
         self.reachability = reachability
     }
@@ -297,11 +297,11 @@ public class BatchedCloudKitOperation<T where T: NSOperation, T: CKBatchedOperat
     }
 
     public convenience init(enableBatchProcessing enable: Bool = true, _ body: () -> T?) {
-        self.init(generator: anyGenerator(body), enableBatchProcessing: enable, connectivity: .AnyConnectionKind, reachability: ReachabilityManager(DeviceReachability()))
+        self.init(generator: AnyGenerator(body: body), enableBatchProcessing: enable, connectivity: .AnyConnectionKind, reachability: ReachabilityManager(DeviceReachability()))
     }
 
     convenience init(enableBatchProcessing enable: Bool = true, connectivity: Reachability.Connectivity = .AnyConnectionKind, reachability: SystemReachabilityType, _ body: () -> T?) {
-        self.init(generator: anyGenerator(body), enableBatchProcessing: enable, connectivity: connectivity, reachability: reachability)
+        self.init(generator: AnyGenerator(body: body), enableBatchProcessing: enable, connectivity: connectivity, reachability: reachability)
     }
 
     init<G where G: GeneratorType, G.Element == T>(generator gen: G, enableBatchProcessing enable: Bool = true, connectivity: Reachability.Connectivity = .AnyConnectionKind, reachability: SystemReachabilityType) {
@@ -313,7 +313,7 @@ public class BatchedCloudKitOperation<T where T: NSOperation, T: CKBatchedOperat
         let delay = MapGenerator(strategy.generator()) { Delay.By($0) }
         let tuple = TupleGenerator(primary: generator, secondary: delay)
 
-        super.init(generator: anyGenerator(tuple))
+        super.init(generator: AnyGenerator(tuple))
     }
 
     public override func willFinishOperation(operation: NSOperation, withErrors errors: [ErrorType]) {

--- a/Sources/Features/iOS/LocationCapability.swift
+++ b/Sources/Features/iOS/LocationCapability.swift
@@ -120,7 +120,7 @@ extension CLAuthorizationStatus: AuthorizationStatusType {
 
  - see: Capability.Location
  */
-public class _LocationCapability<Registrar: LocationCapabilityRegistrarType>: NSObject, CLLocationManagerDelegate, CapabilityType {
+public class LocationCapability: NSObject, CLLocationManagerDelegate, CapabilityType {
 
     /// - returns: a String, the name of the capability
     public let name: String
@@ -128,7 +128,7 @@ public class _LocationCapability<Registrar: LocationCapabilityRegistrarType>: NS
     /// - returns: the EKEntityType, the required type of the capability
     public let requirement: LocationUsage
 
-    let registrar: Registrar
+    var registrar: LocationCapabilityRegistrarType = CLLocationManager()
     var authorizationCompletionBlock: dispatch_block_t?
 
     /**
@@ -137,10 +137,9 @@ public class _LocationCapability<Registrar: LocationCapabilityRegistrarType>: NS
      - parameter requirement: the required LocationUsage, defaults to .WhenInUse
      - parameter registrar: the registrar to use. Defauls to creating a Registrar.
      */
-    public required init(_ requirement: LocationUsage = .WhenInUse, registrar: Registrar = Registrar()) {
+    public required init(_ requirement: LocationUsage = .WhenInUse) {
         self.name = "Location"
         self.requirement = requirement
-        self.registrar = registrar
         super.init()
     }
 
@@ -211,7 +210,7 @@ public extension Capability {
     - see: `ReverseGeocodeUserLocationOperation`
 
      */
-    typealias Location = _LocationCapability<CLLocationManager>
+    typealias Location = LocationCapability
 }
 
 @available(*, unavailable, renamed="AuthorizedFor(Capability.Location(.WhenInUse))")

--- a/Sources/Features/iOS/LocationOperations.swift
+++ b/Sources/Features/iOS/LocationOperations.swift
@@ -118,7 +118,9 @@ public class _UserLocationOperation<Manager: LocationManagerType>: Operation, CL
         self.completion = completion
         super.init()
         name = "User Location"
-        addCondition(AuthorizedFor(_LocationCapability(.WhenInUse, registrar: manager)))
+        let capability = Capability.Location(.WhenInUse)
+        capability.registrar = manager
+        addCondition(AuthorizedFor(capability))
         addCondition(MutuallyExclusive<CLLocationManager>())
         addObserver(CancelledObserver { [weak self] _ in
             dispatch_async(Queue.Main.queue) {

--- a/Sources/Features/iOS/PassbookCapability.swift
+++ b/Sources/Features/iOS/PassbookCapability.swift
@@ -42,7 +42,7 @@ extension PKPassLibrary: PassbookCapabilityRegistrarType {
 
  - see: Capability.Passbook
 */
-public class _PassbookCapability<Registrar: PassbookCapabilityRegistrarType>: NSObject, CapabilityType {
+public class PassbookCapability: CapabilityType {
 
     /// - returns: a String, the name of the capability
     public let name: String
@@ -50,7 +50,8 @@ public class _PassbookCapability<Registrar: PassbookCapabilityRegistrarType>: NS
     /// - return: there is no requirement, Void.
     public let requirement: Void
 
-    let registrar: Registrar
+    /// - returns: the registrar object
+    internal var registrar: PassbookCapabilityRegistrarType = PKPassLibrary()
 
     /**
      Initialize the capability. There are no requirements, the type is Void
@@ -58,11 +59,9 @@ public class _PassbookCapability<Registrar: PassbookCapabilityRegistrarType>: NS
      - parameter requirement: the required Void, defaults to ()
      - parameter registrar: the registrar to use. Defauls to creating a Registrar.
      */
-    public required init(_ requirement: Void = (), registrar: Registrar = Registrar()) {
+    public required init(_ requirement: Void = ()) {
         self.name = "Passbook"
         self.requirement = requirement
-        self.registrar = registrar
-        super.init()
     }
 
     /// - returns: a true Bool is the Passkit library is available on the device.
@@ -99,7 +98,7 @@ extension Capability {
      }
      ```
      */
-    public typealias Passbook = _PassbookCapability<PKPassLibrary>
+    public typealias Passbook = PassbookCapability
 }
 
 @available(*, unavailable, renamed="AuthorizedFor(Capability.Passbook())")

--- a/Sources/Features/iOS/PhotosCapability.swift
+++ b/Sources/Features/iOS/PhotosCapability.swift
@@ -67,7 +67,7 @@ extension PHAuthorizationStatus: AuthorizationStatusType {
 
  - see: Capability.Photos
  */
-public class _PhotosCapability<Registrar: PhotosCapabilityRegistrarType>: NSObject, CapabilityType {
+public class PhotosCapability: CapabilityType {
 
     /// - returns: a String, the name of the capability
     public let name: String
@@ -75,7 +75,7 @@ public class _PhotosCapability<Registrar: PhotosCapabilityRegistrarType>: NSObje
     /// - returns: the EKEntityType, the required type of the capability
     public let requirement: Void
 
-    let registrar: Registrar
+    internal lazy var registrar: PhotosCapabilityRegistrarType = PHPhotoLibrary()
 
     /**
      Initialize the capability. There is no requirement type
@@ -83,11 +83,9 @@ public class _PhotosCapability<Registrar: PhotosCapabilityRegistrarType>: NSObje
      - parameter requirement: Void - defaults to ()
      - parameter registrar: the registrar to use. Defauls to creating a Registrar.
      */
-    public required init(_ requirement: Void = (), registrar: Registrar = Registrar()) {
+    public required init(_ requirement: Void = ()) {
         self.name = "Photos"
         self.requirement = requirement
-        self.registrar = registrar
-        super.init()
     }
 
     /// - returns: true, Photos is always available
@@ -137,7 +135,7 @@ public extension Capability {
      }
      ```
      */
-    typealias Photos = _PhotosCapability<PHPhotoLibrary>
+    typealias Photos = PhotosCapability
 }
 
 @available(*, unavailable, renamed="AuthorizedFor(Capability.Photos())")

--- a/Sources/Features/iOS/RemoteNotificationCondition.swift
+++ b/Sources/Features/iOS/RemoteNotificationCondition.swift
@@ -80,8 +80,15 @@ public class RemoteNotificationsRegistration: Operation {
         case Error(NSError)
     }
 
-    enum NotificationObserver: Selector {
-        case ReceivedResponse = "didReceiveResponse:"
+    enum NotificationObserver {
+        case ReceivedResponse
+
+        var selector: Selector {
+            switch self {
+            case .ReceivedResponse:
+                return #selector(RemoteNotificationsRegistration.didReceiveResponse(_:))
+            }
+        }
     }
 
     let registrar: RemoteNotificationRegistrarType
@@ -105,7 +112,7 @@ public class RemoteNotificationsRegistration: Operation {
     func register() {
         NSNotificationCenter
             .defaultCenter()
-            .addObserver(self, selector: NotificationObserver.ReceivedResponse.rawValue, name: RemoteNotificationName, object: nil)
+            .addObserver(self, selector: NotificationObserver.ReceivedResponse.selector, name: RemoteNotificationName, object: nil)
 
         registrar.opr_registerForRemoteNotifications()
     }

--- a/Sources/Features/iOS/UserNotificationCondition.swift
+++ b/Sources/Features/iOS/UserNotificationCondition.swift
@@ -112,8 +112,15 @@ public func == (lhs: UserNotificationCondition.Error, rhs: UserNotificationCondi
 
 public class UserNotificationPermissionOperation: Operation {
 
-    enum NotificationObserver: Selector {
-        case SettingsDidChange = "notificationSettingsDidChange:"
+    enum NotificationObserver {
+        case SettingsDidChange
+
+        var selector: Selector {
+            switch self {
+            case .SettingsDidChange:
+                return #selector(UserNotificationPermissionOperation.notificationSettingsDidChange(_:))
+            }
+        }
     }
 
     let settings: UIUserNotificationSettings
@@ -136,7 +143,7 @@ public class UserNotificationPermissionOperation: Operation {
     public override func execute() {
         NSNotificationCenter
             .defaultCenter()
-            .addObserver(self, selector: NotificationObserver.SettingsDidChange.rawValue, name: DidRegisterSettingsNotificationName, object: nil)
+            .addObserver(self, selector: NotificationObserver.SettingsDidChange.selector, name: DidRegisterSettingsNotificationName, object: nil)
         dispatch_async(Queue.Main.queue, request)
     }
 

--- a/Tests/Core/AlertOperationTests.swift
+++ b/Tests/Core/AlertOperationTests.swift
@@ -39,7 +39,7 @@ class AlertOperationTests: OperationTests {
         alert.title = title
         alert.message = message
 
-        presentingController.expectation = expectationWithDescription("Test: \(__FUNCTION__)")
+        presentingController.expectation = expectationWithDescription("Test: \(#function)")
         presentingController.check = { received in
             if let alertController = received as? UIAlertController {
                 XCTAssertTrue(alertController.title == alert.title)

--- a/Tests/Core/BackgroundObserverTests.swift
+++ b/Tests/Core/BackgroundObserverTests.swift
@@ -79,7 +79,7 @@ class BackgroundObserverTests: OperationTests {
         let operation = TestOperation(delay: 2, produced: TestOperation())
         operation.addObserver(BackgroundObserver(app: application))
 
-        addCompletionBlockToTestOperation(operation, withExpectation: expectationWithDescription("Test: \(__FUNCTION__)"))
+        addCompletionBlockToTestOperation(operation, withExpectation: expectationWithDescription("Test: \(#function)"))
         runOperation(operation)
         applicationEntersBackground(application)
 
@@ -118,7 +118,7 @@ class BackgroundObserverTests: OperationTests {
         let operation = TestOperation(delay: 2)
         operation.addObserver(BackgroundObserver(app: application))
 
-        addCompletionBlockToTestOperation(operation, withExpectation: expectationWithDescription("Test: \(__FUNCTION__)"))
+        addCompletionBlockToTestOperation(operation, withExpectation: expectationWithDescription("Test: \(#function)"))
         runOperation(operation)
         applicationBecomesActive(application)
 

--- a/Tests/Core/BlockConditionTests.swift
+++ b/Tests/Core/BlockConditionTests.swift
@@ -16,7 +16,7 @@ class BlockConditionTests: OperationTests {
         let operation = TestOperation()
         operation.addCondition(BlockCondition { true })
 
-        addCompletionBlockToTestOperation(operation, withExpectation: expectationWithDescription("Test: \(__FUNCTION__)"))
+        addCompletionBlockToTestOperation(operation, withExpectation: expectationWithDescription("Test: \(#function)"))
         runOperation(operation)
 
         waitForExpectationsWithTimeout(3, handler: nil)
@@ -25,7 +25,7 @@ class BlockConditionTests: OperationTests {
 
     func test__operation_with_unsuccess_block_condition_errors() {
 
-        let expectation = expectationWithDescription("Test: \(__FUNCTION__)")
+        let expectation = expectationWithDescription("Test: \(#function)")
         let operation = TestOperation()
         operation.addCondition(BlockCondition { false })
 

--- a/Tests/Core/BlockObserverTests.swift
+++ b/Tests/Core/BlockObserverTests.swift
@@ -242,7 +242,7 @@ class BlockObserverTests: BaseBlockObserverTests {
             counter += 1
         }))
 
-        addCompletionBlockToTestOperation(operation, withExpectation: expectationWithDescription("Test: \(__FUNCTION__)"))
+        addCompletionBlockToTestOperation(operation, withExpectation: expectationWithDescription("Test: \(#function)"))
         runOperation(operation)
         waitForExpectationsWithTimeout(3, handler: nil)
 
@@ -256,7 +256,7 @@ class BlockObserverTests: BaseBlockObserverTests {
             counter += 1
         }))
 
-        addCompletionBlockToTestOperation(operation, withExpectation: expectationWithDescription("Test: \(__FUNCTION__)"))
+        addCompletionBlockToTestOperation(operation, withExpectation: expectationWithDescription("Test: \(#function)"))
         runOperation(operation)
         operation.cancel()
         operation.cancel() // Deliberately call cancel multiple times.
@@ -275,7 +275,7 @@ class BlockObserverTests: BaseBlockObserverTests {
             XCTAssertEqual(produced, pro)
         }))
 
-        addCompletionBlockToTestOperation(operation, withExpectation: expectationWithDescription("Test: \(__FUNCTION__)"))
+        addCompletionBlockToTestOperation(operation, withExpectation: expectationWithDescription("Test: \(#function)"))
         runOperation(operation)
         waitForExpectationsWithTimeout(3, handler: nil)
 
@@ -288,7 +288,7 @@ class BlockObserverTests: BaseBlockObserverTests {
             counter += 1
         }))
 
-        addCompletionBlockToTestOperation(operation, withExpectation: expectationWithDescription("Test: \(__FUNCTION__)"))
+        addCompletionBlockToTestOperation(operation, withExpectation: expectationWithDescription("Test: \(#function)"))
         runOperation(operation)
         waitForExpectationsWithTimeout(3, handler: nil)
 
@@ -302,7 +302,7 @@ class BlockObserverTests: BaseBlockObserverTests {
             counter += 1
         })
 
-        addCompletionBlockToTestOperation(operation, withExpectation: expectationWithDescription("Test: \(__FUNCTION__)"))
+        addCompletionBlockToTestOperation(operation, withExpectation: expectationWithDescription("Test: \(#function)"))
         runOperation(operation)
         waitForExpectationsWithTimeout(3, handler: nil)
 

--- a/Tests/Core/ComposedOperationTests.swift
+++ b/Tests/Core/ComposedOperationTests.swift
@@ -24,7 +24,7 @@ class ComposedOperationTests: OperationTests {
             didExecute = true
         })
 
-        let expectation = expectationWithDescription("Test: \(__FUNCTION__)")
+        let expectation = expectationWithDescription("Test: \(#function)")
         addCompletionBlockToTestOperation(composed, withExpectation: expectation)
         runOperation(composed)
         waitForExpectationsWithTimeout(3, handler: nil)
@@ -36,7 +36,7 @@ class ComposedOperationTests: OperationTests {
     func test__composed_operation_is_performed() {
         let composed = ComposedOperation(operation: TestOperation())
 
-        let expectation = expectationWithDescription("Test: \(__FUNCTION__)")
+        let expectation = expectationWithDescription("Test: \(#function)")
         addCompletionBlockToTestOperation(composed, withExpectation: expectation)
         runOperation(composed)
         waitForExpectationsWithTimeout(3, handler: nil)

--- a/Tests/Core/FunctionalOperationsTests.swift
+++ b/Tests/Core/FunctionalOperationsTests.swift
@@ -39,7 +39,7 @@ class MapOperationTests: OperationTests {
         let source = TestOperation()
         let destination = source.mapOperation { $0.map { "\($0) \($0)" } ?? "Nope" }
 
-        addCompletionBlockToTestOperation(destination, withExpectation: expectationWithDescription("Test: \(__FUNCTION__)"))
+        addCompletionBlockToTestOperation(destination, withExpectation: expectationWithDescription("Test: \(#function)"))
         runOperations(source, destination)
         waitForExpectationsWithTimeout(3, handler: nil)
 
@@ -50,7 +50,7 @@ class MapOperationTests: OperationTests {
         let source = TestOperation(error: TestOperation.Error.SimulatedError)
         let destination = source.mapOperation { $0.map { "\($0) \($0)" } ?? "Nope" }
 
-        addCompletionBlockToTestOperation(destination, withExpectation: expectationWithDescription("Test: \(__FUNCTION__)"))
+        addCompletionBlockToTestOperation(destination, withExpectation: expectationWithDescription("Test: \(#function)"))
         runOperations(source, destination)
         waitForExpectationsWithTimeout(3, handler: nil)
 
@@ -60,7 +60,7 @@ class MapOperationTests: OperationTests {
     func test__map_operation_with_no_requirement() {
         let map: MapOperation<String, String> = MapOperation { str in return "\(str) \(str)" }
 
-        addCompletionBlockToTestOperation(map, withExpectation: expectationWithDescription("Test: \(__FUNCTION__)"))
+        addCompletionBlockToTestOperation(map, withExpectation: expectationWithDescription("Test: \(#function)"))
         runOperation(map)
         waitForExpectationsWithTimeout(3, handler: nil)
 
@@ -75,7 +75,7 @@ class FilterOperationTests: OperationTests {
         let numbers = NumbersOperation()
         let filtered = numbers.filterOperation { $0 % 2 == 0 }
 
-        addCompletionBlockToTestOperation(filtered, withExpectation: expectationWithDescription("Test: \(__FUNCTION__)"))
+        addCompletionBlockToTestOperation(filtered, withExpectation: expectationWithDescription("Test: \(#function)"))
         runOperations(numbers, filtered)
         waitForExpectationsWithTimeout(3, handler: nil)
 
@@ -88,7 +88,7 @@ class FilterOperationTests: OperationTests {
         numbers.addDependency(delay)
         let filtered = numbers.filterOperation { $0 % 2 == 0 }
 
-        addCompletionBlockToTestOperation(filtered, withExpectation: expectationWithDescription("Test: \(__FUNCTION__)"))
+        addCompletionBlockToTestOperation(filtered, withExpectation: expectationWithDescription("Test: \(#function)"))
         runOperations(delay, numbers, filtered)
         numbers.cancel()
         waitForExpectationsWithTimeout(3, handler: nil)
@@ -100,7 +100,7 @@ class FilterOperationTests: OperationTests {
         let numbers = NumbersOperation(error: TestOperation.Error.SimulatedError)
         let filtered = numbers.filterOperation { $0 % 2 == 0 }
 
-        addCompletionBlockToTestOperation(filtered, withExpectation: expectationWithDescription("Test: \(__FUNCTION__)"))
+        addCompletionBlockToTestOperation(filtered, withExpectation: expectationWithDescription("Test: \(#function)"))
         runOperations(numbers, filtered)
         waitForExpectationsWithTimeout(3, handler: nil)
 
@@ -116,7 +116,7 @@ class ReduceOperationTests: OperationTests {
             return sum + element
         }
 
-        addCompletionBlockToTestOperation(reduce, withExpectation: expectationWithDescription("Test: \(__FUNCTION__)"))
+        addCompletionBlockToTestOperation(reduce, withExpectation: expectationWithDescription("Test: \(#function)"))
         runOperations(numbers, reduce)
         waitForExpectationsWithTimeout(3, handler: nil)
 
@@ -131,7 +131,7 @@ class ReduceOperationTests: OperationTests {
             return sum + element
         }
 
-        addCompletionBlockToTestOperation(reduce, withExpectation: expectationWithDescription("Test: \(__FUNCTION__)"))
+        addCompletionBlockToTestOperation(reduce, withExpectation: expectationWithDescription("Test: \(#function)"))
         runOperations(delay, numbers, reduce)
         numbers.cancel()
         waitForExpectationsWithTimeout(3, handler: nil)
@@ -145,7 +145,7 @@ class ReduceOperationTests: OperationTests {
             return sum + element
         }
 
-        addCompletionBlockToTestOperation(reduce, withExpectation: expectationWithDescription("Test: \(__FUNCTION__)"))
+        addCompletionBlockToTestOperation(reduce, withExpectation: expectationWithDescription("Test: \(#function)"))
         runOperations(numbers, reduce)
         waitForExpectationsWithTimeout(3, handler: nil)
 
@@ -158,7 +158,7 @@ class ResultOperationTests: OperationTests {
     func test__result_executes() {
         let operation = ResultOperation(result: 0)
 
-        addCompletionBlockToTestOperation(operation, withExpectation: expectationWithDescription("Test: \(__FUNCTION__)"))
+        addCompletionBlockToTestOperation(operation, withExpectation: expectationWithDescription("Test: \(#function)"))
         runOperation(operation)
         waitForExpectationsWithTimeout(3, handler: nil)
 

--- a/Tests/Core/GatedOperationTests.swift
+++ b/Tests/Core/GatedOperationTests.swift
@@ -14,7 +14,7 @@ class GatedOperationTests: OperationTests {
     func test__when_gate_is_closed_operation_is_not_performed() {
 
         let gate = GatedOperation(TestOperation()) { return false }
-        addCompletionBlockToTestOperation(gate, withExpectation: expectationWithDescription("Test: \(__FUNCTION__)"))
+        addCompletionBlockToTestOperation(gate, withExpectation: expectationWithDescription("Test: \(#function)"))
 
         runOperation(gate)
 
@@ -25,8 +25,8 @@ class GatedOperationTests: OperationTests {
 
     func test__when_gate_is_open_operation_is_performed() {
         let gate = GatedOperation(TestOperation()) { return true }
-        addCompletionBlockToTestOperation(gate, withExpectation: expectationWithDescription("Test: \(__FUNCTION__), Gate"))
-        addCompletionBlockToTestOperation(gate.operation, withExpectation: expectationWithDescription("Test: \(__FUNCTION__), Operation"))
+        addCompletionBlockToTestOperation(gate, withExpectation: expectationWithDescription("Test: \(#function), Gate"))
+        addCompletionBlockToTestOperation(gate.operation, withExpectation: expectationWithDescription("Test: \(#function), Operation"))
 
         runOperation(gate)
 

--- a/Tests/Core/GroupOperationTests.swift
+++ b/Tests/Core/GroupOperationTests.swift
@@ -41,7 +41,7 @@ class GroupOperationTests: OperationTests {
         let delay = DelayOperation(interval: 10)
         let group = SleepingGroupOperation(operations: [delay])
         
-        let expectation = expectationWithDescription("Test: \(__FUNCTION__)")
+        let expectation = expectationWithDescription("Test: \(#function)")
         group.addObserver(BlockObserver { observedOperation, errors in
             NSOperationQueue.mainQueue().addOperationWithBlock {
                 XCTAssertTrue(observedOperation.cancelled)
@@ -58,7 +58,7 @@ class GroupOperationTests: OperationTests {
 
     func test__group_operations_are_performed_in_order() {
         let group = createGroupOperations()
-        let expectation = expectationWithDescription("Test: \(__FUNCTION__)")
+        let expectation = expectationWithDescription("Test: \(#function)")
         let operation = GroupOperation(operations: group)
         operation.addCompletionBlock {
             expectation.fulfill()
@@ -73,7 +73,7 @@ class GroupOperationTests: OperationTests {
     }
 
     func test__adding_operation_to_running_group() {
-        let expectation = expectationWithDescription("Test: \(__FUNCTION__)")
+        let expectation = expectationWithDescription("Test: \(#function)")
         let operation = GroupOperation(operations: TestOperation(), TestOperation())
         operation.addCompletionBlock {
             expectation.fulfill()
@@ -91,13 +91,13 @@ class GroupOperationTests: OperationTests {
         let operations: [TestOperation] = (0..<3).map { i in
             let op = TestOperation()
             op.addCondition(BlockCondition { true })
-            let exp = self.expectationWithDescription("Group Operation, child \(i): \(__FUNCTION__)")
+            let exp = self.expectationWithDescription("Group Operation, child \(i): \(#function)")
             self.addCompletionBlockToTestOperation(op, withExpectation: exp)
             return op
         }
 
         let group = GroupOperation(operations: operations)
-        addCompletionBlockToTestOperation(group, withExpectation: expectationWithDescription("Test: \(__FUNCTION__)"))
+        addCompletionBlockToTestOperation(group, withExpectation: expectationWithDescription("Test: \(#function)"))
 
         runOperation(group)
         waitForExpectationsWithTimeout(5, handler: nil)
@@ -109,7 +109,7 @@ class GroupOperationTests: OperationTests {
         let operations: [TestOperation] = (0..<3).map { _ in TestOperation() }
         group.addOperations(operations)
 
-        addCompletionBlockToTestOperation(group, withExpectation: expectationWithDescription("Test: \(__FUNCTION__)"))
+        addCompletionBlockToTestOperation(group, withExpectation: expectationWithDescription("Test: \(#function)"))
         runOperation(group)
         waitForExpectationsWithTimeout(3, handler: nil)
 
@@ -136,7 +136,7 @@ class GroupOperationTests: OperationTests {
         let waiter = BlockOperation { }
         waiter.addDependency(group)
 
-        let expectation = expectationWithDescription("Test: \(__FUNCTION__)")
+        let expectation = expectationWithDescription("Test: \(#function)")
         addCompletionBlockToTestOperation(waiter, withExpectation: expectation)
         runOperations(group, waiter)
         waitForExpectationsWithTimeout(5.0, handler: nil)
@@ -153,7 +153,7 @@ class GroupOperationTests: OperationTests {
         let waiter = BlockOperation { }
         waiter.addDependency(group)
 
-        let expectation = expectationWithDescription("Test: \(__FUNCTION__)")
+        let expectation = expectationWithDescription("Test: \(#function)")
         addCompletionBlockToTestOperation(waiter, withExpectation: expectation)
         runOperations(group, waiter)
         waitForExpectationsWithTimeout(3, handler: nil)
@@ -171,7 +171,7 @@ class GroupOperationTests: OperationTests {
         let waiter = BlockOperation { }
         waiter.addDependency(group)
 
-        let expectation = expectationWithDescription("Test: \(__FUNCTION__)")
+        let expectation = expectationWithDescription("Test: \(#function)")
         addCompletionBlockToTestOperation(waiter, withExpectation: expectation)
         runOperations(group, waiter)
         waitForExpectationsWithTimeout(3, handler: nil)

--- a/Tests/Core/LoggingObserverTests.swift
+++ b/Tests/Core/LoggingObserverTests.swift
@@ -50,7 +50,7 @@ class LoggingObserverWithError: LoggingObserverTests {
 
     func test__logger_outputs_number_of_received_errors() {
 
-        addCompletionBlockToTestOperation(operation, withExpectation: expectationWithDescription("Test: \(__FUNCTION__)"))
+        addCompletionBlockToTestOperation(operation, withExpectation: expectationWithDescription("Test: \(#function)"))
         runOperation(operation)
         waitForExpectationsWithTimeout(3, handler: nil)
         XCTAssertTrue(receivedMessages.contains("Test Logging Operation: did finish with error(s): [Operations.BlockCondition.Error.BlockConditionFailed]."))
@@ -68,7 +68,7 @@ class LoggingObserverWithCancellation: LoggingObserverTests {
 
     func test__logger_outputs_cancellation() {
 
-        addCompletionBlockToTestOperation(operation, withExpectation: expectationWithDescription("Test: \(__FUNCTION__)"))
+        addCompletionBlockToTestOperation(operation, withExpectation: expectationWithDescription("Test: \(#function)"))
         runOperation(operation)
         operation.cancel()
         waitForExpectationsWithTimeout(3, handler: nil)
@@ -87,7 +87,7 @@ class LoggingObserverWithProduce: LoggingObserverTests {
 
     func test__logger_outputs_cancellation() {
 
-        addCompletionBlockToTestOperation(operation, withExpectation: expectationWithDescription("Test: \(__FUNCTION__)"))
+        addCompletionBlockToTestOperation(operation, withExpectation: expectationWithDescription("Test: \(#function)"))
         runOperation(operation)
         waitForExpectationsWithTimeout(3, handler: nil)
         XCTAssertTrue(receivedMessages.contains("Test Logging Operation: did produce operation: Test Operation."))

--- a/Tests/Core/MutualExclusiveTests.swift
+++ b/Tests/Core/MutualExclusiveTests.swift
@@ -93,8 +93,8 @@ class MutuallyExclusiveConditionWithDependencyTests: OperationTests {
         let operation2 = BlockOperation()
         operation2.addCondition(MutuallyExclusive<BlockOperation>())
 
-        addCompletionBlockToTestOperation(operation1, withExpectation: expectationWithDescription("Test 1: \(__FUNCTION__)"))
-        addCompletionBlockToTestOperation(operation2, withExpectation: expectationWithDescription("Test 2: \(__FUNCTION__)"))
+        addCompletionBlockToTestOperation(operation1, withExpectation: expectationWithDescription("Test 1: \(#function)"))
+        addCompletionBlockToTestOperation(operation2, withExpectation: expectationWithDescription("Test 2: \(#function)"))
 
         runOperations(operation1, operation2)
         waitForExpectationsWithTimeout(3, handler: nil)

--- a/Tests/Core/MutualExclusiveTests.swift
+++ b/Tests/Core/MutualExclusiveTests.swift
@@ -77,8 +77,8 @@ class MutuallyExclusiveConditionWithDependencyTests: OperationTests {
         let operation2 = TestOperation()
         operation2.addCondition(condition2)
 
-        addCompletionBlockToTestOperation(operation1, withExpectation: expectationWithDescription("Test 1: \(__FUNCTION__)"))
-        addCompletionBlockToTestOperation(operation2, withExpectation: expectationWithDescription("Test 2: \(__FUNCTION__)"))
+        addCompletionBlockToTestOperation(operation1, withExpectation: expectationWithDescription("Test 1: \(#function)"))
+        addCompletionBlockToTestOperation(operation2, withExpectation: expectationWithDescription("Test 2: \(#function)"))
 
         runOperations(operation1, operation2)
         waitForExpectationsWithTimeout(3, handler: nil)

--- a/Tests/Core/NegatedConditionTests.swift
+++ b/Tests/Core/NegatedConditionTests.swift
@@ -12,7 +12,7 @@ import XCTest
 class NegatedConditionTests: OperationTests {
 
     func test__operation_with_successful_block_condition_fails() {
-        let expectation = expectationWithDescription("Test: \(__FUNCTION__)")
+        let expectation = expectationWithDescription("Test: \(#function)")
         let operation = TestOperation()
         operation.addCondition(NegatedCondition(BlockCondition { true }))
 
@@ -40,7 +40,7 @@ class NegatedConditionTests: OperationTests {
         let operation = TestOperation()
         operation.addCondition(NegatedCondition(BlockCondition { false }))
 
-        addCompletionBlockToTestOperation(operation, withExpectation: expectationWithDescription("Test: \(__FUNCTION__)"))
+        addCompletionBlockToTestOperation(operation, withExpectation: expectationWithDescription("Test: \(#function)"))
         runOperation(operation)
         waitForExpectationsWithTimeout(3, handler: nil)
 

--- a/Tests/Core/NetworkObserverTests.swift
+++ b/Tests/Core/NetworkObserverTests.swift
@@ -48,7 +48,7 @@ class NetworkObserverTests: OperationTests {
         let operation = TestOperation(delay: 1)
         operation.addObserver(NetworkObserver(indicator: indicator))
 
-        addCompletionBlockToTestOperation(operation, withExpectation: expectationWithDescription("Test: \(__FUNCTION__)"))
+        addCompletionBlockToTestOperation(operation, withExpectation: expectationWithDescription("Test: \(#function)"))
         runOperation(operation)
 
         waitForExpectationsWithTimeout(3) { error in
@@ -60,7 +60,7 @@ class NetworkObserverTests: OperationTests {
 
     func test__network_indicator_hides_after_short_delay_when_operation_ends() {
 
-        let expectation = expectationWithDescription("Test: \(__FUNCTION__)")
+        let expectation = expectationWithDescription("Test: \(#function)")
         let operation = TestOperation(delay: 1)
         operation.addObserver(NetworkObserver(indicator: indicator))
 

--- a/Tests/Core/NoFailedDependenciesConditionTests.swift
+++ b/Tests/Core/NoFailedDependenciesConditionTests.swift
@@ -32,7 +32,7 @@ class NoFailedDependenciesConditionTests: OperationTests {
         let operation = TestOperation()
         operation.addCondition(NoFailedDependenciesCondition())
 
-        addCompletionBlockToTestOperation(operation, withExpectation: expectationWithDescription("Test: \(__FUNCTION__)"))
+        addCompletionBlockToTestOperation(operation, withExpectation: expectationWithDescription("Test: \(#function)"))
         runOperation(operation)
 
         waitForExpectationsWithTimeout(3, handler: nil)
@@ -42,8 +42,8 @@ class NoFailedDependenciesConditionTests: OperationTests {
     func test__operation_with_sucessful_dependency_succeeds() {
 
         let operation = TestOperation()
-        addCompletionBlockToTestOperation(operation, withExpectation: expectationWithDescription("Test: \(__FUNCTION__)"))
-        let dependency = createCancellingOperation(false, expectation: expectationWithDescription("Dependency for Test: \(__FUNCTION__)"))
+        addCompletionBlockToTestOperation(operation, withExpectation: expectationWithDescription("Test: \(#function)"))
+        let dependency = createCancellingOperation(false, expectation: expectationWithDescription("Dependency for Test: \(#function)"))
         operation.addDependency(dependency)
         operation.addCondition(NoFailedDependenciesCondition())
 
@@ -56,7 +56,7 @@ class NoFailedDependenciesConditionTests: OperationTests {
     func test__operation_with_single_cancelled_dependency_doesnt_execute() {
 
         let operation = TestOperation()
-        let dependency = createCancellingOperation(true, expectation: expectationWithDescription("Dependency for Test: \(__FUNCTION__)"))
+        let dependency = createCancellingOperation(true, expectation: expectationWithDescription("Dependency for Test: \(#function)"))
         operation.addDependency(dependency)
         operation.addCondition(NoFailedDependenciesCondition())
 
@@ -67,11 +67,11 @@ class NoFailedDependenciesConditionTests: OperationTests {
     }
 
     func test__operation_with_mixture_fails() {
-        let expectation = expectationWithDescription("Test: \(__FUNCTION__)")
+        let expectation = expectationWithDescription("Test: \(#function)")
         let operation = TestOperation()
-        let dependency1 = createCancellingOperation(true, expectation: expectationWithDescription("Dependency 1 for Test: \(__FUNCTION__)"))
+        let dependency1 = createCancellingOperation(true, expectation: expectationWithDescription("Dependency 1 for Test: \(#function)"))
         operation.addDependency(dependency1)
-        let dependency2 = createCancellingOperation(false, expectation: expectationWithDescription("Dependency 2 for Test: \(__FUNCTION__)"))
+        let dependency2 = createCancellingOperation(false, expectation: expectationWithDescription("Dependency 2 for Test: \(#function)"))
         operation.addDependency(dependency2)
         operation.addCondition(NoFailedDependenciesCondition())
 
@@ -89,7 +89,7 @@ class NoFailedDependenciesConditionTests: OperationTests {
     }
 
     func test__operation_with_errored_dependency_fails() {
-        let expectation = expectationWithDescription("Test: \(__FUNCTION__)")
+        let expectation = expectationWithDescription("Test: \(#function)")
         let operation = TestOperation()
         let dependency = TestOperation(delay: 0, error: TestOperation.Error.SimulatedError)
         operation.addDependency(dependency)
@@ -109,7 +109,7 @@ class NoFailedDependenciesConditionTests: OperationTests {
     }
 
     func test__operation_with_group_dependency_with_errored_child_fails() {
-        let expectation = expectationWithDescription("Test: \(__FUNCTION__)")
+        let expectation = expectationWithDescription("Test: \(#function)")
         let operation = TestOperation()
         let childOperation = TestOperation(delay: 0, error: TestOperation.Error.SimulatedError)
         let dependency = GroupOperation(operations: [childOperation])

--- a/Tests/Core/OperationTests.swift
+++ b/Tests/Core/OperationTests.swift
@@ -134,14 +134,14 @@ class OperationTests: XCTestCase {
         queue.addOperations(operations, waitUntilFinished: false)
     }
 
-    func waitForOperation(operation: Operation, withExpectationDescription text: String = __FUNCTION__) {
+    func waitForOperation(operation: Operation, withExpectationDescription text: String = #function) {
         addCompletionBlockToTestOperation(operation, withExpectationDescription: text)
         queue.delegate = delegate
         queue.addOperation(operation)
         waitForExpectationsWithTimeout(3, handler: nil)
     }
 
-    func waitForOperations(operations: Operation..., withExpectationDescription text: String = __FUNCTION__) {
+    func waitForOperations(operations: Operation..., withExpectationDescription text: String = #function) {
         for (i, op) in operations.enumerate() {
             addCompletionBlockToTestOperation(op, withExpectationDescription: "\(i), \(text)")
         }
@@ -157,7 +157,7 @@ class OperationTests: XCTestCase {
         })
     }
 
-    func addCompletionBlockToTestOperation(operation: Operation, withExpectationDescription text: String = __FUNCTION__) -> XCTestExpectation {
+    func addCompletionBlockToTestOperation(operation: Operation, withExpectationDescription text: String = #function) -> XCTestExpectation {
         let expectation = expectationWithDescription("Test: \(text), \(NSUUID().UUIDString)")
         operation.addObserver(DidFinishObserver { _, _ in
             expectation.fulfill()
@@ -170,7 +170,7 @@ class OperationTests: XCTestCase {
 class BasicTests: OperationTests {
 
     func test__queue_delegate_is_notified_when_operation_starts() {
-        let expectation = expectationWithDescription("Test: \(__FUNCTION__)")
+        let expectation = expectationWithDescription("Test: \(#function)")
 
         let operation = TestOperation()
         addCompletionBlockToTestOperation(operation, withExpectation: expectation)
@@ -183,7 +183,7 @@ class BasicTests: OperationTests {
     }
 
     func test__executing_basic_operation() {
-        let expectation = expectationWithDescription("Test: \(__FUNCTION__)")
+        let expectation = expectationWithDescription("Test: \(#function)")
 
         let operation = TestOperation()
 
@@ -202,7 +202,7 @@ class BasicTests: OperationTests {
     }
 
     func test__add_multiple_completion_blocks() {
-        let expectation = expectationWithDescription("Test: \(__FUNCTION__)")
+        let expectation = expectationWithDescription("Test: \(#function)")
         let operation = TestOperation()
 
         var completionBlockOneDidRun = 0
@@ -230,7 +230,7 @@ class BasicTests: OperationTests {
     }
 
     func test__add_multiple_dependencies() {
-        let expectation = expectationWithDescription("Test: \(__FUNCTION__)")
+        let expectation = expectationWithDescription("Test: \(#function)")
 
         let dep1 = TestOperation()
         let dep2 = TestOperation()
@@ -291,7 +291,7 @@ class BlockOperationTests: OperationTests {
 
     func test__that_block_in_block_operation_executes() {
 
-        let expectation = expectationWithDescription("Test: \(__FUNCTION__)")
+        let expectation = expectationWithDescription("Test: \(#function)")
         var didExecuteBlock: Bool = false
         let operation = BlockOperation {
             didExecuteBlock = true
@@ -303,7 +303,7 @@ class BlockOperationTests: OperationTests {
     }
 
     func test__that_block_operation_with_no_block_finishes_immediately() {
-        let expectation = expectationWithDescription("Test: \(__FUNCTION__)")
+        let expectation = expectationWithDescription("Test: \(#function)")
         let operation = BlockOperation()
         addCompletionBlockToTestOperation(operation, withExpectation: expectation)
         runOperation(operation)
@@ -326,7 +326,7 @@ class BlockOperationTests: OperationTests {
             continuation(error: nil)
         }
 
-        addCompletionBlockToTestOperation(block, withExpectation: expectationWithDescription("Test: \(__FUNCTION__)"))
+        addCompletionBlockToTestOperation(block, withExpectation: expectationWithDescription("Test: \(#function)"))
 
         block.addDependency(delay)
         blockToCancel.addDependency(delay)
@@ -344,7 +344,7 @@ private var completionBlockObservationContext = 0
 class CompletionBlockOperationTests: OperationTests {
 
     func test__block_operation_with_default_block_runs_completion_block_once() {
-        let expectation = expectationWithDescription("Test: \(__FUNCTION__)")
+        let expectation = expectationWithDescription("Test: \(#function)")
         var numberOfTimesCompletionBlockIsRun = 0
 
 //        let operation = BlockOperation { (continuation: BlockOperation.ContinuationBlockType) in
@@ -377,7 +377,7 @@ class CompletionBlockOperationTests: OperationTests {
 
     func test__nsblockoperation_runs_completion_block_once() {
         let _queue = NSOperationQueue()
-        let expectation = expectationWithDescription("Test: \(__FUNCTION__)")
+        let expectation = expectationWithDescription("Test: \(#function)")
 
         let operation = NSBlockOperation()
         operation.completionBlock = { expectation.fulfill() }
@@ -483,7 +483,7 @@ class OperationDependencyTests: OperationTests {
         operation.addCondition(condition1)
         operation.addCondition(condition2)
 
-        addCompletionBlockToTestOperation(operation, withExpectation: expectationWithDescription("Test: \(__FUNCTION__)"))
+        addCompletionBlockToTestOperation(operation, withExpectation: expectationWithDescription("Test: \(#function)"))
         runOperations(dependency1, dependency2, operation)
         waitForExpectationsWithTimeout(3, handler: nil)
 
@@ -509,7 +509,7 @@ class OperationDependencyTests: OperationTests {
         operation.addCondition(condition1)
         operation.addCondition(condition2)
 
-        addCompletionBlockToTestOperation(operation, withExpectation: expectationWithDescription("Test: \(__FUNCTION__)"))
+        addCompletionBlockToTestOperation(operation, withExpectation: expectationWithDescription("Test: \(#function)"))
         runOperations(dependency1, dependency2, operation)
         waitForExpectationsWithTimeout(3, handler: nil)
 
@@ -548,7 +548,7 @@ class DelayOperationTests: OperationTests {
     }
 
     func test__delay_operation_with_negative_time_interval_finishes_immediately() {
-        let expectation = expectationWithDescription("Test: \(__FUNCTION__)")
+        let expectation = expectationWithDescription("Test: \(#function)")
         let operation = DelayOperation(interval: -9_000_000)
         runOperation(operation)
         let after = dispatch_time(DISPATCH_TIME_NOW, Int64(0.05 * Double(NSEC_PER_SEC)))
@@ -560,7 +560,7 @@ class DelayOperationTests: OperationTests {
     }
 
     func test__delay_operation_with_distant_past_finishes_immediately() {
-        let expectation = expectationWithDescription("Test: \(__FUNCTION__)")
+        let expectation = expectationWithDescription("Test: \(#function)")
         let operation = DelayOperation(date: NSDate.distantPast())
         runOperation(operation)
         let after = dispatch_time(DISPATCH_TIME_NOW, Int64(0.05 * Double(NSEC_PER_SEC)))
@@ -574,7 +574,7 @@ class DelayOperationTests: OperationTests {
     func test__delay_operation_completes_after_interval() {
         var started: NSDate!
         var ended: NSDate!
-        let expectation = expectationWithDescription("Test: \(__FUNCTION__)")
+        let expectation = expectationWithDescription("Test: \(#function)")
         let interval: NSTimeInterval = 0.5
         let operation = DelayOperation(interval: interval)
         operation.addCompletionBlock {
@@ -599,7 +599,7 @@ class CancellationOperationTests: OperationTests {
         let operation = TestOperation()
         operation.addDependency(delay)
 
-        addCompletionBlockToTestOperation(operation, withExpectation: expectationWithDescription("Test: \(__FUNCTION__)"))
+        addCompletionBlockToTestOperation(operation, withExpectation: expectationWithDescription("Test: \(#function)"))
 
         delay.cancel()
 

--- a/Tests/Core/RepeatedOperationTests.swift
+++ b/Tests/Core/RepeatedOperationTests.swift
@@ -13,7 +13,7 @@ class RandomFailGeneratorTests: XCTestCase {
 
     func test__failure_probability_distribution() {
 
-        var generator = RandomFailGenerator(anyGenerator { true })
+        var generator = RandomFailGenerator(AnyGenerator { true })
 
         let total = 1_000
         var failures = 0
@@ -36,7 +36,7 @@ class FiniteGeneratorTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
-        generator = FiniteGenerator(anyGenerator(0.stride(to: 10, by: 1).generate()), limit: 2)
+        generator = FiniteGenerator(AnyGenerator(0.stride(to: 10, by: 1).generate()), limit: 2)
     }
 
     func test__limits_are_reached() {
@@ -260,9 +260,9 @@ class RepeatedOperationTests: OperationTests {
     var operation: RepeatedOperation<TestOperation>!
 
     func test__custom_generator_with_delay() {
-        operation = RepeatedOperation(maxCount: 2, generator: anyGenerator { (Delay.By(0.1), TestOperation() )})
+        operation = RepeatedOperation(maxCount: 2, generator: AnyGenerator { (Delay.By(0.1), TestOperation() )})
 
-        addCompletionBlockToTestOperation(operation, withExpectation: expectationWithDescription("Test: \(__FUNCTION__)"))
+        addCompletionBlockToTestOperation(operation, withExpectation: expectationWithDescription("Test: \(#function)"))
         runOperation(operation)
         waitForExpectationsWithTimeout(3, handler: nil)
 
@@ -272,9 +272,9 @@ class RepeatedOperationTests: OperationTests {
     }
 
     func test__custom_generator_without_delay() {
-        operation = RepeatedOperation(maxCount: 2, generator: anyGenerator { (.None, TestOperation() )})
+        operation = RepeatedOperation(maxCount: 2, generator: AnyGenerator { (.None, TestOperation() )})
 
-        addCompletionBlockToTestOperation(operation, withExpectation: expectationWithDescription("Test: \(__FUNCTION__)"))
+        addCompletionBlockToTestOperation(operation, withExpectation: expectationWithDescription("Test: \(#function)"))
         runOperation(operation)
         waitForExpectationsWithTimeout(3, handler: nil)
 
@@ -284,9 +284,9 @@ class RepeatedOperationTests: OperationTests {
     }
 
     func test__init_separate_delay_generator_and_item_generator() {
-        operation = RepeatedOperation(maxCount: 2, delay: anyGenerator { Delay.By(0.1) }, generator: anyGenerator { TestOperation() })
+        operation = RepeatedOperation(maxCount: 2, delay: AnyGenerator { Delay.By(0.1) }, generator: AnyGenerator { TestOperation() })
 
-        addCompletionBlockToTestOperation(operation, withExpectation: expectationWithDescription("Test: \(__FUNCTION__)"))
+        addCompletionBlockToTestOperation(operation, withExpectation: expectationWithDescription("Test: \(#function)"))
         runOperation(operation)
         waitForExpectationsWithTimeout(3, handler: nil)
 
@@ -300,7 +300,7 @@ class NonRepeatableRepeatedOperationTests: OperationTests {
 
     func createGenerator(succeedsAfterCount target: Int = 1) -> AnyGenerator<TestOperation> {
         var count = 0
-        return anyGenerator { () -> TestOperation? in
+        return AnyGenerator { () -> TestOperation? in
             guard count < target else { return nil }
             defer { count += 1 }
             if count < target - 1 {
@@ -315,7 +315,7 @@ class NonRepeatableRepeatedOperationTests: OperationTests {
     func test__repeated_operation_repeats() {
         let operation = RepeatedOperation(generator: createGenerator(succeedsAfterCount: 5))
 
-        addCompletionBlockToTestOperation(operation, withExpectation: expectationWithDescription("Test: \(__FUNCTION__)"))
+        addCompletionBlockToTestOperation(operation, withExpectation: expectationWithDescription("Test: \(#function)"))
         runOperation(operation)
         waitForExpectationsWithTimeout(3, handler: nil)
 
@@ -326,7 +326,7 @@ class NonRepeatableRepeatedOperationTests: OperationTests {
     func test__repeated_with_max_number_of_attempts() {
         let operation = RepeatedOperation(maxCount: 2, generator: createGenerator(succeedsAfterCount: 5))
 
-        addCompletionBlockToTestOperation(operation, withExpectation: expectationWithDescription("Test: \(__FUNCTION__)"))
+        addCompletionBlockToTestOperation(operation, withExpectation: expectationWithDescription("Test: \(#function)"))
         runOperation(operation)
         waitForExpectationsWithTimeout(3, handler: nil)
 
@@ -346,7 +346,7 @@ class RepeatableRepeatedOperationTests: OperationTests {
     func test__repeated_operation_repeats() {
         let operation = RepeatedOperation { RepeatingTestOperation() }
 
-        addCompletionBlockToTestOperation(operation, withExpectation: expectationWithDescription("Test: \(__FUNCTION__)"))
+        addCompletionBlockToTestOperation(operation, withExpectation: expectationWithDescription("Test: \(#function)"))
         runOperation(operation)
         waitForExpectationsWithTimeout(3, handler: nil)
 
@@ -356,7 +356,7 @@ class RepeatableRepeatedOperationTests: OperationTests {
     func test__repeated_with_max_number_of_attempts() {
         let operation = RepeatedOperation(maxCount: 2) { RepeatingTestOperation() }
 
-        addCompletionBlockToTestOperation(operation, withExpectation: expectationWithDescription("Test: \(__FUNCTION__)"))
+        addCompletionBlockToTestOperation(operation, withExpectation: expectationWithDescription("Test: \(#function)"))
         runOperation(operation)
         waitForExpectationsWithTimeout(3, handler: nil)
 
@@ -376,7 +376,7 @@ class RepeatableRepeatedOperationTests: OperationTests {
             return RepeatableOperation(op) { _ in errors.count < 3 }
         }
 
-        addCompletionBlockToTestOperation(operation, withExpectation: expectationWithDescription("Test: \(__FUNCTION__)"))
+        addCompletionBlockToTestOperation(operation, withExpectation: expectationWithDescription("Test: \(#function)"))
         runOperation(operation)
         waitForExpectationsWithTimeout(3, handler: nil)
 

--- a/Tests/Core/ResultInjectionTests.swift
+++ b/Tests/Core/ResultInjectionTests.swift
@@ -44,7 +44,7 @@ class ManualResultInjectionTests: ResultInjectionTests {
             XCTAssertEqual(dep.result, "Hello World")
         }
 
-        addCompletionBlockToTestOperation(processing, withExpectation: expectationWithDescription("Test: \(__FUNCTION__)"))
+        addCompletionBlockToTestOperation(processing, withExpectation: expectationWithDescription("Test: \(#function)"))
         runOperations(retrieval, processing)
         waitForExpectationsWithTimeout(3, handler: nil)
     }
@@ -59,7 +59,7 @@ class ManualResultInjectionTests: ResultInjectionTests {
             }
         }
 
-        addCompletionBlockToTestOperation(processing, withExpectation: expectationWithDescription("Test: \(__FUNCTION__)"))
+        addCompletionBlockToTestOperation(processing, withExpectation: expectationWithDescription("Test: \(#function)"))
         runOperations(retrieval, processing)
         waitForExpectationsWithTimeout(3, handler: nil)
     }
@@ -70,7 +70,7 @@ class AutomaticResultInjectionTests: ResultInjectionTests {
     func test__requirement_is_injected() {
         processing.injectResultFromDependency(retrieval)
 
-        addCompletionBlockToTestOperation(processing, withExpectation: expectationWithDescription("Test: \(__FUNCTION__)"))
+        addCompletionBlockToTestOperation(processing, withExpectation: expectationWithDescription("Test: \(#function)"))
         runOperations(retrieval, processing)
         waitForExpectationsWithTimeout(3, handler: nil)
 
@@ -99,7 +99,7 @@ class AutomaticResultInjectionTests: ResultInjectionTests {
             }
         })
 
-        addCompletionBlockToTestOperation(processing, withExpectation: expectationWithDescription("Test: \(__FUNCTION__)"))
+        addCompletionBlockToTestOperation(processing, withExpectation: expectationWithDescription("Test: \(#function)"))
         runOperations(retrieval, processing)
         waitForExpectationsWithTimeout(3, handler: nil)
 

--- a/Tests/Core/RetryOperationTests.swift
+++ b/Tests/Core/RetryOperationTests.swift
@@ -73,9 +73,9 @@ class RetryOperationTests: OperationTests {
     }
 
     func test__retry_operation_with_payload_generator() {
-        operation = RetryOperation(generator: anyGenerator(producerWithDelay(2)), retry: { $1 })
+        operation = RetryOperation(generator: AnyGenerator(body: producerWithDelay(2)), retry: { $1 })
 
-        addCompletionBlockToTestOperation(operation, withExpectation: expectationWithDescription("Test: \(__FUNCTION__)"))
+        addCompletionBlockToTestOperation(operation, withExpectation: expectationWithDescription("Test: \(#function)"))
         runOperation(operation)
         waitForExpectationsWithTimeout(3, handler: nil)
 
@@ -84,10 +84,9 @@ class RetryOperationTests: OperationTests {
     }
 
     func test__retry_operation_with_default_delay() {
+        operation = RetryOperation(AnyGenerator(body: producer(2)))
 
-        operation = RetryOperation(anyGenerator(producer(2)))
-
-        addCompletionBlockToTestOperation(operation, withExpectation: expectationWithDescription("Test: \(__FUNCTION__)"))
+        addCompletionBlockToTestOperation(operation, withExpectation: expectationWithDescription("Test: \(#function)"))
         runOperation(operation)
         waitForExpectationsWithTimeout(3, handler: nil)
 
@@ -96,9 +95,9 @@ class RetryOperationTests: OperationTests {
     }
 
     func test__retry_operation_where_generator_returns_nil() {
-        operation = RetryOperation(maxCount: 12, strategy: .Fixed(0.01), anyGenerator(producer(11))) { $1 } // Includes the retry block
+        operation = RetryOperation(maxCount: 12, strategy: .Fixed(0.01), AnyGenerator(body: producer(11))) { $1 } // Includes the retry block
 
-        addCompletionBlockToTestOperation(operation, withExpectation: expectationWithDescription("Test: \(__FUNCTION__)"))
+        addCompletionBlockToTestOperation(operation, withExpectation: expectationWithDescription("Test: \(#function)"))
         runOperation(operation)
         waitForExpectationsWithTimeout(3, handler: nil)
 
@@ -107,10 +106,9 @@ class RetryOperationTests: OperationTests {
     }
 
     func test__retry_operation_where_max_count_is_reached() {
+        operation = RetryOperation(AnyGenerator(body: producer(9)))
 
-        operation = RetryOperation(anyGenerator(producer(9)))
-
-        addCompletionBlockToTestOperation(operation, withExpectation: expectationWithDescription("Test: \(__FUNCTION__)"))
+        addCompletionBlockToTestOperation(operation, withExpectation: expectationWithDescription("Test: \(#function)"))
         runOperation(operation)
         waitForExpectationsWithTimeout(3, handler: nil)
 
@@ -133,9 +131,9 @@ class RetryOperationTests: OperationTests {
             return recommended
         }
 
-        operation = RetryOperation(anyGenerator(producer(3)), retry: retry)
+        operation = RetryOperation(AnyGenerator(body: producer(3)), retry: retry)
 
-        addCompletionBlockToTestOperation(operation, withExpectation: expectationWithDescription("Test: \(__FUNCTION__)"))
+        addCompletionBlockToTestOperation(operation, withExpectation: expectationWithDescription("Test: \(#function)"))
         runOperation(operation)
         waitForExpectationsWithTimeout(3, handler: nil)
 
@@ -162,9 +160,9 @@ class RetryOperationTests: OperationTests {
             return .None
         }
 
-        operation = RetryOperation(anyGenerator(producer(3)), retry: retry)
+        operation = RetryOperation(AnyGenerator(body: producer(3)), retry: retry)
 
-        addCompletionBlockToTestOperation(operation, withExpectation: expectationWithDescription("Test: \(__FUNCTION__)"))
+        addCompletionBlockToTestOperation(operation, withExpectation: expectationWithDescription("Test: \(#function)"))
         runOperation(operation)
         waitForExpectationsWithTimeout(3, handler: nil)
 

--- a/Tests/Core/TimeoutObserverTests.swift
+++ b/Tests/Core/TimeoutObserverTests.swift
@@ -12,7 +12,7 @@ import XCTest
 class TimeoutObserverTests: OperationTests {
 
     func test__timeout_observer() {
-        let expectation = expectationWithDescription("Test: \(__FUNCTION__)")
+        let expectation = expectationWithDescription("Test: \(#function)")
 
         let operation = TestOperation(delay: 0.5)
         operation.addObserver(TimeoutObserver(timeout: 0.1))

--- a/Tests/Core/UIOperationTests.swift
+++ b/Tests/Core/UIOperationTests.swift
@@ -141,7 +141,7 @@ class UIOperationTests: OperationTests {
     }
 
     func test__presents() {
-        let expectation = expectationWithDescription("Test: \(__FUNCTION__)")
+        let expectation = expectationWithDescription("Test: \(#function)")
 
         var completionBlockDidRun = false
         operation = TypeUnderTest(controller: presented, displayControllerFrom: .Present(presenter), sender: .None)
@@ -157,7 +157,7 @@ class UIOperationTests: OperationTests {
     }
 
     func test__presents_with_navigation_controller_wrapping_by_default() {
-        let expectation = expectationWithDescription("Test: \(__FUNCTION__)")
+        let expectation = expectationWithDescription("Test: \(#function)")
 
         presenter.check = { [unowned self] received in
             guard let nav = received as? UINavigationController else {
@@ -175,7 +175,7 @@ class UIOperationTests: OperationTests {
 
 
     func test__presents_without_navigation_controller_when_wrapping_overridden() {
-        let expectation = expectationWithDescription("Test: \(__FUNCTION__)")
+        let expectation = expectationWithDescription("Test: \(#function)")
 
         presenter.check = { [unowned self] received in
             guard let _ = received as? UINavigationController else {

--- a/Tests/Extras/AddressBook/AddressBookConditionTests.swift
+++ b/Tests/Extras/AddressBook/AddressBookConditionTests.swift
@@ -86,7 +86,7 @@ class AddressBookOperationTests: OperationTests {
             }
         ))
 
-        addCompletionBlockToTestOperation(operation, withExpectation: expectationWithDescription("Test: \(__FUNCTION__)"))
+        addCompletionBlockToTestOperation(operation, withExpectation: expectationWithDescription("Test: \(#function)"))
         runOperation(operation)
 
         waitForExpectationsWithTimeout(3, handler: nil)
@@ -115,7 +115,7 @@ class AddressBookOperationTests: OperationTests {
             }
         ))
 
-        addCompletionBlockToTestOperation(operation, withExpectation: expectationWithDescription("Test: \(__FUNCTION__)"))
+        addCompletionBlockToTestOperation(operation, withExpectation: expectationWithDescription("Test: \(#function)"))
         runOperation(operation)
 
         waitForExpectationsWithTimeout(3, handler: nil)
@@ -156,7 +156,7 @@ class AddressBookConditionTests: OperationTests {
         let operation = TestOperation()
         operation.addCondition(AddressBookCondition(registrar: registrar))
 
-        addCompletionBlockToTestOperation(operation, withExpectation: expectationWithDescription("Test: \(__FUNCTION__)"))
+        addCompletionBlockToTestOperation(operation, withExpectation: expectationWithDescription("Test: \(#function)"))
         runOperation(operation)
 
         waitForExpectationsWithTimeout(3, handler: nil)
@@ -176,7 +176,7 @@ class AddressBookConditionTests: OperationTests {
             receivedErrors = errors
         })
 
-        addCompletionBlockToTestOperation(operation, withExpectation: expectationWithDescription("Test: \(__FUNCTION__)"))
+        addCompletionBlockToTestOperation(operation, withExpectation: expectationWithDescription("Test: \(#function)"))
         runOperation(operation)
 
         waitForExpectationsWithTimeout(3, handler: nil)

--- a/Tests/Extras/Contacts/ContactsOperationsTests.swift
+++ b/Tests/Extras/Contacts/ContactsOperationsTests.swift
@@ -323,7 +323,7 @@ class GetContactsOperationTest: ContactsTests {
         let contact = setUpForContactWithIdentifier(contactId)
         operation = _GetContacts(predicate: .WithIdentifiers([contactId]), keysToFetch: [], contactStore: store)
 
-        addCompletionBlockToTestOperation(operation, withExpectation: expectationWithDescription("Test: \(__FUNCTION__)"))
+        addCompletionBlockToTestOperation(operation, withExpectation: expectationWithDescription("Test: \(#function)"))
         runOperation(operation)
         waitForExpectationsWithTimeout(3, handler: nil)
 
@@ -337,7 +337,7 @@ class GetContactsOperationTest: ContactsTests {
         let contacts = setUpForContactsWithPredicate(predicate)
         operation = _GetContacts(predicate: predicate, keysToFetch: [CNContainerNameKey], contactStore: store)
 
-        addCompletionBlockToTestOperation(operation, withExpectation: expectationWithDescription("Test: \(__FUNCTION__)"))
+        addCompletionBlockToTestOperation(operation, withExpectation: expectationWithDescription("Test: \(#function)"))
         runOperation(operation)
         waitForExpectationsWithTimeout(3, handler: nil)
 
@@ -372,7 +372,7 @@ class GetContactsGroupOperationTests: ContactsTests {
         let group = setUpForGroupsWithName(groupName)
         operation = _GetContactsGroup(groupName: groupName, contactStore: store)
 
-        addCompletionBlockToTestOperation(operation, withExpectation: expectationWithDescription("Test: \(__FUNCTION__)"))
+        addCompletionBlockToTestOperation(operation, withExpectation: expectationWithDescription("Test: \(#function)"))
         runOperation(operation)
         waitForExpectationsWithTimeout(3, handler: nil)
 
@@ -384,7 +384,7 @@ class GetContactsGroupOperationTests: ContactsTests {
     func test__get_contacts_group_creates_group_if_necessary() {
         operation = _GetContactsGroup(groupName: groupName, containerId: .Identifier(containerId), contactStore: store)
 
-        addCompletionBlockToTestOperation(operation, withExpectation: expectationWithDescription("Test: \(__FUNCTION__)"))
+        addCompletionBlockToTestOperation(operation, withExpectation: expectationWithDescription("Test: \(#function)"))
         runOperation(operation)
         waitForExpectationsWithTimeout(3, handler: nil)
 
@@ -419,7 +419,7 @@ class RemoveContactsGroupOperationTests: ContactsTests {
     func test__remove_contacts_does_nothing_if_group_does_not_exist() {
         operation = _RemoveContactsGroup(groupName: groupName, contactStore: store)
 
-        addCompletionBlockToTestOperation(operation, withExpectation: expectationWithDescription("Test: \(__FUNCTION__)"))
+        addCompletionBlockToTestOperation(operation, withExpectation: expectationWithDescription("Test: \(#function)"))
         runOperation(operation)
         waitForExpectationsWithTimeout(3, handler: nil)
 
@@ -430,7 +430,7 @@ class RemoveContactsGroupOperationTests: ContactsTests {
         let _ = setUpForGroupsWithName(groupName)
         operation = _RemoveContactsGroup(groupName: groupName, contactStore: store)
 
-        addCompletionBlockToTestOperation(operation, withExpectation: expectationWithDescription("Test: \(__FUNCTION__)"))
+        addCompletionBlockToTestOperation(operation, withExpectation: expectationWithDescription("Test: \(#function)"))
         runOperation(operation)
         waitForExpectationsWithTimeout(3, handler: nil)
 
@@ -465,7 +465,7 @@ class AddContactsToGroupOperationTests: ContactsTests {
         setUpForContactEnumerationWithContactIds(contactIds)
         operation = _AddContactsToGroup(groupName: groupName, contactIDs: contactIds, contactStore: store)
 
-        addCompletionBlockToTestOperation(operation, withExpectation: expectationWithDescription("Test: \(__FUNCTION__)"))
+        addCompletionBlockToTestOperation(operation, withExpectation: expectationWithDescription("Test: \(#function)"))
         runOperation(operation)
         waitForExpectationsWithTimeout(3, handler: nil)
 
@@ -499,7 +499,7 @@ class RemoveContactsFromGroupOperationTests: ContactsTests {
         setUpForContactEnumerationWithContactIds(contactIds)
         operation = _RemoveContactsFromGroup(groupName: groupName, contactIDs: contactIds, contactStore: store)
 
-        addCompletionBlockToTestOperation(operation, withExpectation: expectationWithDescription("Test: \(__FUNCTION__)"))
+        addCompletionBlockToTestOperation(operation, withExpectation: expectationWithDescription("Test: \(#function)"))
         runOperation(operation)
         waitForExpectationsWithTimeout(3, handler: nil)
 
@@ -525,7 +525,7 @@ class ContactsAccessOperationsTests: OperationTests {
         let operation = TestOperation()
         operation.addCondition(_ContactsCondition(registrar: registrar))
 
-        addCompletionBlockToTestOperation(operation, withExpectation: expectationWithDescription("Test: \(__FUNCTION__)"))
+        addCompletionBlockToTestOperation(operation, withExpectation: expectationWithDescription("Test: \(#function)"))
         runOperation(operation)
         waitForExpectationsWithTimeout(3, handler: nil)
 
@@ -540,7 +540,7 @@ class ContactsAccessOperationsTests: OperationTests {
         let operation = TestOperation()
         operation.addCondition(_ContactsCondition(registrar: registrar))
 
-        addCompletionBlockToTestOperation(operation, withExpectation: expectationWithDescription("Test: \(__FUNCTION__)"))
+        addCompletionBlockToTestOperation(operation, withExpectation: expectationWithDescription("Test: \(#function)"))
         runOperation(operation)
         waitForExpectationsWithTimeout(3, handler: nil)
 
@@ -554,7 +554,7 @@ class ContactsAccessOperationsTests: OperationTests {
         let operation = TestOperation()
         operation.addCondition(_ContactsCondition(registrar: registrar))
 
-        addCompletionBlockToTestOperation(operation, withExpectation: expectationWithDescription("Test: \(__FUNCTION__)"))
+        addCompletionBlockToTestOperation(operation, withExpectation: expectationWithDescription("Test: \(#function)"))
         runOperation(operation)
         waitForExpectationsWithTimeout(3, handler: nil)
 

--- a/Tests/Features/AuthorizationTests.swift
+++ b/Tests/Features/AuthorizationTests.swift
@@ -34,6 +34,8 @@ class TestableCapability: NSObject, CapabilityType {
     let name = "Testable Capability"
     var requirement: Status.Requirement
 
+    var registrar: CapabilityRegistrarType = Registrar()
+
     var isAsynchronous = false
 
     var serviceIsAvailable = true
@@ -45,7 +47,7 @@ class TestableCapability: NSObject, CapabilityType {
     var responseAuthorizationStatus: Status = .MaximumAuthorized
     var didRequestAuthorization = false
 
-    required init(_ requirement: Status.Requirement = .Minimum, registrar: Registrar = Registrar()) {
+    required init(_ requirement: Status.Requirement = .Minimum) {
         self.requirement = requirement
     }
 

--- a/Tests/Features/AuthorizationTests.swift
+++ b/Tests/Features/AuthorizationTests.swift
@@ -101,7 +101,7 @@ class AuthorizationTests: OperationTests {
 
         let operation = GetAuthorizationStatus(capability)
 
-        addCompletionBlockToTestOperation(operation, withExpectation: expectationWithDescription("Test: \(__FUNCTION__)"))
+        addCompletionBlockToTestOperation(operation, withExpectation: expectationWithDescription("Test: \(#function)"))
         runOperation(operation)
         waitForExpectationsWithTimeout(3, handler: nil)
 
@@ -127,7 +127,7 @@ class AuthorizationTests: OperationTests {
             completedWithStatus = status
         }
 
-        addCompletionBlockToTestOperation(operation, withExpectation: expectationWithDescription("Test: \(__FUNCTION__)"))
+        addCompletionBlockToTestOperation(operation, withExpectation: expectationWithDescription("Test: \(#function)"))
         runOperation(operation)
         waitForExpectationsWithTimeout(3, handler: nil)
 
@@ -152,7 +152,7 @@ class AuthorizationTests: OperationTests {
 
         let operation = Authorize(capability)
 
-        addCompletionBlockToTestOperation(operation, withExpectation: expectationWithDescription("Test: \(__FUNCTION__)"))
+        addCompletionBlockToTestOperation(operation, withExpectation: expectationWithDescription("Test: \(#function)"))
         runOperation(operation)
         waitForExpectationsWithTimeout(3, handler: nil)
 
@@ -187,7 +187,7 @@ class AuthorizationTests: OperationTests {
     }
 
     func test__authorized_condition_fails_if_capability_is_not_available() {
-        let expectation = expectationWithDescription("Test: \(__FUNCTION__)")
+        let expectation = expectationWithDescription("Test: \(#function)")
         let operation = TestOperation()
         capability.serviceIsAvailable = false
         let condition = AuthorizedFor(capability)
@@ -217,7 +217,7 @@ class AuthorizationTests: OperationTests {
     }
 
     func test__authorized_condition_fails_if_requirement_is_not_met() {
-        let expectation = expectationWithDescription("Test: \(__FUNCTION__)")
+        let expectation = expectationWithDescription("Test: \(#function)")
         let operation = TestOperation()
         capability.requirement = .Maximum
         capability.serviceAuthorizationStatus = .MinimumAuthorized
@@ -250,7 +250,7 @@ class AuthorizationTests: OperationTests {
     }
 
     func test__authorized_condition_succeeds_when_requirements_are_met() {
-        let expectation = expectationWithDescription("Test: \(__FUNCTION__)")
+        let expectation = expectationWithDescription("Test: \(#function)")
         let operation = TestOperation()
         capability.serviceAuthorizationStatus = .MinimumAuthorized
 
@@ -274,7 +274,7 @@ class AuthorizationTests: OperationTests {
     }
 
     func test__authorized_condition_succeeds_when_requirements_are_exceeded() {
-        let expectation = expectationWithDescription("Test: \(__FUNCTION__)")
+        let expectation = expectationWithDescription("Test: \(#function)")
         let operation = TestOperation()
         capability.serviceAuthorizationStatus = .MaximumAuthorized
 
@@ -310,7 +310,7 @@ class AsyncCapabilityAuthorizationTests: AuthorizationTests {
 
         let operation = GetAuthorizationStatus(capability)
 
-        addCompletionBlockToTestOperation(operation, withExpectation: expectationWithDescription("Test: \(__FUNCTION__)"))
+        addCompletionBlockToTestOperation(operation, withExpectation: expectationWithDescription("Test: \(#function)"))
         runOperation(operation)
         waitForExpectationsWithTimeout(3, handler: nil)
 
@@ -337,7 +337,7 @@ class AsyncCapabilityAuthorizationTests: AuthorizationTests {
             completedWithStatus = status
         }
 
-        addCompletionBlockToTestOperation(operation, withExpectation: expectationWithDescription("Test: \(__FUNCTION__)"))
+        addCompletionBlockToTestOperation(operation, withExpectation: expectationWithDescription("Test: \(#function)"))
         runOperation(operation)
         waitForExpectationsWithTimeout(3, handler: nil)
 

--- a/Tests/Features/CalendarCapabilityTests.swift
+++ b/Tests/Features/CalendarCapabilityTests.swift
@@ -62,12 +62,13 @@ class EKAuthorizationStatusTests: XCTestCase {
 
 class EventsCapabilityTests: XCTestCase {
     var registrar: TestableEventsRegistrar!
-    var capability: _EventsCapability<TestableEventsRegistrar>!
+    var capability: EventsCapability!
 
     override func setUp() {
         super.setUp()
         registrar = TestableEventsRegistrar()
-        capability = _EventsCapability(.Event, registrar: registrar)
+        capability = EventsCapability(.Event)
+        capability.registrar = registrar
     }
 
     override func tearDown() {
@@ -103,7 +104,7 @@ class EventsCapabilityTests: XCTestCase {
     }
 
     func test__given_denied_does_not_request() {
-        capability.registrar.authorizationStatus = .Denied
+        registrar.authorizationStatus = .Denied
         var didComplete = false
         capability.requestAuthorizationWithCompletion {
             didComplete = true
@@ -113,7 +114,7 @@ class EventsCapabilityTests: XCTestCase {
     }
 
     func test__given_authorized_does_not_request() {
-        capability.registrar.authorizationStatus = .Authorized
+        registrar.authorizationStatus = .Authorized
         var didComplete = false
         capability.requestAuthorizationWithCompletion {
             didComplete = true

--- a/Tests/Features/CloudCapabilityTests.swift
+++ b/Tests/Features/CloudCapabilityTests.swift
@@ -175,7 +175,7 @@ class CloudCapabilitiesTests: XCTestCase {
     // Requesting authorization
 
     func test__request_permissions() {
-        let expectation = expectationWithDescription("Test: \(__FUNCTION__)")
+        let expectation = expectationWithDescription("Test: \(#function)")
         requirement = [ .UserDiscoverability ]
         makeDefaultCapability()
         capability.registrar.accountStatus = .Available

--- a/Tests/Features/CloudCapabilityTests.swift
+++ b/Tests/Features/CloudCapabilityTests.swift
@@ -12,6 +12,8 @@ import XCTest
 
 final class TestableCloudContainer: NSObject {
 
+    var containerIdentifier: String? = .None
+
     var didCreateContainerWithIdentifier: String! = nil
     var didCreateContainerWithDefaultIdentifier = false
 
@@ -34,8 +36,13 @@ final class TestableCloudContainer: NSObject {
 
 extension TestableCloudContainer: CloudContainerRegistrarType {
 
+    var cloudKitContainer: CKContainer! {
+        return nil
+    }
+
     static func containerWithIdentifier(identifier: String?) -> TestableCloudContainer {
         let container = TestableCloudContainer()
+        container.containerIdentifier = identifier
         if let id = identifier {
             container.didCreateContainerWithIdentifier = id
         }
@@ -67,33 +74,39 @@ class CloudCapabilitiesTests: XCTestCase {
 
     let identifier = "cloud container identifier"
     var requirement: CKApplicationPermissions = []
-    var capability: CloudCapability<TestableCloudContainer>!
+    var container: TestableCloudContainer!
+    var capability: CloudCapability!
 
     override func setUp() {
         super.setUp()
+        container = TestableCloudContainer()
         makeDefaultCapability()
     }
 
     override func tearDown() {
         capability = nil
+        container = nil
         super.tearDown()
     }
 
     func makeDefaultCapability() {
         capability = CloudCapability(permissions: requirement)
+        capability.storedRegistrar = container
     }
 
     func makeCapabilityWithIdentifier() {
         capability = CloudCapability(permissions: requirement, containerId: identifier)
+        container.containerIdentifier = identifier
+        capability.storedRegistrar = container
     }
 
     func test__cloud_container_with_no_container_id_is_default() {
-        XCTAssertTrue(capability.registrar.didCreateContainerWithDefaultIdentifier)
+        XCTAssertNil(capability.registrar.containerIdentifier)
     }
 
     func test__cloud_container_with_identifier() {
         makeCapabilityWithIdentifier()
-        XCTAssertEqual(capability.registrar.didCreateContainerWithIdentifier, identifier)
+        XCTAssertEqual(capability.registrar.containerIdentifier, identifier)
     }
 
     func test_name_is_set() {
@@ -118,7 +131,7 @@ class CloudCapabilitiesTests: XCTestCase {
 
     func test__given_status_could_not_be_determined__authorization_status_queries_the_registrar() {
         capability.authorizationStatus { status in
-            XCTAssertTrue(self.capability.registrar.didGetAccountStatus)
+            XCTAssertTrue(self.container.didGetAccountStatus)
             XCTAssertEqual(status.account, CKAccountStatus.CouldNotDetermine)
             XCTAssertNil(status.permissions)
             XCTAssertNil(status.error)
@@ -126,10 +139,10 @@ class CloudCapabilitiesTests: XCTestCase {
     }
 
     func test__given_status_is_available_but_with_no_permissions_does_not_get_status_for_permissions() {
-        capability.registrar.accountStatus = .Available
+        container.accountStatus = .Available
         capability.authorizationStatus { status in
-            XCTAssertTrue(self.capability.registrar.didGetAccountStatus)
-            XCTAssertFalse(self.capability.registrar.didVerifyApplicationStatus)
+            XCTAssertTrue(self.container.didGetAccountStatus)
+            XCTAssertFalse(self.container.didVerifyApplicationStatus)
             XCTAssertEqual(status.account, CKAccountStatus.Available)
             XCTAssertNil(status.permissions)
             XCTAssertNil(status.error)
@@ -139,10 +152,10 @@ class CloudCapabilitiesTests: XCTestCase {
     func test__given_status_is_available_but_with_permissions_does_not_get_status_for_permissions() {
         requirement = [ .UserDiscoverability ]
         makeDefaultCapability()
-        capability.registrar.accountStatus = .Available
+        container.accountStatus = .Available
         capability.authorizationStatus { status in
-            XCTAssertTrue(self.capability.registrar.didGetAccountStatus)
-            XCTAssertTrue(self.capability.registrar.didVerifyApplicationStatus)
+            XCTAssertTrue(self.container.didGetAccountStatus)
+            XCTAssertTrue(self.container.didVerifyApplicationStatus)
             XCTAssertEqual(status.account, CKAccountStatus.Available)
             XCTAssertNotNil(status.permissions)
             XCTAssertEqual(status.permissions, CKApplicationPermissionStatus.InitialState)
@@ -151,10 +164,10 @@ class CloudCapabilitiesTests: XCTestCase {
     }
 
     func test__no_account_status() {
-        capability.registrar.accountStatus = .NoAccount
+        container.accountStatus = .NoAccount
         capability.authorizationStatus { status in
-            XCTAssertTrue(self.capability.registrar.didGetAccountStatus)
-            XCTAssertFalse(self.capability.registrar.didVerifyApplicationStatus)
+            XCTAssertTrue(self.container.didGetAccountStatus)
+            XCTAssertFalse(self.container.didVerifyApplicationStatus)
             XCTAssertEqual(status.account, CKAccountStatus.NoAccount)
             XCTAssertNil(status.permissions)
             XCTAssertNil(status.error)
@@ -162,10 +175,10 @@ class CloudCapabilitiesTests: XCTestCase {
     }
 
     func test__restricted_account_status() {
-        capability.registrar.accountStatus = .Restricted
+        container.accountStatus = .Restricted
         capability.authorizationStatus { status in
-            XCTAssertTrue(self.capability.registrar.didGetAccountStatus)
-            XCTAssertFalse(self.capability.registrar.didVerifyApplicationStatus)
+            XCTAssertTrue(self.container.didGetAccountStatus)
+            XCTAssertFalse(self.container.didVerifyApplicationStatus)
             XCTAssertEqual(status.account, CKAccountStatus.Restricted)
             XCTAssertNil(status.permissions)
             XCTAssertNil(status.error)
@@ -178,11 +191,11 @@ class CloudCapabilitiesTests: XCTestCase {
         let expectation = expectationWithDescription("Test: \(#function)")
         requirement = [ .UserDiscoverability ]
         makeDefaultCapability()
-        capability.registrar.accountStatus = .Available
+        container.accountStatus = .Available
         capability.requestAuthorizationWithCompletion {
-            XCTAssertTrue(self.capability.registrar.didGetAccountStatus)
-            XCTAssertTrue(self.capability.registrar.didVerifyApplicationStatus)
-            XCTAssertTrue(self.capability.registrar.didRequestApplicationStatus)
+            XCTAssertTrue(self.container.didGetAccountStatus)
+            XCTAssertTrue(self.container.didVerifyApplicationStatus)
+            XCTAssertTrue(self.container.didRequestApplicationStatus)
             expectation.fulfill()
         }
 

--- a/Tests/Features/LocationCapabilityTests.swift
+++ b/Tests/Features/LocationCapabilityTests.swift
@@ -104,12 +104,13 @@ class CLAuthorizationStatusTests: XCTestCase {
 class LocationCapabilityTests: OperationTests {
 
     var registrar: TestableLocationRegistrar!
-    var capability: _LocationCapability<TestableLocationRegistrar>!
+    var capability: LocationCapability!
 
     override func setUp() {
         super.setUp()
         registrar = TestableLocationRegistrar()
-        capability = _LocationCapability(.WhenInUse, registrar: registrar)
+        capability = LocationCapability(.WhenInUse)
+        capability.registrar = registrar
     }
 
     override func tearDown() {
@@ -160,7 +161,8 @@ class LocationCapabilityTests: OperationTests {
 
     func test__given_when_in_use_require_always_request_authorization() {
         registrar.authorizationStatus = .AuthorizedWhenInUse
-        capability = _LocationCapability(.Always, registrar: registrar)
+        capability = LocationCapability(.Always)
+        capability.registrar = registrar
         var didComplete = false
         capability.requestAuthorizationWithCompletion {
             didComplete = true
@@ -172,7 +174,7 @@ class LocationCapabilityTests: OperationTests {
     }
 
     func test__given_denied_does_not_request_authorization() {
-        capability.registrar.authorizationStatus = .Denied
+        registrar.authorizationStatus = .Denied
         var didComplete = false
         capability.requestAuthorizationWithCompletion {
             didComplete = true
@@ -183,7 +185,8 @@ class LocationCapabilityTests: OperationTests {
 
     func test__given_already_authorized_always_does_not_request_authorization() {
         registrar.authorizationStatus = .AuthorizedAlways
-        capability = _LocationCapability(.WhenInUse, registrar: registrar)
+        capability = LocationCapability(.WhenInUse)
+        capability.registrar = registrar
         var didComplete = false
         capability.requestAuthorizationWithCompletion {
             didComplete = true
@@ -194,7 +197,8 @@ class LocationCapabilityTests: OperationTests {
 
     func test__given_already_authorized_sufficiently_does_not_request_authorization() {
         registrar.authorizationStatus = .AuthorizedAlways
-        capability = _LocationCapability(.WhenInUse, registrar: registrar)
+        capability = LocationCapability(.WhenInUse)
+        capability.registrar = registrar
         var didComplete = false
         capability.requestAuthorizationWithCompletion {
             didComplete = true

--- a/Tests/Features/LocationOperationsTests.swift
+++ b/Tests/Features/LocationOperationsTests.swift
@@ -130,7 +130,7 @@ class UserLocationOperationTests: LocationOperationTests {
 
         let operation = _UserLocationOperation(manager: locationManager, accuracy: accuracy, completion: { _ in })
 
-        addCompletionBlockToTestOperation(operation, withExpectation: expectationWithDescription("Test: \(__FUNCTION__)"))
+        addCompletionBlockToTestOperation(operation, withExpectation: expectationWithDescription("Test: \(#function)"))
         runOperation(operation)
         waitForExpectationsWithTimeout(3, handler: nil)
 
@@ -155,7 +155,7 @@ class UserLocationOperationTests: LocationOperationTests {
             receivedLocation = location
         }
 
-        addCompletionBlockToTestOperation(operation, withExpectation: expectationWithDescription("Test: \(__FUNCTION__)"))
+        addCompletionBlockToTestOperation(operation, withExpectation: expectationWithDescription("Test: \(#function)"))
         runOperation(operation)
         waitForExpectationsWithTimeout(3, handler: nil)
 
@@ -183,7 +183,7 @@ class UserLocationOperationTests: LocationOperationTests {
             receivedErrors = errors
         })
 
-        addCompletionBlockToTestOperation(operation, withExpectation: expectationWithDescription("Test: \(__FUNCTION__)"))
+        addCompletionBlockToTestOperation(operation, withExpectation: expectationWithDescription("Test: \(#function)"))
         runOperation(operation)
         waitForExpectationsWithTimeout(3, handler: nil)
 
@@ -247,7 +247,7 @@ class ReverseGeocodeOperationTests: LocationOperationTests {
     func test__reverse_geocode_starts_geocoder() {
         let operation = _ReverseGeocodeOperation(geocoder: geocoder, location: location, completion: { _ in })
 
-        addCompletionBlockToTestOperation(operation, withExpectation: expectationWithDescription("Test: \(__FUNCTION__)"))
+        addCompletionBlockToTestOperation(operation, withExpectation: expectationWithDescription("Test: \(#function)"))
         runOperation(operation)
         waitForExpectationsWithTimeout(3, handler: nil)
 
@@ -266,7 +266,7 @@ class ReverseGeocodeOperationTests: LocationOperationTests {
             receivedErrors = errors
         })
 
-        addCompletionBlockToTestOperation(operation, withExpectation: expectationWithDescription("Test: \(__FUNCTION__)"))
+        addCompletionBlockToTestOperation(operation, withExpectation: expectationWithDescription("Test: \(#function)"))
         runOperation(operation)
         waitForExpectationsWithTimeout(3, handler: nil)
 
@@ -293,7 +293,7 @@ class ReverseGeocodeOperationTests: LocationOperationTests {
             op.cancel()
         })
 
-        addCompletionBlockToTestOperation(operation, withExpectation: expectationWithDescription("Test: \(__FUNCTION__)"))
+        addCompletionBlockToTestOperation(operation, withExpectation: expectationWithDescription("Test: \(#function)"))
         runOperation(operation)
         waitForExpectationsWithTimeout(3, handler: nil)
 
@@ -308,7 +308,7 @@ class ReverseGeocodeOperationTests: LocationOperationTests {
             XCTAssertEqual(self.placemark, placemark)
         }
 
-        addCompletionBlockToTestOperation(operation, withExpectation: expectationWithDescription("Test: \(__FUNCTION__)"))
+        addCompletionBlockToTestOperation(operation, withExpectation: expectationWithDescription("Test: \(#function)"))
         runOperation(operation)
         waitForExpectationsWithTimeout(3, handler: nil)
 
@@ -329,7 +329,7 @@ class ReverseGeocodeUserLocationOperationTests: ReverseGeocodeOperationTests {
 
         let operation = _ReverseGeocodeUserLocationOperation(geocoder: geocoder, manager: locationManager, accuracy: accuracy, completion: { _, _ in })
 
-        addCompletionBlockToTestOperation(operation, withExpectation: expectationWithDescription("Test: \(__FUNCTION__)"))
+        addCompletionBlockToTestOperation(operation, withExpectation: expectationWithDescription("Test: \(#function)"))
         runOperation(operation)
         waitForExpectationsWithTimeout(3, handler: nil)
 
@@ -344,7 +344,7 @@ class ReverseGeocodeUserLocationOperationTests: ReverseGeocodeOperationTests {
     }
 
     func test__completion_handler_receives_location_and_placeholder() {
-        let expectation = expectationWithDescription("Test: \(__FUNCTION__)")
+        let expectation = expectationWithDescription("Test: \(#function)")
 
         var blockLocation: CLLocation? = .None
         var blockPlacemark: CLPlacemark? = .None

--- a/Tests/Features/PassbookCapabilityTests.swift
+++ b/Tests/Features/PassbookCapabilityTests.swift
@@ -27,12 +27,13 @@ extension TestablePassbookRegistrar: PassbookCapabilityRegistrarType {
 class PassbookCapabilityTests: XCTestCase {
 
     var registrar: TestablePassbookRegistrar!
-    var capability: _PassbookCapability<TestablePassbookRegistrar>!
+    var capability: PassbookCapability!
 
     override func setUp() {
         super.setUp()
         registrar = TestablePassbookRegistrar()
-        capability = _PassbookCapability(registrar: registrar)
+        capability = PassbookCapability()
+        capability.registrar = registrar
     }
 
     override func tearDown() {

--- a/Tests/Features/PhotosCapabilityTests.swift
+++ b/Tests/Features/PhotosCapabilityTests.swift
@@ -61,12 +61,13 @@ class PHAuthorizationStatusTests: XCTestCase {
 
 class PhotosCapabilityTests: XCTestCase {
     var registrar: TestablePhotosRegistrar!
-    var capability: _PhotosCapability<TestablePhotosRegistrar>!
+    var capability: PhotosCapability!
 
     override func setUp() {
         super.setUp()
         registrar = TestablePhotosRegistrar()
-        capability = _PhotosCapability(registrar: registrar)
+        capability = PhotosCapability()
+        capability.registrar = registrar
     }
 
     override func tearDown() {
@@ -98,7 +99,7 @@ class PhotosCapabilityTests: XCTestCase {
     }
 
     func test__given_denied_does_not_request() {
-        capability.registrar.authorizationStatus = .Denied
+        registrar.authorizationStatus = .Denied
         var didComplete = false
         capability.requestAuthorizationWithCompletion {
             didComplete = true
@@ -108,7 +109,7 @@ class PhotosCapabilityTests: XCTestCase {
     }
 
     func test__given_authorized_does_not_request() {
-        capability.registrar.authorizationStatus = .Authorized
+        registrar.authorizationStatus = .Authorized
         var didComplete = false
         capability.requestAuthorizationWithCompletion {
             didComplete = true

--- a/Tests/Features/ReachabilityConditionTests.swift
+++ b/Tests/Features/ReachabilityConditionTests.swift
@@ -56,7 +56,7 @@ class ReachabilityConditionTests: OperationTests {
 
     func test__condition_fails_with_not_reachable() {
 
-        let expectation = expectationWithDescription("Test: \(__FUNCTION__)")
+        let expectation = expectationWithDescription("Test: \(#function)")
         let operation = TestOperation()
         let condition = ReachabilityCondition(url: url)
         condition.reachability = manager
@@ -81,7 +81,7 @@ class ReachabilityConditionTests: OperationTests {
     #if os(iOS)
     func test__condition_fails_when_wifi_required_but_only_wwan_available() {
 
-        let expectation = expectationWithDescription("Test: \(__FUNCTION__)")
+        let expectation = expectationWithDescription("Test: \(#function)")
 
         let operation = TestOperation()
         let condition = ReachabilityCondition(url: url, connectivity: .ViaWiFi)

--- a/Tests/Features/ReachabilityTests.swift
+++ b/Tests/Features/ReachabilityTests.swift
@@ -208,7 +208,7 @@ class SystemReachabilityManagerTests: ReachabilityManagerTests {
 
     func test__whenConnected__block_is_run() {
         var blockDidRun = false
-        let expectation = expectationWithDescription("Test: \(__FUNCTION__)")
+        let expectation = expectationWithDescription("Test: \(#function)")
         manager.whenConnected(.AnyConnectionKind) {
             blockDidRun = true
             expectation.fulfill()
@@ -223,7 +223,7 @@ class SystemReachabilityManagerTests: ReachabilityManagerTests {
 class HostReachabilityManagerTests: ReachabilityManagerTests {
 
     func test__reachabilityForURL__with_no_host__not_reachable() {
-        let expectation = expectationWithDescription("Test: \(__FUNCTION__)")
+        let expectation = expectationWithDescription("Test: \(#function)")
         var receivedStatus: Reachability.NetworkStatus? = .None
         manager.reachabilityForURL(NSURL(string: "http://")!) { status in
             receivedStatus = status
@@ -235,7 +235,7 @@ class HostReachabilityManagerTests: ReachabilityManagerTests {
     }
 
     func test__reachabilityForURL__without_flags__not_reachable() {
-        let expectation = expectationWithDescription("Test: \(__FUNCTION__)")
+        let expectation = expectationWithDescription("Test: \(#function)")
         var receivedStatus: Reachability.NetworkStatus? = .None
         network.flags = .None
         manager.reachabilityForURL(NSURL(string: "http://apple.com")!) { status in
@@ -248,7 +248,7 @@ class HostReachabilityManagerTests: ReachabilityManagerTests {
     }
 
     func test__reachabilityForURL__reachable() {
-        let expectation = expectationWithDescription("Test: \(__FUNCTION__)")
+        let expectation = expectationWithDescription("Test: \(#function)")
         var receivedStatus: Reachability.NetworkStatus? = .None
         manager.reachabilityForURL(NSURL(string: "http://apple.com")!) { status in
             receivedStatus = status
@@ -298,7 +298,7 @@ class DeviceReachabilityTests: XCTestCase, NetworkReachabilityDelegate {
     }
 
     func test__check() {
-        expectation = expectationWithDescription("Test: \(__FUNCTION__)")
+        expectation = expectationWithDescription("Test: \(#function)")
         if let reachability = device.reachabilityForHost("https://apple.com") {
             device.check(reachability, queue: queue)
         }

--- a/Tests/Features/RemoteNotificationConditionTests.swift
+++ b/Tests/Features/RemoteNotificationConditionTests.swift
@@ -39,7 +39,7 @@ class RemoteNotificationConditionTests: OperationTests {
         let operation = TestOperation()
         operation.addCondition(RemoteNotificationCondition(registrar: registrar))
 
-        addCompletionBlockToTestOperation(operation, withExpectation: expectationWithDescription("Test: \(__FUNCTION__)"))
+        addCompletionBlockToTestOperation(operation, withExpectation: expectationWithDescription("Test: \(#function)"))
         runOperation(operation)
         waitForExpectationsWithTimeout(3, handler: nil)
 
@@ -52,7 +52,7 @@ class RemoteNotificationConditionTests: OperationTests {
         let operation = TestOperation()
         operation.addCondition(RemoteNotificationCondition(registrar: registrar))
 
-        let expectation = expectationWithDescription("Test: \(__FUNCTION__)")
+        let expectation = expectationWithDescription("Test: \(#function)")
         var receivedErrors = [ErrorType]()
         operation.addObserver(DidFinishObserver { _, errors in
             receivedErrors = errors

--- a/Tests/Features/UserNotificationConditionTests.swift
+++ b/Tests/Features/UserNotificationConditionTests.swift
@@ -66,7 +66,7 @@ class UserNotificationConditionTests: OperationTests {
         let operation = TestOperation()
         operation.addCondition(SilentCondition(condition))
 
-        let expectation = expectationWithDescription("Test: \(__FUNCTION__)")
+        let expectation = expectationWithDescription("Test: \(#function)")
         var receivedErrors = [ErrorType]()
         operation.addObserver(DidFinishObserver { _, errors in
             receivedErrors = errors
@@ -94,7 +94,7 @@ class UserNotificationConditionTests: OperationTests {
         let operation = TestOperation()
         operation.addCondition(SilentCondition(condition))
 
-        addCompletionBlockToTestOperation(operation, withExpectation: expectationWithDescription("Test: \(__FUNCTION__)"))
+        addCompletionBlockToTestOperation(operation, withExpectation: expectationWithDescription("Test: \(#function)"))
         runOperation(operation)
         waitForExpectationsWithTimeout(3, handler: nil)
 
@@ -109,7 +109,7 @@ class UserNotificationConditionTests: OperationTests {
         let operation = TestOperation()
         operation.addCondition(condition)
 
-        addCompletionBlockToTestOperation(operation, withExpectation: expectationWithDescription("Test: \(__FUNCTION__)"))
+        addCompletionBlockToTestOperation(operation, withExpectation: expectationWithDescription("Test: \(#function)"))
         runOperation(operation)
         waitForExpectationsWithTimeout(300, handler: nil)
 

--- a/Tests/Features/WebpageOperationTests.swift
+++ b/Tests/Features/WebpageOperationTests.swift
@@ -36,7 +36,7 @@ class WebpageOperationTests: OperationTests {
         var didPresentWebpage = false
         let operation = WebpageOperation(url: url, displayControllerFrom: .ShowDetail(presentingController))
 
-        presentingController.expectation = expectationWithDescription("Test: \(__FUNCTION__)")
+        presentingController.expectation = expectationWithDescription("Test: \(#function)")
         presentingController.check = { received in
             if let safariViewController = received as? SFSafariViewController {
                 didPresentWebpage = true


### PR DESCRIPTION
There seems to be a pretty serious issue with the way Capability has its Registrar types. Causing a EXC_BAD_ACCESS somewhere.

Now, as it happens, the `Registrar` protocol stuff can probably be simplified and removed entirely from the constructors. This would be similar to how the `HostReachabilityType` was refactored into a variable property with a default value.

This would grant nicer public interfaces.