### PR TITLE
Implements AcitivityIndicatorViewObserver

### DIFF
--- a/Operations.xcodeproj/project.pbxproj
+++ b/Operations.xcodeproj/project.pbxproj
@@ -236,6 +236,8 @@
 		6526197B1C11FE6D00654091 /* AddressBookConditionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6526171D1C11F5EB00654091 /* AddressBookConditionTests.swift */; };
 		6526197C1C11FE6D00654091 /* AddressBookTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6526171E1C11F5EB00654091 /* AddressBookTests.swift */; };
 		6526197D1C11FE6D00654091 /* ContactsOperationsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 652617201C11F5EB00654091 /* ContactsOperationsTests.swift */; };
+		653D40221CC2591700893746 /* ActivityIndicatorViewObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 653D40211CC2591700893746 /* ActivityIndicatorViewObserver.swift */; };
+		653D40241CC2594800893746 /* ActivityIndicatorViewObserverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 653D40231CC2594800893746 /* ActivityIndicatorViewObserverTests.swift */; };
 		6565FFE51C98B7AC008B5248 /* Profiler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6565FFE41C98B7AC008B5248 /* Profiler.swift */; };
 		6565FFE61C98B7AC008B5248 /* Profiler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6565FFE41C98B7AC008B5248 /* Profiler.swift */; };
 		6565FFE71C98B7AC008B5248 /* Profiler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6565FFE41C98B7AC008B5248 /* Profiler.swift */; };
@@ -406,6 +408,8 @@
 		652617E91C11F72A00654091 /* Operations.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Operations.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		652617F21C11F72A00654091 /* OS X OperationsTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "OS X OperationsTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		652618561C11F84800654091 /* Extension Compatible.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = "Extension Compatible.xcconfig"; sourceTree = "<group>"; };
+		653D40211CC2591700893746 /* ActivityIndicatorViewObserver.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ActivityIndicatorViewObserver.swift; sourceTree = "<group>"; };
+		653D40231CC2594800893746 /* ActivityIndicatorViewObserverTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ActivityIndicatorViewObserverTests.swift; sourceTree = "<group>"; };
 		6565FFE41C98B7AC008B5248 /* Profiler.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Profiler.swift; sourceTree = "<group>"; };
 		6565FFE91C98C860008B5248 /* ProfilerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProfilerTests.swift; sourceTree = "<group>"; };
 		65691C9D1C21A29C00AF06B4 /* ResultInjectionTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ResultInjectionTests.swift; sourceTree = "<group>"; };
@@ -511,6 +515,7 @@
 		652616C81C11F5EB00654091 /* iOS */ = {
 			isa = PBXGroup;
 			children = (
+				653D40211CC2591700893746 /* ActivityIndicatorViewObserver.swift */,
 				652616C91C11F5EB00654091 /* AlertOperation.swift */,
 				652616CA1C11F5EB00654091 /* BackgroundObserver.swift */,
 				652616CB1C11F5EB00654091 /* NetworkObserver.swift */,
@@ -676,6 +681,7 @@
 		6526170A1C11F5EB00654091 /* Core */ = {
 			isa = PBXGroup;
 			children = (
+				653D40231CC2594800893746 /* ActivityIndicatorViewObserverTests.swift */,
 				6526170B1C11F5EB00654091 /* AlertOperationTests.swift */,
 				6526170C1C11F5EB00654091 /* BackgroundObserverTests.swift */,
 				6526170D1C11F5EB00654091 /* BlockConditionTests.swift */,
@@ -1180,6 +1186,7 @@
 				652618691C11F8FC00654091 /* MutuallyExclusive.swift in Sources */,
 				652618E71C11F98500654091 /* ContactsUIOperations.swift in Sources */,
 				652618681C11F8FC00654091 /* LoggingObserver.swift in Sources */,
+				653D40221CC2591700893746 /* ActivityIndicatorViewObserver.swift in Sources */,
 				652618661C11F8FC00654091 /* GroupOperation.swift in Sources */,
 				652618EB1C11F99E00654091 /* AddressBookConditions.swift in Sources */,
 				652618EC1C11F99E00654091 /* AddressBookOperations.swift in Sources */,
@@ -1209,6 +1216,7 @@
 				652619211C11FC3D00654091 /* GatedOperationTests.swift in Sources */,
 				652619721C11FE6900654091 /* LocationOperationsTests.swift in Sources */,
 				652619791C11FE6900654091 /* UserNotificationConditionTests.swift in Sources */,
+				653D40241CC2594800893746 /* ActivityIndicatorViewObserverTests.swift in Sources */,
 				652619231C11FC3D00654091 /* LoggingObserverTests.swift in Sources */,
 				6526197B1C11FE6D00654091 /* AddressBookConditionTests.swift in Sources */,
 				6526192C1C11FC3D00654091 /* UIOperationTests.swift in Sources */,

--- a/Operations_ExtensionCompatible.xcodeproj/project.pbxproj
+++ b/Operations_ExtensionCompatible.xcodeproj/project.pbxproj
@@ -195,6 +195,8 @@
 		65356EBC1C8B3B9D0029E8AF /* CloudKitOperationExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65356EB41C8B3B390029E8AF /* CloudKitOperationExtensions.swift */; };
 		65356EBD1C8B3B9D0029E8AF /* CloudKitInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65356EB31C8B3B390029E8AF /* CloudKitInterface.swift */; };
 		65356EBE1C8B3B9D0029E8AF /* CloudKitOperationExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65356EB41C8B3B390029E8AF /* CloudKitOperationExtensions.swift */; };
+		653D40261CC25A6800893746 /* ActivityIndicatorViewObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 653D40251CC25A6800893746 /* ActivityIndicatorViewObserver.swift */; };
+		653D40281CC25A7D00893746 /* ActivityIndicatorViewObserverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 653D40271CC25A7D00893746 /* ActivityIndicatorViewObserverTests.swift */; };
 		6584D2381C6BF86200306EED /* FunctionalOperations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6584D2341C6BF86200306EED /* FunctionalOperations.swift */; };
 		6584D2391C6BF86200306EED /* RepeatedOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6584D2351C6BF86200306EED /* RepeatedOperation.swift */; };
 		6584D23A1C6BF86200306EED /* ResultInjection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6584D2361C6BF86200306EED /* ResultInjection.swift */; };
