### PR TITLE
CLLocationManager runloop issues

### DIFF
--- a/Operations.xcodeproj/project.pbxproj
+++ b/Operations.xcodeproj/project.pbxproj
@@ -266,6 +266,10 @@
 		659A55101CD328CC00D9D311 /* CloudKitInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = 659A54EC1CD3285000D9D311 /* CloudKitInterface.swift */; };
 		659A55111CD328CC00D9D311 /* CloudKitOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 659A54ED1CD3285000D9D311 /* CloudKitOperation.swift */; };
 		659A55121CD328CC00D9D311 /* CloudKitOperationExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 659A54EE1CD3285000D9D311 /* CloudKitOperationExtensions.swift */; };
+		65A592991D1C28E5001F9229 /* Queue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65A592981D1C28E5001F9229 /* Queue.swift */; };
+		65A5929A1D1C28E5001F9229 /* Queue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65A592981D1C28E5001F9229 /* Queue.swift */; };
+		65A5929B1D1C28E5001F9229 /* Queue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65A592981D1C28E5001F9229 /* Queue.swift */; };
+		65A5929C1D1C28E5001F9229 /* Queue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65A592981D1C28E5001F9229 /* Queue.swift */; };
 		65AE14971C34865E00F592D2 /* RetryOperationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65AE14961C34865E00F592D2 /* RetryOperationTests.swift */; };
 		65AE14981C34865E00F592D2 /* RetryOperationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65AE14961C34865E00F592D2 /* RetryOperationTests.swift */; };
 		65AE14991C34865E00F592D2 /* RetryOperationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65AE14961C34865E00F592D2 /* RetryOperationTests.swift */; };
@@ -447,6 +451,7 @@
 		659A54EC1CD3285000D9D311 /* CloudKitInterface.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CloudKitInterface.swift; sourceTree = "<group>"; };
 		659A54ED1CD3285000D9D311 /* CloudKitOperation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CloudKitOperation.swift; sourceTree = "<group>"; };
 		659A54EE1CD3285000D9D311 /* CloudKitOperationExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CloudKitOperationExtensions.swift; sourceTree = "<group>"; };
+		65A592981D1C28E5001F9229 /* Queue.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Queue.swift; sourceTree = "<group>"; };
 		65A6BA7B1C220F09003A375D /* HealthCapability.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HealthCapability.swift; sourceTree = "<group>"; };
 		65A6BA7E1C220FBD003A375D /* HealthCapabilityTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HealthCapabilityTests.swift; sourceTree = "<group>"; };
 		65AE14961C34865E00F592D2 /* RetryOperationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RetryOperationTests.swift; sourceTree = "<group>"; };
@@ -592,6 +597,7 @@
 				652616DD1C11F5EB00654091 /* OperationObserver.swift */,
 				652616DE1C11F5EB00654091 /* OperationQueue.swift */,
 				6565FFE41C98B7AC008B5248 /* Profiler.swift */,
+				65A592981D1C28E5001F9229 /* Queue.swift */,
 				650852301C8B23580058F8AA /* Repeatable.swift */,
 				65E4CDE11C33427500B9F9D8 /* RepeatedOperation.swift */,
 				658158441C20DBAD0086FB2A /* ResultInjection.swift */,
@@ -1287,6 +1293,7 @@
 				652618D21C11F93D00654091 /* UIOperation.swift in Sources */,
 				6526185F1C11F8FC00654091 /* BlockCondition.swift in Sources */,
 				652618F31C11F9AA00654091 /* RemoteNotificationCondition.swift in Sources */,
+				65A592991D1C28E5001F9229 /* Queue.swift in Sources */,
 				652618671C11F8FC00654091 /* Logging.swift in Sources */,
 				652618601C11F8FC00654091 /* BlockObserver.swift in Sources */,
 				652618F41C11F9AA00654091 /* UserConfirmationCondition.swift in Sources */,
@@ -1387,6 +1394,7 @@
 				652618741C11F8FD00654091 /* BlockObserver.swift in Sources */,
 				65BB56D81C70F29500DF5211 /* ThreadSafety.swift in Sources */,
 				652618811C11F8FD00654091 /* OperationCondition.swift in Sources */,
+				65A5929A1D1C28E5001F9229 /* Queue.swift in Sources */,
 				650852371C8B23950058F8AA /* Generators.swift in Sources */,
 				6565FFE61C98B7AC008B5248 /* Profiler.swift in Sources */,
 			);
@@ -1421,6 +1429,7 @@
 				659A550C1CD328CB00D9D311 /* CloudKitOperation.swift in Sources */,
 				658158471C20DBAD0086FB2A /* ResultInjection.swift in Sources */,
 				6526188D1C11F8FE00654091 /* GatedOperation.swift in Sources */,
+				65A5929B1D1C28E5001F9229 /* Queue.swift in Sources */,
 				6526188C1C11F8FE00654091 /* ExclusivityManager.swift in Sources */,
 				652618911C11F8FE00654091 /* MutuallyExclusive.swift in Sources */,
 				652618901C11F8FE00654091 /* LoggingObserver.swift in Sources */,
