### PR TITLE
Add preferredStyle to AlertOperation initializer

### DIFF
--- a/Sources/Core/iOS/AlertOperation.swift
+++ b/Sources/Core/iOS/AlertOperation.swift
@@ -67,8 +67,8 @@ public class AlertOperation<From: PresentingViewController>: Operation {
     - parameter from: a generic type conforming to `PresentingViewController`,
     such as an `UIViewController`
     */
-    public init(presentAlertFrom from: From) {
-        let controller = UIAlertController(title: .None, message: .None, preferredStyle: .Alert)
+    public init(presentAlertFrom from: From, preferredStyle: UIAlertControllerStyle = .Alert) {
+        let controller = UIAlertController(title: .None, message: .None, preferredStyle: preferredStyle)
         uiOperation = UIOperation(controller: controller, displayControllerFrom: .Present(from))
         super.init()
         name = "Alert<\(From.self)>"

--- a/Sources/Core/iOS/AlertOperation.swift
+++ b/Sources/Core/iOS/AlertOperation.swift
@@ -86,7 +86,7 @@ public class AlertOperation<From: PresentingViewController>: Operation {
     - parameter style: a `UIAlertActionStyle` which defaults to `.Default`.
     - parameter handler: a block which receives the operation, and returns Void.
     */
-    public func addActionWithTitle(title: String, style: UIAlertActionStyle = .Default, handler: AlertOperation -> Void = { _ in }) {
+    public func addActionWithTitle(title: String, style: UIAlertActionStyle = .Default, handler: AlertOperation -> Void = { _ in }) -> UIAlertAction {
         let action = UIAlertAction(title: title, style: style) { [weak self] _ in
             if let weakSelf = self {
                 handler(weakSelf)
@@ -94,6 +94,7 @@ public class AlertOperation<From: PresentingViewController>: Operation {
             }
         }
         alert.addAction(action)
+        return action
     }
 
     /**

--- a/Tests/Core/AlertOperationTests.swift
+++ b/Tests/Core/AlertOperationTests.swift
@@ -19,6 +19,17 @@ class AlertOperationTests: OperationTests {
         super.setUp()
         presentingController = TestablePresentingController()
     }
+    
+    func test__alert_style_set_default() {
+        let alert = AlertOperation(presentAlertFrom: presentingController)
+        XCTAssertEqual(alert.preferredStyle, UIAlertControllerStyle.Alert)
+    }
+    
+    func test__alert_style_actionSheet() {
+        let style = UIAlertControllerStyle.ActionSheet
+        let alert = AlertOperation(presentAlertFrom: presentingController, preferredStyle: style)
+        XCTAssertEqual(alert.preferredStyle, style)
+    }
 
     func test__alert_title_works() {
         let alert = AlertOperation(presentAlertFrom: presentingController)

--- a/Tests/Core/AlertOperationTests.swift
+++ b/Tests/Core/AlertOperationTests.swift
@@ -21,14 +21,14 @@ class AlertOperationTests: OperationTests {
     }
     
     func test__alert_style_set_default() {
-        let alert = AlertOperation(presentAlertFrom: presentingController)
-        XCTAssertEqual(alert.preferredStyle, UIAlertControllerStyle.Alert)
+        let op = AlertOperation(presentAlertFrom: presentingController)
+        XCTAssertEqual(op.alert.preferredStyle, UIAlertControllerStyle.Alert)
     }
     
     func test__alert_style_actionSheet() {
         let style = UIAlertControllerStyle.ActionSheet
-        let alert = AlertOperation(presentAlertFrom: presentingController, preferredStyle: style)
-        XCTAssertEqual(alert.preferredStyle, style)
+        let op = AlertOperation(presentAlertFrom: presentingController, preferredStyle: style)
+        XCTAssertEqual(op.alert.preferredStyle, style)
     }
 
     func test__alert_title_works() {


### PR DESCRIPTION
I'd like to be able to use alert operation for showing an ActionSheet as well:

`let alertOp = AlertOperation(presentAlertFrom: self, style: .ActionSheet)`