@@ -348,6 +350,8 @@
 		65356EB01C8B3B2C0029E8AF /* Repeatable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Repeatable.swift; sourceTree = "<group>"; };
 		65356EB31C8B3B390029E8AF /* CloudKitInterface.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CloudKitInterface.swift; sourceTree = "<group>"; };
 		65356EB41C8B3B390029E8AF /* CloudKitOperationExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CloudKitOperationExtensions.swift; sourceTree = "<group>"; };
+		653D40251CC25A6800893746 /* ActivityIndicatorViewObserver.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ActivityIndicatorViewObserver.swift; sourceTree = "<group>"; };
+		653D40271CC25A7D00893746 /* ActivityIndicatorViewObserverTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ActivityIndicatorViewObserverTests.swift; sourceTree = "<group>"; };
 		6584D2341C6BF86200306EED /* FunctionalOperations.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FunctionalOperations.swift; sourceTree = "<group>"; };
 		6584D2351C6BF86200306EED /* RepeatedOperation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RepeatedOperation.swift; sourceTree = "<group>"; };
 		6584D2361C6BF86200306EED /* ResultInjection.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ResultInjection.swift; sourceTree = "<group>"; };
@@ -451,6 +455,7 @@
 		652617341C11F61700654091 /* iOS */ = {
 			isa = PBXGroup;
 			children = (
+				653D40251CC25A6800893746 /* ActivityIndicatorViewObserver.swift */,
 				652617351C11F61700654091 /* AlertOperation.swift */,
 				652617361C11F61700654091 /* BackgroundObserver.swift */,
 				652617371C11F61700654091 /* NetworkObserver.swift */,
@@ -615,6 +620,7 @@
 		652617761C11F61700654091 /* Core */ = {
 			isa = PBXGroup;
 			children = (
+				653D40271CC25A7D00893746 /* ActivityIndicatorViewObserverTests.swift */,
 				652617771C11F61700654091 /* AlertOperationTests.swift */,
 				652617781C11F61700654091 /* BackgroundObserverTests.swift */,
 				652617791C11F61700654091 /* BlockConditionTests.swift */,
@@ -978,6 +984,7 @@
 				6584D2381C6BF86200306EED /* FunctionalOperations.swift in Sources */,
 				652619CA1C12003F00654091 /* CloudKitOperation.swift in Sources */,
 				652619811C11FF5200654091 /* ComposedOperation.swift in Sources */,
+				653D40281CC25A7D00893746 /* ActivityIndicatorViewObserverTests.swift in Sources */,
 				652619D11C12004900654091 /* ContactsCondition.swift in Sources */,
 				652619911C11FF5200654091 /* TimeoutObserver.swift in Sources */,
 				652619C21C12003A00654091 /* PhotosCapability.swift in Sources */,
@@ -999,6 +1006,7 @@
 				652619D31C12004C00654091 /* AddressBook.swift in Sources */,
 				652619881C11FF5200654091 /* MutuallyExclusive.swift in Sources */,
 				652619871C11FF5200654091 /* LoggingObserver.swift in Sources */,
+				653D40261CC25A6800893746 /* ActivityIndicatorViewObserver.swift in Sources */,
 				652619851C11FF5200654091 /* GroupOperation.swift in Sources */,
 				6526198D1C11FF5200654091 /* OperationObserver.swift in Sources */,
 				6526197E1C11FF5200654091 /* BlockCondition.swift in Sources */,

--- a/Sources/Core/iOS/ActivityIndicatorViewObserver.swift
+++ b/Sources/Core/iOS/ActivityIndicatorViewObserver.swift
@@ -2,14 +2,50 @@
 //  ActivityIndicatorViewObserver.swift
 //  Operations
 //
-//  Created by Daniel Thorpe on 16/04/2016.
+//  Created by Matthew Holden 16/04/2016.
 //
 //
 
-import Foundation
+import UIKit
 
-// TODO 🙂
+public protocol ActivityIndicatorViewAnimationInterface {
+    func startAnimating()
+    func stopAnimating()
+}
 
-public class ActivityIndicatorViewObserver {
+extension UIActivityIndicatorView: ActivityIndicatorViewAnimationInterface {}
 
+/**
+ An OperationObserverType that can update the state of an associated `UIActivityIndicatorView`
+ when the observed operation starts and finishes.
+ 
+ - note: Any type conforming to `ActivityIndicatorViewAnimationInterface` can be provided as 
+         the activity indicator.
+ */
+public class ActivityIndicatorViewObserver: OperationDidStartObserver, OperationDidFinishObserver {
+
+    private let activityIndicator: ActivityIndicatorViewAnimationInterface
+
+    /**
+     Initialize the observer with an `ActivityIndicatorViewAnimationInterface`-conforming type.
+     - parameter activityIndicator: the object to start and stop animating
+     - returns: an observer
+     - note: The activity indicator's `startAninating` and `stopAnimating` methods 
+             are guaranteed to execute on the main queue.
+     */
+    public init(activityIndicator: ActivityIndicatorViewAnimationInterface) {
+        self.activityIndicator = activityIndicator
+    }
+
+    public func didStartOperation(operation: Operation) {
+        dispatch_async(Queue.Main.queue) {
+            self.activityIndicator.startAnimating()
+        }
+    }
+
+    public func didFinishOperation(operation: Operation, errors: [ErrorType]) {
+        dispatch_async(Queue.Main.queue) {
+            self.activityIndicator.stopAnimating()
+        }
+    }
 }

--- a/Sources/Core/iOS/ActivityIndicatorViewObserver.swift
+++ b/Sources/Core/iOS/ActivityIndicatorViewObserver.swift
@@ -1,0 +1,15 @@
+//
+//  ActivityIndicatorViewObserver.swift
+//  Operations
+//
+//  Created by Daniel Thorpe on 16/04/2016.
+//
+//
+
+import Foundation
+
+// TODO 🙂
+
+public class ActivityIndicatorViewObserver {
+
+}

--- a/Sources/Core/iOS/ActivityIndicatorViewObserver.swift
+++ b/Sources/Core/iOS/ActivityIndicatorViewObserver.swift
@@ -8,7 +8,13 @@
 
 import UIKit
 
-public protocol ActivityIndicatorViewAnimationInterface {
+/**
+ Conforming types are compatible with `ActivityIndicatorViewObserver`.
+ Its two methods are modeled after `UIActivityIndicatorView`.
+
+ As a convenience, Operations extends `UIActivityIndicatorView` to declare conformance.
+ */
+public protocol ActivityIndicatorViewAnimationInterface: class {
     func startAnimating()
     func stopAnimating()
 }
@@ -24,7 +30,7 @@ extension UIActivityIndicatorView: ActivityIndicatorViewAnimationInterface {}
  */
 public class ActivityIndicatorViewObserver: OperationDidStartObserver, OperationDidFinishObserver {
 
-    private let activityIndicator: ActivityIndicatorViewAnimationInterface
+    private weak var activityIndicator: ActivityIndicatorViewAnimationInterface?
 
     /**
      Initialize the observer with an `ActivityIndicatorViewAnimationInterface`-conforming type.
@@ -33,19 +39,19 @@ public class ActivityIndicatorViewObserver: OperationDidStartObserver, Operation
      - note: The activity indicator's `startAninating` and `stopAnimating` methods 
              are guaranteed to execute on the main queue.
      */
-    public init(activityIndicator: ActivityIndicatorViewAnimationInterface) {
+    public init(_ activityIndicator: ActivityIndicatorViewAnimationInterface) {
         self.activityIndicator = activityIndicator
     }
 
     public func didStartOperation(operation: Operation) {
-        dispatch_async(Queue.Main.queue) {
-            self.activityIndicator.startAnimating()
+        dispatch_async(Queue.Main.queue) { [weak self] in
+            self?.activityIndicator?.startAnimating()
         }
     }
 
     public func didFinishOperation(operation: Operation, errors: [ErrorType]) {
-        dispatch_async(Queue.Main.queue) {
-            self.activityIndicator.stopAnimating()
+        dispatch_async(Queue.Main.queue) { [weak self] in
+            self?.activityIndicator?.stopAnimating()
         }
     }
 }

--- a/Tests/Core/ActivityIndicatorViewObserverTests.swift
+++ b/Tests/Core/ActivityIndicatorViewObserverTests.swift
@@ -2,7 +2,7 @@
 //  ActivityIndicatorViewObserverTests.swift
 //  Operations
 //
-//  Created by Daniel Thorpe on 16/04/2016.
+//  Created by Matthew Holden 16/04/2016.
 //
 //
 
@@ -10,16 +10,44 @@ import Foundation
 import XCTest
 @testable import Operations
 
-// TODO 🙂
+enum AnimationState {
+    case Animating
+    case NotAnimating
+}
 
-class ActivityIndicatorViewObserverTests: XCTestCase {
+class TestableActivityIndicatorView: ActivityIndicatorViewAnimationInterface {
+    typealias IndicatorAnimationStateDidChangeBlock =  (toState: AnimationState) -> Void
+
+    let animationStateDidChange: IndicatorAnimationStateDidChangeBlock
+
+    init(_ didChange: IndicatorAnimationStateDidChangeBlock) {
+        animationStateDidChange = didChange
+    }
+
+    func startAnimating() {
+        animationStateDidChange(toState: .Animating)
+    }
+
+    func stopAnimating() {
+        animationStateDidChange(toState: .NotAnimating)
+    }
+}
+
+
+class ActivityIndicatorViewObserverTests: OperationTests {
 
     var operation: TestOperation!
-    var indicator: ActivityIndicatorViewObserver!
+    var indicator: ActivityIndicatorViewAnimationInterface!
+    var animationStateChanges: [AnimationState]!
 
     override func setUp() {
         super.setUp()
+        animationStateChanges = [AnimationState]()
         operation = TestOperation()
+        indicator = TestableActivityIndicatorView { [unowned self] animationState in
+            self.animationStateChanges.append(animationState)
+        }
+        operation.addObserver(ActivityIndicatorViewObserver(activityIndicator: indicator))
     }
 
     override func tearDown() {
@@ -29,10 +57,52 @@ class ActivityIndicatorViewObserverTests: XCTestCase {
     }
 
     func test__activity_indicator_starts_animating__when_operation_starts() {
+        addCompletionBlockToTestOperation(operation, withExpectation: expectationWithDescription("Test: \(#function)"))
 
+        var animationStateChangesBeforeWillFinish = 0
+        var firstAnimationChangeState: AnimationState? = .None
+
+        operation.addObserver(WillFinishObserver { [unowned self] _, _ in
+                animationStateChangesBeforeWillFinish = self.animationStateChanges.count
+                firstAnimationChangeState = self.animationStateChanges.first
+            })
+
+        runOperation(operation)
+
+        waitForExpectationsWithTimeout(3) { error in
+            XCTAssertTrue(self.operation.didExecute)
+            XCTAssertTrue(self.operation.finished)
+
+            XCTAssertEqual(animationStateChangesBeforeWillFinish, 1)
+            XCTAssertTrue(firstAnimationChangeState == .Animating)
+        }
     }
 
     func test__activity_indicator_stops_animating__when_operation_stops() {
+
+        let expectation = expectationWithDescription("Test: \(#function)")
+
+        operation.addCompletionBlock {
+            // ActivityIndicatorViewObserver will marshalls its invocation of the indicator's `stopAnimating` method
+            // onto the main queue. 
+            // As such, we need to ensure we don't fulfill this test's expectations
+            // until the run loop has had the opportunity to run one additional time.
+            dispatch_async(Queue.Main.queue) {
+                expectation.fulfill()
+            }
+        }
+
+        runOperation(operation)
+
+        waitForExpectationsWithTimeout(3) { [unowned self] error in
+            XCTAssertTrue(self.operation.didExecute)
+            XCTAssertTrue(self.operation.finished)
+
+            XCTAssertEqual(self.animationStateChanges.count, 2)
+
+            XCTAssertTrue(self.animationStateChanges.first == .Animating)
+            XCTAssertTrue(self.animationStateChanges.last == .NotAnimating)
+        }
 
     }
 }

--- a/Tests/Core/ActivityIndicatorViewObserverTests.swift
+++ b/Tests/Core/ActivityIndicatorViewObserverTests.swift
@@ -83,8 +83,8 @@ class ActivityIndicatorViewObserverTests: OperationTests {
         let expectation = expectationWithDescription("Test: \(#function)")
 
         operation.addCompletionBlock {
-            // ActivityIndicatorViewObserver will marshalls its invocation of the indicator's `stopAnimating` method
-            // onto the main queue. 
+            // ActivityIndicatorViewObserver will marshall its invocation of 
+            // the indicator's `stopAnimating` method onto the main queue.
             // As such, we need to ensure we don't fulfill this test's expectations
             // until the run loop has had the opportunity to run one additional time.
             dispatch_async(Queue.Main.queue) {

--- a/Tests/Core/ActivityIndicatorViewObserverTests.swift
+++ b/Tests/Core/ActivityIndicatorViewObserverTests.swift
@@ -1,0 +1,38 @@
+//
+//  ActivityIndicatorViewObserverTests.swift
+//  Operations
+//
+//  Created by Daniel Thorpe on 16/04/2016.
+//
+//
+
+import Foundation
+import XCTest
+@testable import Operations
+
+// TODO 🙂
+
+class ActivityIndicatorViewObserverTests: XCTestCase {
+
+    var operation: TestOperation!
+    var indicator: ActivityIndicatorViewObserver!
+
+    override func setUp() {
+        super.setUp()
+        operation = TestOperation()
+    }
+
+    override func tearDown() {
+        operation = nil
+        indicator = nil
+        super.tearDown()
+    }
+
+    func test__activity_indicator_starts_animating__when_operation_starts() {
+
+    }
+
+    func test__activity_indicator_stops_animating__when_operation_stops() {
+
+    }
+}


### PR DESCRIPTION
(For earlier discussion, refer to #202.)
    
`ActivityIndicatorViewObserver` is initialized with an `ActivityIndicatorViewAnimationInterface` type.
    
The observer will call that activity indicator's `startAnimating()` and `stopAnimating()` in response to the observed operation's start and finish.