@@ -1489,6 +1498,7 @@
 				652618AC1C11F8FF00654091 /* SlientCondition.swift in Sources */,
 				652618AB1C11F8FF00654091 /* OperationQueue.swift in Sources */,
 				652618A61C11F8FF00654091 /* NegatedCondition.swift in Sources */,
+				65A5929C1D1C28E5001F9229 /* Queue.swift in Sources */,
 				652618A81C11F8FF00654091 /* Operation.swift in Sources */,
 				652618AD1C11F8FF00654091 /* Support.swift in Sources */,
 				652618CD1C11F91500654091 /* ReachabilityCondition.swift in Sources */,

--- a/Operations_ExtensionCompatible.xcodeproj/project.pbxproj
+++ b/Operations_ExtensionCompatible.xcodeproj/project.pbxproj
@@ -229,6 +229,9 @@
 		659A55061CD328BB00D9D311 /* CloudKitInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = 659A54F71CD328A700D9D311 /* CloudKitInterface.swift */; };
 		659A55071CD328BB00D9D311 /* CloudKitOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 659A54F81CD328A700D9D311 /* CloudKitOperation.swift */; };
 		659A55081CD328BB00D9D311 /* CloudKitOperationExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 659A54F91CD328A700D9D311 /* CloudKitOperationExtensions.swift */; };
+		65A5929E1D1C2DF6001F9229 /* Queue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65A5929D1D1C2DF6001F9229 /* Queue.swift */; };
+		65A5929F1D1C2DF6001F9229 /* Queue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65A5929D1D1C2DF6001F9229 /* Queue.swift */; };
+		65A592A01D1C2DF6001F9229 /* Queue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65A5929D1D1C2DF6001F9229 /* Queue.swift */; };
 		65A74FC11CC59488008D7193 /* Condition.swift in Sources */ = {isa = PBXBuildFile; fileRef = 653097A91CC4BFB200EC1431 /* Condition.swift */; };
 		65A74FC21CC59488008D7193 /* Condition.swift in Sources */ = {isa = PBXBuildFile; fileRef = 653097A91CC4BFB200EC1431 /* Condition.swift */; };
 		65B9E07D1CB85941009161AD /* URLSessionTaskOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65B9E07C1CB85941009161AD /* URLSessionTaskOperation.swift */; };
@@ -377,6 +380,7 @@
 		659A54F71CD328A700D9D311 /* CloudKitInterface.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CloudKitInterface.swift; sourceTree = "<group>"; };
 		659A54F81CD328A700D9D311 /* CloudKitOperation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CloudKitOperation.swift; sourceTree = "<group>"; };
 		659A54F91CD328A700D9D311 /* CloudKitOperationExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CloudKitOperationExtensions.swift; sourceTree = "<group>"; };
+		65A5929D1D1C2DF6001F9229 /* Queue.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Queue.swift; sourceTree = "<group>"; };
 		65B9E07C1CB85941009161AD /* URLSessionTaskOperation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = URLSessionTaskOperation.swift; sourceTree = "<group>"; };
 		65B9E0841CB85F4E009161AD /* URLSessionTaskOperationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = URLSessionTaskOperationTests.swift; sourceTree = "<group>"; };
 		65BB56DB1C70FAB100DF5211 /* ThreadSafety.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ThreadSafety.swift; sourceTree = "<group>"; };
@@ -503,6 +507,7 @@
 				652617491C11F61700654091 /* OperationObserver.swift */,
 				6526174A1C11F61700654091 /* OperationQueue.swift */,
 				653D402A1CC26F3600893746 /* Profiler.swift */,
+				65A5929D1D1C2DF6001F9229 /* Queue.swift */,
 				65356EB01C8B3B2C0029E8AF /* Repeatable.swift */,
 				6584D2351C6BF86200306EED /* RepeatedOperation.swift */,
 				6584D2361C6BF86200306EED /* ResultInjection.swift */,
@@ -1022,6 +1027,7 @@
 				6526198A1C11FF5200654091 /* NoFailedDependenciesCondition.swift in Sources */,
 				652619CC1C12003F00654091 /* Reachability.swift in Sources */,
 				65BB56DC1C70FAB100DF5211 /* ThreadSafety.swift in Sources */,
+				65A5929E1D1C2DF6001F9229 /* Queue.swift in Sources */,
 				659A54FA1CD328A700D9D311 /* CloudCapability.swift in Sources */,
 				659A54FE1CD328A700D9D311 /* CloudKitOperationExtensions.swift in Sources */,
 				652619841C11FF5200654091 /* GatedOperation.swift in Sources */,
@@ -1126,6 +1132,7 @@
 				65BB56DD1C70FAB700DF5211 /* ThreadSafety.swift in Sources */,
 				652619DA1C12010300654091 /* UIOperation.swift in Sources */,
 				652619DB1C12012C00654091 /* Capability.swift in Sources */,
+				65A5929F1D1C2DF6001F9229 /* Queue.swift in Sources */,
 				652619971C11FF5200654091 /* ExclusivityManager.swift in Sources */,
 				65356EB81C8B3B910029E8AF /* Repeatable.swift in Sources */,
 				6526199C1C11FF5200654091 /* MutuallyExclusive.swift in Sources */,
