### PR TITLE
- Un-ticking target for watchOS CloudKit references

### DIFF
--- a/Operations.xcodeproj/project.pbxproj
+++ b/Operations.xcodeproj/project.pbxproj
@@ -16,11 +16,9 @@
 		650852381C8B23950058F8AA /* Generators.swift in Sources */ = {isa = PBXBuildFile; fileRef = 650852351C8B23950058F8AA /* Generators.swift */; };
 		650852391C8B23950058F8AA /* Generators.swift in Sources */ = {isa = PBXBuildFile; fileRef = 650852351C8B23950058F8AA /* Generators.swift */; };
 		6508523B1C8B2E320058F8AA /* CloudKitInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6508523A1C8B2E320058F8AA /* CloudKitInterface.swift */; };
-		6508523C1C8B2E320058F8AA /* CloudKitInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6508523A1C8B2E320058F8AA /* CloudKitInterface.swift */; };
 		6508523D1C8B2E320058F8AA /* CloudKitInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6508523A1C8B2E320058F8AA /* CloudKitInterface.swift */; };
 		6508523E1C8B2E320058F8AA /* CloudKitInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6508523A1C8B2E320058F8AA /* CloudKitInterface.swift */; };
 		650852401C8B2E460058F8AA /* CloudKitOperationExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6508523F1C8B2E460058F8AA /* CloudKitOperationExtensions.swift */; };
-		650852411C8B2E460058F8AA /* CloudKitOperationExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6508523F1C8B2E460058F8AA /* CloudKitOperationExtensions.swift */; };
 		650852421C8B2E460058F8AA /* CloudKitOperationExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6508523F1C8B2E460058F8AA /* CloudKitOperationExtensions.swift */; };
 		650852431C8B2E460058F8AA /* CloudKitOperationExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6508523F1C8B2E460058F8AA /* CloudKitOperationExtensions.swift */; };
 		652617AE1C11F62A00654091 /* Operations.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 652617A31C11F62A00654091 /* Operations.framework */; };
@@ -1256,7 +1254,6 @@
 			files = (
 				652618FA1C11F9AD00654091 /* PassbookCapability.swift in Sources */,
 				652618841C11F8FD00654091 /* SlientCondition.swift in Sources */,
-				6508523C1C8B2E320058F8AA /* CloudKitInterface.swift in Sources */,
 				65E4CDDE1C33422100B9F9D8 /* RetryOperation.swift in Sources */,
 				652618831C11F8FD00654091 /* OperationQueue.swift in Sources */,
 				6526187E1C11F8FD00654091 /* NegatedCondition.swift in Sources */,
@@ -1287,7 +1284,6 @@
 				652618811C11F8FD00654091 /* OperationCondition.swift in Sources */,
 				650852371C8B23950058F8AA /* Generators.swift in Sources */,
 				6565FFE61C98B7AC008B5248 /* Profiler.swift in Sources */,
-				650852411C8B2E460058F8AA /* CloudKitOperationExtensions.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
- WatchOS target wasn't building due to CloudKit references.