### PR TITLE
Expose LogSeverity enum to objective-c

### DIFF
--- a/Sources/Core/Shared/Logging.swift
+++ b/Sources/Core/Shared/Logging.swift
@@ -21,7 +21,7 @@ import Foundation
  is greater than the minimum severity the message string will
  be sent to the logger's block.
 */
-public enum LogSeverity: Int, Comparable {
+@objc public enum LogSeverity: Int, Comparable {
 
     /// Chatty
     case Verbose = 0


### PR DESCRIPTION
This allows me to pass around logging levels within a project that is mainly Objective-C.