### PR TITLE
Bugfix: Retaincycle in WebpageOperation 

### DIFF
--- a/Sources/Features/iOS/WebpageOperation.swift
+++ b/Sources/Features/iOS/WebpageOperation.swift
@@ -10,25 +10,19 @@ import Foundation
 import SafariServices
 
 @available(iOS 9.0, *)
-protocol WebpageController: class {
-    weak var delegate: SFSafariViewControllerDelegate? { get set }
-    init(URL: NSURL, entersReaderIfAvailable: Bool)
-}
+public class WebpageOperation<From: PresentingViewController>: GroupOperation, SFSafariViewControllerDelegate {
 
-@available(iOS 9.0, *)
-public class WebpageOperation<From: PresentingViewController>: Operation, SFSafariViewControllerDelegate {
-
-    let operation: UIOperation<SFSafariViewController, From>
+    var operation: UIOperation<SFSafariViewController, From>
     
     public init(url: NSURL, displayControllerFrom from: ViewControllerDisplayStyle<From>, entersReaderIfAvailable: Bool = true, sender: AnyObject? = .None) {
         operation = UIOperation(controller: SFSafariViewController(URL: url, entersReaderIfAvailable: entersReaderIfAvailable), displayControllerFrom: from, sender: sender)
-        super.init()
+        super.init(operations: [operation])
+        
+        addObserver(WillExecuteObserver() { [weak self] _ in
+            self?.operation.controller.delegate = self
+        })
+        
         addCondition(MutuallyExclusive<UIViewController>())
-    }
-
-    public override func execute() {
-        operation.controller.delegate = self
-        produceOperation(operation)
     }
 
     @objc public func safariViewControllerDidFinish(controller: SFSafariViewController) {

--- a/Sources/Features/iOS/WebpageOperation.swift
+++ b/Sources/Features/iOS/WebpageOperation.swift
@@ -9,20 +9,35 @@
 import Foundation
 import SafariServices
 
-@available(iOS 9.0, *)
-public class WebpageOperation<From: PresentingViewController>: GroupOperation, SFSafariViewControllerDelegate {
 
-    var operation: UIOperation<SFSafariViewController, From>
+/**
+ An operation that presents an instance of the `SFSafariViewController` on a presenting view controller.
+ */
+@available(iOS 9.0, *)
+public class WebpageOperation<From: PresentingViewController>: ComposedOperation<UIOperation<SFSafariViewController, From>>, SFSafariViewControllerDelegate {
     
-    public init(url: NSURL, displayControllerFrom from: ViewControllerDisplayStyle<From>, entersReaderIfAvailable: Bool = true, sender: AnyObject? = .None) {
-        operation = UIOperation(controller: SFSafariViewController(URL: url, entersReaderIfAvailable: entersReaderIfAvailable), displayControllerFrom: from, sender: sender)
-        super.init(operations: [operation])
+    /**
+     Composes an operation that presents an instance of the `SFSafariViewController` on a presenting view controller.
+     
+     - parameter url: the `URL` that will be opend by `SFSafariViewController`.
+     - parameter displayControllerFrom: a `ViewControllerDisplayStyle`.
+     - parameter entersReaderIfAvailable: an optional flag that tells the `SFSafariViewController` to open the webpage in a reader mode if available.
+     - parameter sender: an `AnyObject` sender.
+     */
+    public convenience init(url: NSURL, displayControllerFrom from: ViewControllerDisplayStyle<From>, entersReaderIfAvailable: Bool = true, sender: AnyObject? = .None) {
+        let operation = UIOperation(controller: SFSafariViewController(URL: url, entersReaderIfAvailable: entersReaderIfAvailable), displayControllerFrom: from, sender: sender)
+        self.init(operation: operation)
         
         addObserver(WillExecuteObserver() { [weak self] _ in
             self?.operation.controller.delegate = self
         })
         
         addCondition(MutuallyExclusive<UIViewController>())
+    }
+    
+    // Annotated to be private so a consumer needs to call init(_:, displayControllerFrom:) because a URL is needed.
+    override private init(operation composed: UIOperation<SFSafariViewController, From>) {
+        super.init(operation: composed)
     }
 
     @objc public func safariViewControllerDidFinish(controller: SFSafariViewController) {

--- a/Sources/Features/iOS/WebpageOperation.swift
+++ b/Sources/Features/iOS/WebpageOperation.swift
@@ -19,9 +19,9 @@ protocol WebpageController: class {
 public class WebpageOperation<From: PresentingViewController>: Operation, SFSafariViewControllerDelegate {
 
     let operation: UIOperation<SFSafariViewController, From>
-
-    public init(url: NSURL, displayControllerFrom from: ViewControllerDisplayStyle<From>, sender: AnyObject? = .None) {
-        operation = UIOperation(controller: SFSafariViewController(URL: url, entersReaderIfAvailable: true), displayControllerFrom: from, sender: sender)
+    
+    public init(url: NSURL, displayControllerFrom from: ViewControllerDisplayStyle<From>, entersReaderIfAvailable: Bool = true, sender: AnyObject? = .None) {
+        operation = UIOperation(controller: SFSafariViewController(URL: url, entersReaderIfAvailable: entersReaderIfAvailable), displayControllerFrom: from, sender: sender)
         super.init()
         addCondition(MutuallyExclusive<UIViewController>())
     }

--- a/Tests/Features/WebpageOperationTests.swift
+++ b/Tests/Features/WebpageOperationTests.swift
@@ -44,11 +44,11 @@ class WebpageOperationTests: OperationTests {
                     delegate.safariViewControllerDidFinish?(safariViewController)
                 }
                 else {
-                    XCTFail("Delete not set on the SFSafariViewController.")
+                    XCTFail("Delegate not set on the SFSafariViewController.")
                 }
             }
             else {
-                XCTFail("Did not receive a UIAlertController.")
+                XCTFail("Did not receive a SFSafariViewController.")
             }
         }
 


### PR DESCRIPTION
I notices that WebpageOperation has an retain cycle in its current implementation.

I changed it to be a GroupOperation, because it actually is even if it only has one UIOperation.
Added a WillExecuteObsersever to setup the delegate property of SFSafariViewController.