### PR TITLE
Error when removing condition dependencies

### DIFF
--- a/Sources/Core/Shared/Condition.swift
+++ b/Sources/Core/Shared/Condition.swift
@@ -179,6 +179,11 @@ public class ComposedCondition<C: Condition>: Condition, AutomaticInjectionOpera
         }
         completion(result)
     }
+
+    override func removeDirectDependency(directDependency: NSOperation) {
+        condition.removeDirectDependency(directDependency)
+        super.removeDirectDependency(directDependency)
+    }
 }
 
 internal class WrappedOperationCondition: Condition {


### PR DESCRIPTION
Since refactoring `OperationCondition` into `Condition` which is an `Operation` subclass, there is now an issue where any condition dependencies are executed immediately (well upon adding to the queue), which is not the desired behaviour.