### PR TITLE
Fixes bug accessing the PHPhotoLibrary

### DIFF
--- a/Sources/Features/iOS/PhotosCapability.swift
+++ b/Sources/Features/iOS/PhotosCapability.swift
@@ -75,7 +75,7 @@ public class PhotosCapability: CapabilityType {
     /// - returns: the EKEntityType, the required type of the capability
     public let requirement: Void
 
-    internal lazy var registrar: PhotosCapabilityRegistrarType = PHPhotoLibrary()
+    internal lazy var registrar: PhotosCapabilityRegistrarType = PHPhotoLibrary.sharedPhotoLibrary()
 
     /**
      Initialize the capability. There is no requirement type

--- a/Tests/Features/PhotosCapabilityTests.swift
+++ b/Tests/Features/PhotosCapabilityTests.swift
@@ -117,4 +117,8 @@ class PhotosCapabilityTests: XCTestCase {
         XCTAssertFalse(registrar.didRequestAuthorization)
         XCTAssertTrue(didComplete)
     }
+
+    func test__default_registrar() {
+        XCTAssertNotNil(PhotosCapability().registrar.opr_authorizationStatus())
+    }
 }


### PR DESCRIPTION
This was not getting trigged in unit tests, because the registrar property is lazy. And for all tests we replace the actual registrar object (in this case the PHPhotoLibrary) with a testable equivalent.

This means that the init() of PHPhotoLibrary was never called - and it turns out that it hits a run time exception.

This is exactly the sort of bug that Swift prevents, as if PHPhotoLibrary were written in Swift, the code would not have even compiled.

This fixes #280.