### PR TITLE
Removes Codecov

### DIFF
--- a/.ci/scripts/test-ios
+++ b/.ci/scripts/test-ios
@@ -2,4 +2,3 @@
 source /usr/local/opt/chruby/share/chruby/chruby.sh
 chruby ruby
 bundle install --quiet && bundle exec fastlane ios test
-bash <(curl -s https://codecov.io/bash) -D .ci/xcodebuild-data


### PR DESCRIPTION
I just don't understand how reporting code coverage can be so error prone! At the moment @codecov only reports the coverage for the diffs in the branch - not the total coverage.