@@ -1185,6 +1192,7 @@
 				652619B71C11FF5300654091 /* SlientCondition.swift in Sources */,
 				652619B61C11FF5300654091 /* OperationQueue.swift in Sources */,
 				652619B11C11FF5300654091 /* NegatedCondition.swift in Sources */,
+				65A592A01D1C2DF6001F9229 /* Queue.swift in Sources */,
 				652619B31C11FF5300654091 /* Operation.swift in Sources */,
 				652619B81C11FF5300654091 /* Support.swift in Sources */,
 				652619E91C1201AF00654091 /* ReachabilityCondition.swift in Sources */,

--- a/Sources/Core/Shared/Queue.swift
+++ b/Sources/Core/Shared/Queue.swift
@@ -1,0 +1,121 @@
+//
+//  Queue.swift
+//  Operations
+//
+//  Created by Daniel Thorpe on 23/06/2016.
+//
+//
+
+import Foundation
+
+// MARK: - Queues
+
+/**
+ A nice Swift wrapper around `dispatch_queue_create`. The cases
+ correspond to GCD's quality of service classes. To get the
+ main queue use like this:
+
+ dispatch_async(Queue.Main.queue) {
+ print("I'm on the main queue!")
+ }
+ */
+public enum Queue {
+
+    internal final class Scheduler {
+
+        private var once: dispatch_once_t = 0
+        private var key: UInt8 = 0
+        private var context: UInt8 = 0
+
+        init(queue: dispatch_queue_t) {
+            dispatch_once(&once) {
+                dispatch_queue_set_specific(queue, &self.key, &self.context, nil)
+            }
+        }
+
+        var isScheduleQueue: Bool {
+            return dispatch_get_specific(&self.key) == &self.context
+        }
+    }
+
+    /// returns: a Bool to indicate if the current queue is the main queue
+    public static var isMainQueue: Bool {
+        return mainQueueScheduler.isScheduleQueue
+    }
+
+    /// The main queue
+    case Main
+
+    /// The default QOS
+    case Default
+
+    /// Use for user initiated tasks which do not impact the UI. Such as data processing.
+    case Initiated
+
+    /// Use for user initiated tasks which do impact the UI - e.g. a rendering pipeline.
+    case Interactive
+
+    /// Use for non-user initiated task.
+    case Utility
+
+    /// Backgound QOS is a severly limited class, should not be used for anything when the app is active.
+    case Background
+
+    // swiftlint:disable variable_name
+    private var qos_class: qos_class_t {
+        switch self {
+        case .Main: return qos_class_main()
+        case .Default: return QOS_CLASS_DEFAULT
+        case .Initiated: return QOS_CLASS_USER_INITIATED
+        case .Interactive: return QOS_CLASS_USER_INTERACTIVE
+        case .Utility: return QOS_CLASS_UTILITY
+        case .Background: return QOS_CLASS_BACKGROUND
+        }
+    }
+    // swiftlint:enable variable_name
+
+    /**
+     Access the appropriate global `dispatch_queue_t`. For `.Main` this
+     is the main queue, for other cases, it is the global queue for the
+     appropriate `qos_class_t`.
+
+     - parameter queue: the corresponding global dispatch_queue_t
+     */
+    public var queue: dispatch_queue_t {
+        switch self {
+        case .Main: return dispatch_get_main_queue()
+        default: return dispatch_get_global_queue(qos_class, 0)
+        }
+    }
+
+    /**
+     Creates a named serial queue with the correct QOS class.
+
+     Use like this:
+
+     let queue = Queue.Utility.serial("me.danthorpe.Operation.eg")
+     dispatch_async(queue) {
+     print("I'm on a utility serial queue.")
+     }
+     */
+    public func serial(named: String) -> dispatch_queue_t {
+        return dispatch_queue_create(named, dispatch_queue_attr_make_with_qos_class(DISPATCH_QUEUE_SERIAL, qos_class, QOS_MIN_RELATIVE_PRIORITY))
+    }
+
+    /**
+     Creates a named concurrent queue with the correct QOS class.
+
+     Use like this:
+
+     let queue = Queue.Initiated.concurrent("me.danthorpe.Operation.eg")
+     dispatch_barrier_async(queue) {
+     print("I'm on a initiated concurrent queue.")
+     }
+     */
+    public func concurrent(named: String) -> dispatch_queue_t {
+        return dispatch_queue_create(named, dispatch_queue_attr_make_with_qos_class(DISPATCH_QUEUE_CONCURRENT, qos_class, QOS_MIN_RELATIVE_PRIORITY))
+    }
+}
+
+internal let mainQueueScheduler = Queue.Scheduler(queue: Queue.Main.queue)
+

--- a/Sources/Core/Shared/Queue.swift
+++ b/Sources/Core/Shared/Queue.swift
@@ -118,4 +118,3 @@ public enum Queue {
 }
 
 internal let mainQueueScheduler = Queue.Scheduler(queue: Queue.Main.queue)
-

--- a/Sources/Core/Shared/Support.swift
+++ b/Sources/Core/Shared/Support.swift
@@ -1,99 +1,12 @@
 //
 //  Support.swift
-//  YapDB
+//  Operations
 //
 //  Created by Daniel Thorpe on 25/06/2015.
 //  Copyright (c) 2015 Daniel Thorpe. All rights reserved.
 //
 
 import Foundation
