### PR TITLE
Disable automatic KVO notifications for state

### DIFF
--- a/Sources/Core/Shared/Operation.swift
+++ b/Sources/Core/Shared/Operation.swift
@@ -94,6 +94,10 @@ public class Operation: NSOperation {
         }
     }
 
+    class func automaticallyNotifiesObserversOfState() -> Bool {
+        return false
+    }
+
     // use the KVO mechanism to indicate that changes to "state" affect other properties as well
     class func keyPathsForValuesAffectingIsReady() -> Set<NSObject> {
         return ["State", "Cancelled"]


### PR DESCRIPTION
I think KVO wraps setters in will/didChangeValueForKey automatically. Switching `automaticallyNotifiesObserversOfState` produces a different call stack when running from Objective-C. This is pretty much invisible in Swift, but I think this piece is hidden somewhere within "thunk".

`automaticallyNotifiesObserversOfState = YES`

<img width="394" alt="screenshot 2016-04-09 09 57 43" src="https://cloud.githubusercontent.com/assets/704044/14402872/9548b804-fe39-11e5-8494-f4950a1b72cc.png">

`automaticallyNotifiesObserversOfState = NO`

<img width="378" alt="screenshot 2016-04-09 09 59 05" src="https://cloud.githubusercontent.com/assets/704044/14402890/dfec1f18-fe39-11e5-85b9-0df98623d305.png">