### PR TITLE
Fix an incorrect Xcode Fix-It hint.

### DIFF
--- a/Sources/Core/Shared/Operation.swift
+++ b/Sources/Core/Shared/Operation.swift
@@ -265,7 +265,7 @@ public class Operation: NSOperation {
 
      - parameter errors: an array of `ErrorType`.
      */
-    @available(*, unavailable, renamed="didFinish")
+    @available(*, unavailable, renamed="operationDidFinish")
     public func finished(errors: [ErrorType]) {
         operationDidFinish(errors)
     }


### PR DESCRIPTION
`finished` has been renamed to `operationDidFinish` but the `@availability` attribute did not reflect this.

This fixes #299.