-
-// MARK: - Queues
-
-/**
-A nice Swift wrapper around `dispatch_queue_create`. The cases
-correspond to GCD's quality of service classes. To get the
-main queue use like this:
-
-    dispatch_async(Queue.Main.queue) {
-       print("I'm on the main queue!")
-    }
-*/
-public enum Queue {
-
-    /// The main queue
-    case Main
-
-    /// The default QOS
-    case Default
-
-    /// Use for user initiated tasks which do not impact the UI. Such as data processing.
-    case Initiated
-
-    /// Use for user initiated tasks which do impact the UI - e.g. a rendering pipeline.
-    case Interactive
-
-    /// Use for non-user initiated task.
-    case Utility
-
-    /// Backgound QOS is a severly limited class, should not be used for anything when the app is active.
-    case Background
-
-    // swiftlint:disable variable_name
-    private var qos_class: qos_class_t {
-        switch self {
-        case .Main: return qos_class_main()
-        case .Default: return QOS_CLASS_DEFAULT
-        case .Initiated: return QOS_CLASS_USER_INITIATED
-        case .Interactive: return QOS_CLASS_USER_INTERACTIVE
-        case .Utility: return QOS_CLASS_UTILITY
-        case .Background: return QOS_CLASS_BACKGROUND
-        }
-    }
-    // swiftlint:enable variable_name
-
-    /**
-    Access the appropriate global `dispatch_queue_t`. For `.Main` this
-    is the main queue, for other cases, it is the global queue for the
-    appropriate `qos_class_t`.
-
-    - parameter queue: the corresponding global dispatch_queue_t
-    */
-    public var queue: dispatch_queue_t {
-        switch self {
-        case .Main: return dispatch_get_main_queue()
-        default: return dispatch_get_global_queue(qos_class, 0)
-        }
-    }
-
-    /**
-    Creates a named serial queue with the correct QOS class.
-
-    Use like this:
-
-        let queue = Queue.Utility.serial("me.danthorpe.Operation.eg")
-            dispatch_async(queue) {
-            print("I'm on a utility serial queue.")
-        }
-    */
-    public func serial(named: String) -> dispatch_queue_t {
-        return dispatch_queue_create(named, dispatch_queue_attr_make_with_qos_class(DISPATCH_QUEUE_SERIAL, qos_class, QOS_MIN_RELATIVE_PRIORITY))
-    }
-
-    /**
-    Creates a named concurrent queue with the correct QOS class.
-
-    Use like this:
-
-        let queue = Queue.Initiated.concurrent("me.danthorpe.Operation.eg")
-        dispatch_barrier_async(queue) {
-            print("I'm on a initiated concurrent queue.")
-        }
-    */
-    public func concurrent(named: String) -> dispatch_queue_t {
-        return dispatch_queue_create(named, dispatch_queue_attr_make_with_qos_class(DISPATCH_QUEUE_CONCURRENT, qos_class, QOS_MIN_RELATIVE_PRIORITY))
-    }
-}
 
 extension Dictionary {
 

--- a/Sources/Core/Shared/ThreadSafety.swift
+++ b/Sources/Core/Shared/ThreadSafety.swift
@@ -105,3 +105,10 @@ public func dispatch_sync<T>(queue: dispatch_queue_t, _ block: () throws -> T) r
     }
     return result
 }
+
+internal func dispatch_main_sync<T>(block: () throws -> T) rethrows -> T {
+    guard NSThread.isMainThread() else {
+        return try dispatch_sync(Queue.Main.queue, block)
+    }
+    return try block()
+}

