### PR TITLE
Pass NetworkOperation error if present when operation finishes

### DIFF
--- a/Sources/Features/Shared/NetworkOperation.swift
+++ b/Sources/Features/Shared/NetworkOperation.swift
@@ -45,7 +45,7 @@ public class URLSessionTaskOperation: Operation {
 
         if object === task && task.state == .Completed  && keyPath == KeyPath.State.rawValue {
             task.removeObserver(self, forKeyPath: KeyPath.State.rawValue)
-            finish()
+            finish(task.error)
         }
     }
 }


### PR DESCRIPTION
Hi again! I noticed that when wrapping a `NetworkOperation` in a `RetryOperation`, it would never retry because the error is not passed. Passing the `task` error in `finished()` seems most straightforward to me (it is `nil` for successful operations) but I'm happy to consider other approaches.