### PR TITLE
Creating a UI which reflects CLLocationAuthorizationStatus

### DIFF
--- a/Sources/Features/iOS/LocationCapability.swift
+++ b/Sources/Features/iOS/LocationCapability.swift
@@ -183,6 +183,10 @@ public class LocationCapability: NSObject, CLLocationManagerDelegate, Capability
      - parameter status: the CLAuthorizationStatus
      */
     @objc public func locationManager(manager: CLLocationManager, didChangeAuthorizationStatus status: CLAuthorizationStatus) {
+        guard status != .NotDetermined else {
+            return
+        }
+
         authorizationCompletionBlock?()
     }
 }


### PR DESCRIPTION
I'm not sure why it thinks this is the right thing to do, but in some (but perhaps not all?) cases when asking CLLocationManager to authorize us for Location updates, it will immediately respond with 'NotDetermined' and then show the user the dialog asking for permission. After the dialog is dismissed, it proceeds to call us back with the proper status value.

Without this fix, adding a condition like this: 

    addCondition(AuthorizedFor(Capability.Location()))

will immediately fail our operation due to the premature callback.