--- a/Sources/Core/Shared/ThreadSafety.swift
+++ b/Sources/Core/Shared/ThreadSafety.swift
@@ -107,7 +107,7 @@ public func dispatch_sync<T>(queue: dispatch_queue_t, _ block: () throws -> T) r
 }
 
 internal func dispatch_main_sync<T>(block: () throws -> T) rethrows -> T {
-    guard NSThread.isMainThread() else {
+    guard Queue.isMainQueue else {
         return try dispatch_sync(Queue.Main.queue, block)
     }
     return try block()

--- a/Sources/Features/iOS/LocationCapability.swift
+++ b/Sources/Features/iOS/LocationCapability.swift
@@ -128,9 +128,7 @@ public class LocationCapability: NSObject, CLLocationManagerDelegate, Capability
     /// - returns: the EKEntityType, the required type of the capability
     public let requirement: LocationUsage
 
-    internal lazy var registrar: LocationCapabilityRegistrarType = {
-        return dispatch_sync(Queue.Main.queue) { CLLocationManager() }
-    }()
+    internal lazy var registrar: LocationCapabilityRegistrarType = CLLocationManager.create()
 
     internal var authorizationCompletionBlock: dispatch_block_t? = .None
 

--- a/Sources/Features/iOS/LocationCapability.swift
+++ b/Sources/Features/iOS/LocationCapability.swift
@@ -164,19 +164,19 @@ public class LocationCapability: NSObject, CLLocationManagerDelegate, Capability
      - parameter completion: a dispatch_block_t
      */
     public func requestAuthorizationWithCompletion(completion: dispatch_block_t) {
-        if !registrar.opr_locationServicesEnabled() {
+        guard isAvailable() else {
             completion()
+            return
         }
-        else {
-            let status = registrar.opr_authorizationStatus()
-            switch (status, requirement) {
-            case (.NotDetermined, _), (.AuthorizedWhenInUse, .Always):
-                authorizationCompletionBlock = completion
-                registrar.opr_setDelegate(self)
-                registrar.opr_requestAuthorizationWithRequirement(requirement)
-            default:
-                completion()
-            }
+
+        let status = registrar.opr_authorizationStatus()
+        switch (status, requirement) {
+        case (.NotDetermined, _), (.AuthorizedWhenInUse, .Always):
+            authorizationCompletionBlock = completion
+            registrar.opr_setDelegate(self)
+            registrar.opr_requestAuthorizationWithRequirement(requirement)
+        default:
+            completion()
         }
     }
 

--- a/Sources/Features/iOS/LocationCapability.swift
+++ b/Sources/Features/iOS/LocationCapability.swift
@@ -128,8 +128,11 @@ public class LocationCapability: NSObject, CLLocationManagerDelegate, Capability
     /// - returns: the EKEntityType, the required type of the capability
     public let requirement: LocationUsage
 
-    var registrar: LocationCapabilityRegistrarType = CLLocationManager()
-    var authorizationCompletionBlock: dispatch_block_t?
+    internal lazy var registrar: LocationCapabilityRegistrarType = {
+        return dispatch_sync(Queue.Main.queue) { CLLocationManager() }
+    }()
+
+    internal var authorizationCompletionBlock: dispatch_block_t? = .None
 
     /**
      Initialize the capability. By default, it requires access .WhenInUse.

--- a/Sources/Features/iOS/LocationOperations.swift
+++ b/Sources/Features/iOS/LocationOperations.swift
@@ -273,15 +273,17 @@ public class ReverseGeocodeUserLocationOperation: GroupOperation, ResultOperatio
         addCondition(MutuallyExclusive<ReverseGeocodeUserLocationOperation>())
     }
 
-    public override func willFinishOperation(operation: NSOperation, withErrors errors: [ErrorType]) {
-        guard let location = location where errors.isEmpty && userLocationOperation == operation && !operation.cancelled else { return }
+    public override func willFinishOperation(operation: NSOperation) {
+        guard userLocationOperation == operation && !operation.cancelled, let location = location else { return }
 
         let reverseOp = ReverseGeocodeOperation(location: location) { [unowned self] placemark in
             self.completion(location, placemark)
         }
+
         if let geocoder = geocoder {
             reverseOp.geocoder = geocoder
         }
+
         addOperation(reverseOp)
         reverseGeocodeOperation = reverseOp
     }

--- a/Sources/Features/iOS/LocationOperations.swift
+++ b/Sources/Features/iOS/LocationOperations.swift
@@ -9,39 +9,7 @@
 import Foundation
 import CoreLocation
 
-
 // MARK: Consumer Interfaces -
-
-// MARK: UserLocationOperation
-
-/**
-Access the device's current location. It will ask for
-permission if required.
-
-- parameter accuracy: the location accuracy which defaults to 3km.
-- parameter completion: a closure CLLocation -> Void.
-*/
-public typealias UserLocationOperation = _UserLocationOperation<CLLocationManager>
-
-// MARK: ReverseGeocodeOperation
-
-/**
-Reverse geocode a given CLLocation.
-
-- parameter location: the location to reverse lookup.
-- parameter completion: a completion block of CompletionBlockType
-*/
-public typealias ReverseGeocodeOperation = _ReverseGeocodeOperation<CLGeocoder>
-
-// MARK: ReverseGeocodeUserLocationOperation
-
-/**
-Reverse geocode the device's current location.
-
-- parameter accuracy: the location accuracy.
-- parameter completion: a completion block of CompletionBlockType
-*/
-public typealias ReverseGeocodeUserLocationOperation = _ReverseGeocodeUserLocationOperation<CLGeocoder, CLLocationManager>
 
 @available(*, unavailable, renamed="UserLocationOperation")
 public typealias LocationOperation = UserLocationOperation
@@ -74,12 +42,17 @@ public enum LocationOperationError: ErrorType, Equatable {
     case GeocoderError(NSError)
 }
 
-public class _UserLocationOperation<Manager: LocationManagerType>: Operation, CLLocationManagerDelegate, ResultOperationType {
+// MARK: - UserLocationOperation
+
+public class UserLocationOperation: Operation, CLLocationManagerDelegate, ResultOperationType {
     public typealias CompletionBlockType = CLLocation -> Void
 
-    private let manager: Manager
     private let accuracy: CLLocationAccuracy
     private let completion: CompletionBlockType
+
+    internal lazy var manager: LocationManagerType = {
+        return dispatch_sync(Queue.Main.queue) { CLLocationManager() }
+    }()
 
     /// - returns: the CLLocation if available
     public private(set) var location: CLLocation? = .None
@@ -90,30 +63,13 @@ public class _UserLocationOperation<Manager: LocationManagerType>: Operation, CL
     }
 
     /**
-     Initialize an operation which will use a custom location manager to
-     determine the user's current location to the desired accuracy. It will ask for
-     permission if required.
-
-     Framework consumers should use: UserLocationOperation
+     Initialize an operation which will determine the user's current location
+     to the desired accuracy. It will ask for permission if required.
 
      - parameter accuracy: the location accuracy which defaults to 3km.
      - parameter completion: a closure CLLocation -> Void.
     */
-    public convenience init(accuracy: CLLocationAccuracy = kCLLocationAccuracyThreeKilometers, completion: CompletionBlockType = { _ in }) {
-        self.init(manager: Manager(), accuracy: accuracy, completion: completion)
-    }
-
-    /**
-    Initialize an operation which will use a custom location manager to
-    determine the user's current location to the desired accuracy. It will ask for
-    permission if required.
-
-     - parameter manager: instance of a type which implements LocationManagerType.
-     - parameter accuracy: the location accuracy which defaults to 3km.
-     - parameter completion: a closure CLLocation -> Void.
-    */
-    public init(manager: Manager, accuracy: CLLocationAccuracy, completion: CompletionBlockType) {
-        self.manager = manager
+    public init(accuracy: CLLocationAccuracy = kCLLocationAccuracyThreeKilometers, completion: CompletionBlockType = { _ in }) {
         self.accuracy = accuracy
         self.completion = completion
         super.init()
@@ -173,8 +129,9 @@ public class _UserLocationOperation<Manager: LocationManagerType>: Operation, CL
     }
 }
 
+// MARK: - ReverseGeocodeOperation
+
 public protocol ReverseGeocoderType {
-    init()
     func opr_cancel()
     func opr_reverseGeocodeLocation(location: CLLocation, completion: ([CLPlacemark], NSError?) -> Void)
 }
@@ -192,12 +149,16 @@ extension CLGeocoder: ReverseGeocoderType {
     }
 }
 
-public class _ReverseGeocodeOperation<Geocoder: ReverseGeocoderType>: Operation, ResultOperationType {
+public class ReverseGeocodeOperation: Operation, ResultOperationType {
+
     public typealias CompletionBlockType = CLPlacemark -> Void
 
     public let location: CLLocation
 
-    private let geocoder: Geocoder
+    internal lazy var geocoder: ReverseGeocoderType = {
+        return dispatch_sync(Queue.Main.queue) { CLGeocoder() }
+    }()
+
     private let completion: CompletionBlockType
 
     /// - returns: the CLPlacemark from the geocoder
@@ -212,26 +173,11 @@ public class _ReverseGeocodeOperation<Geocoder: ReverseGeocoderType>: Operation,
     Initialize an operation which will use a custom geocoder to
     reverse lookup the given location.
 
-    Framework consumers see: ReverseGeocodeOperation
-
     - parameter location: the location to reverse lookup.
     - parameter completion: a completion block of CompletionBlockType
     */
-    public convenience init(location: CLLocation, completion: CompletionBlockType = { _ in }) {
-        self.init(geocoder: Geocoder(), location: location, completion: completion)
-    }
-
-    /**
-    Initialize an operation which will use a custom geocoder to
-    reverse lookup the given location.
-
-    - parameter geocoder: instance of a type which implements ReverseGeocoderType.
-    - parameter location: the location to reverse lookup.
-    - parameter completion: a completion block of CompletionBlockType
-    */
-    public init(geocoder: Geocoder, location: CLLocation, completion: CompletionBlockType) {
+    public init(location: CLLocation, completion: CompletionBlockType = { _ in }) {
         self.location = location
-        self.geocoder = geocoder
         self.completion = completion
         super.init()
         name = "Reverse Geocode"
@@ -267,13 +213,16 @@ public class _ReverseGeocodeOperation<Geocoder: ReverseGeocoderType>: Operation,
     }
 }
 
-public class _ReverseGeocodeUserLocationOperation<Geocoder, Manager where Geocoder: ReverseGeocoderType, Manager: LocationManagerType>: GroupOperation, ResultOperationType {
+// MARK: - ReverseGeocodeUserLocationOperation
+
+public class ReverseGeocodeUserLocationOperation: GroupOperation, ResultOperationType {
     public typealias CompletionBlockType = (CLLocation, CLPlacemark) -> Void
 
-    private let geocoder: Geocoder
     private let completion: CompletionBlockType
-    private let userLocationOperation: _UserLocationOperation<Manager>
-    private var reverseGeocodeOperation: _ReverseGeocodeOperation<Geocoder>?
+
+    internal let userLocationOperation: UserLocationOperation
+    internal var reverseGeocodeOperation: ReverseGeocodeOperation?
+    internal lazy var geocoder: ReverseGeocoderType? = .None
 
     /// - returns: the CLLocation if available
     public var location: CLLocation? {
@@ -295,28 +244,12 @@ public class _ReverseGeocodeUserLocationOperation<Geocoder, Manager where Geocod
     Initialize a group operation which will use a custom geocoder to
     reverse lookup the device location (using a custom location manager).
 
-    Framework consumers see: ReverseGeocodeUserLocationOperation
-
     - parameter accuracy: the location accuracy.
     - parameter completion: a completion block of CompletionBlockType
     */
-    public convenience init(accuracy: CLLocationAccuracy = kCLLocationAccuracyThreeKilometers, completion: CompletionBlockType = { _, _ in }) {
-        self.init(geocoder: Geocoder(), manager: Manager(), accuracy: accuracy, completion: completion)
-    }
-
-    /**
-    Initialize a group operation which will use a custom geocoder to
-    reverse lookup the device location (using a custom location manager).
-
-    - parameter geocoder: instance of a type which implements ReverseGeocoderType.
-    - parameter manager: instance of a type which implements LocationManagerType.
-    - parameter accuracy: the location accuracy.
-    - parameter completion: a completion block of CompletionBlockType
-    */
-    public init(geocoder: Geocoder, manager: Manager, accuracy: CLLocationAccuracy, completion: CompletionBlockType) {
-        self.geocoder = geocoder
+    public init(accuracy: CLLocationAccuracy = kCLLocationAccuracyThreeKilometers, completion: CompletionBlockType = { _, _ in }) {
         self.completion = completion
-        self.userLocationOperation = _UserLocationOperation(manager: manager, accuracy: accuracy, completion: { _ in })
+        self.userLocationOperation = UserLocationOperation(accuracy: accuracy, completion: { _ in })
         super.init(operations: [ userLocationOperation ])
         name = "Reverse Geocode User Location"
         addCondition(MutuallyExclusive<ReverseGeocodeUserLocationOperation>())
@@ -325,8 +258,11 @@ public class _ReverseGeocodeUserLocationOperation<Geocoder, Manager where Geocod
     public override func willFinishOperation(operation: NSOperation, withErrors errors: [ErrorType]) {
         if errors.isEmpty && userLocationOperation == operation && !operation.cancelled {
             if let location = location {
-                let reverseOp = _ReverseGeocodeOperation(geocoder: geocoder, location: location) { [unowned self] placemark in
+                let reverseOp = ReverseGeocodeOperation(location: location) { [unowned self] placemark in
                     self.completion(location, placemark)
+                }
+                if let geocoder = geocoder {
+                    reverseOp.geocoder = geocoder
                 }
                 addOperation(reverseOp)
                 reverseGeocodeOperation = reverseOp

--- a/Tests/Features/LocationOperationsTests.swift
+++ b/Tests/Features/LocationOperationsTests.swift
@@ -122,13 +122,14 @@ class LocationOperationErrorTests: XCTestCase {
 class UserLocationOperationTests: LocationOperationTests {
 
     func test__operation_name() {
-        let operation = _UserLocationOperation(manager: locationManager, accuracy: accuracy, completion: { _ in })
+        let operation = UserLocationOperation(accuracy: accuracy)
+        operation.manager = locationManager
         XCTAssertEqual(operation.name!, "User Location")
     }
 
     func test__location_operation_received_location_is_set() {
-
-        let operation = _UserLocationOperation(manager: locationManager, accuracy: accuracy, completion: { _ in })
+        let operation = UserLocationOperation(accuracy: accuracy)
+        operation.manager = locationManager
 
         addCompletionBlockToTestOperation(operation, withExpectation: expectationWithDescription("Test: \(#function)"))
         runOperation(operation)
@@ -151,9 +152,10 @@ class UserLocationOperationTests: LocationOperationTests {
 
         var receivedLocation: CLLocation? = .None
 
-        let operation = _UserLocationOperation(manager: locationManager, accuracy: accuracy) { location in
+        let operation = UserLocationOperation(accuracy: accuracy) { location in
             receivedLocation = location
         }
+        operation.manager = locationManager
 
         addCompletionBlockToTestOperation(operation, withExpectation: expectationWithDescription("Test: \(#function)"))
         runOperation(operation)
@@ -168,7 +170,8 @@ class UserLocationOperationTests: LocationOperationTests {
     }
 
     func test__location_updates_stopped_when_operation_is_cancelled() {
-        let operation = _UserLocationOperation(manager: locationManager, accuracy: accuracy, completion: { _ in })
+        let operation = UserLocationOperation(accuracy: accuracy)
+        operation.manager = locationManager
         operation.stopLocationUpdates()
         XCTAssertTrue(locationManager.didStopLocationUpdates)
     }
@@ -176,7 +179,8 @@ class UserLocationOperationTests: LocationOperationTests {
     func test__given_location_manager_fails_operation_fails() {
         locationManager.returnedError = NSError(domain: kCLErrorDomain, code: CLError.LocationUnknown.rawValue, userInfo: nil)
 
-        let operation = _UserLocationOperation(manager: locationManager, accuracy: accuracy, completion: { _ in })
+        let operation = UserLocationOperation(accuracy: accuracy)
+        operation.manager = locationManager
 
         var receivedErrors = [ErrorType]()
         operation.addObserver(DidFinishObserver { _, errors in
@@ -240,12 +244,14 @@ class ReverseGeocodeOperationTests: LocationOperationTests {
     }
 
     func test__name_is_correct() {
-        let operation = _ReverseGeocodeOperation(geocoder: geocoder, location: location, completion: { _ in })
+        let operation = ReverseGeocodeOperation(location: location)
+        operation.geocoder = geocoder
         XCTAssertEqual(operation.name, "Reverse Geocode")
     }
 
     func test__reverse_geocode_starts_geocoder() {
-        let operation = _ReverseGeocodeOperation(geocoder: geocoder, location: location, completion: { _ in })
+        let operation = ReverseGeocodeOperation(location: location, completion: { _ in })
+        operation.geocoder = geocoder
 
         addCompletionBlockToTestOperation(operation, withExpectation: expectationWithDescription("Test: \(#function)"))
         runOperation(operation)
@@ -259,7 +265,8 @@ class ReverseGeocodeOperationTests: LocationOperationTests {
         geocoder.placemark = .None
         geocoder.error = NSError(domain: kCLErrorDomain, code: CLError.GeocodeFoundNoResult.rawValue, userInfo: nil)
 
-        let operation = _ReverseGeocodeOperation(geocoder: geocoder, location: location, completion: { _ in })
+        let operation = ReverseGeocodeOperation(location: location)
+        operation.geocoder = geocoder
 
         var receivedErrors = [ErrorType]()
         operation.addObserver(DidFinishObserver { _, errors in
@@ -287,7 +294,8 @@ class ReverseGeocodeOperationTests: LocationOperationTests {
 
     func test__reverse_geocode_cancels_when_operation_cancels() {
 
-        let operation = _ReverseGeocodeOperation(geocoder: geocoder, location: location, completion: { _ in })
+        let operation = ReverseGeocodeOperation(location: location)
+        operation.geocoder = geocoder
 
         operation.addObserver(WillExecuteObserver { op in
             op.cancel()
@@ -303,10 +311,11 @@ class ReverseGeocodeOperationTests: LocationOperationTests {
 
     func test__completion_handler_receives_placeholder() {
         var completionBlockDidExecute = false
-        let operation = _ReverseGeocodeOperation(geocoder: geocoder, location: location) { placemark in
+        let operation = ReverseGeocodeOperation(location: location) { placemark in
             completionBlockDidExecute = true
             XCTAssertEqual(self.placemark, placemark)
         }
+        operation.geocoder = geocoder
 
         addCompletionBlockToTestOperation(operation, withExpectation: expectationWithDescription("Test: \(#function)"))
         runOperation(operation)
@@ -327,7 +336,9 @@ class ReverseGeocodeUserLocationOperationTests: ReverseGeocodeOperationTests {
 
     func test__reverse_geocode_user_location_starts_geocoder() {
 
-        let operation = _ReverseGeocodeUserLocationOperation(geocoder: geocoder, manager: locationManager, accuracy: accuracy, completion: { _, _ in })
+        let operation = ReverseGeocodeUserLocationOperation(accuracy: accuracy)
+        operation.userLocationOperation.manager = locationManager
+        operation.geocoder = geocoder
 
         addCompletionBlockToTestOperation(operation, withExpectation: expectationWithDescription("Test: \(#function)"))
         runOperation(operation)
@@ -349,10 +360,12 @@ class ReverseGeocodeUserLocationOperationTests: ReverseGeocodeOperationTests {
         var blockLocation: CLLocation? = .None
         var blockPlacemark: CLPlacemark? = .None
 
-        let operation = _ReverseGeocodeUserLocationOperation(geocoder: geocoder, manager: locationManager, accuracy: accuracy) { location, placemark in
+        let operation = ReverseGeocodeUserLocationOperation(accuracy: accuracy) { location, placemark in
             blockLocation = location
             blockPlacemark = placemark
         }
+        operation.userLocationOperation.manager = locationManager
+        operation.geocoder = geocoder
 
         addCompletionBlockToTestOperation(operation, withExpectation: expectation)
         runOperation(operation)


### PR DESCRIPTION
Me again with another CLLocationManager bug/issue/headache.

I am triggering a LocationCapability authorization from within a group operation like this:

```
let op = Authorize.init(Capability.Location(.WhenInUse), completion: weakSelf.cb)
weakSelf.addOperations(op)
```

This is basically taken from your Examples repo project. The issue I run into is that this correctly _asks_ for permissions, but the Capability delegate never gets the callback. I've tracked it down to being an issue with the thread the manager is created on, and the fact that it doesn't have a runloop. I came to this conclusion after reading [this helpful answer](http://stackoverflow.com/a/19041925/1273175) and then verifying [in the documentation](https://developer.apple.com/library/ios/documentation/CoreLocation/Reference/CLLocationManagerDelegate_Protocol/index.html).

The interesting bit is this

> The methods of your delegate object are called from the thread in which you started the corresponding location services. That thread must itself have an active run loop, like the one found in your application’s main thread.

Is this something you are aware of/familiar with working around from an `NSOperationQueue`? If so, what is the suggested approach? I've simply done the following hack:

```
weakSelf.queue.suspended = true
NSOperationQueue.mainQueue().addOperationWithBlock({ 
  let op = Authorize.init(Capability.Location(.WhenInUse), completion: weakSelf.cb)
  weakSelf.addOperations(op)
  weakSelf.queue.suspended = false
})
```

The `suspended` nonsense is to make sure the `GroupOperation` stays around until I am done dispatching the block. It just feels like the wrong answer, and I would rather the `LocationCapability` be smart enough to handle this on it's own by ensuring the `CLLocationManager` is configured on a thread which complies with the documentation.

Thanks for any suggestions you might have, or any insight into how I might be doing things wrong!

