### PR TITLE
Remove Reachability from CloudKitOperation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,4 @@ docs
 # Swift Package Manager
 /.build
 /Packages
+.DS_Store

--- a/Sources/Core/Shared/TimeoutObserver.swift
+++ b/Sources/Core/Shared/TimeoutObserver.swift
@@ -14,7 +14,7 @@ if it doesn't finish before a time interval is expired.
 */
 public struct TimeoutObserver: OperationWillExecuteObserver {
 
-    private let timeout: NSTimeInterval
+    internal let timeout: NSTimeInterval
 
     /**
     Initialize the operation observer with a timeout, which will start when

--- a/Sources/Features/Shared/CloudKit/CloudKitOperation.swift
+++ b/Sources/Features/Shared/CloudKit/CloudKitOperation.swift
@@ -11,12 +11,13 @@ import CloudKit
 
 // MARK: - OPRCKOperation
 
-public class OPRCKOperation<T where T: NSOperation, T: CKOperationType>: ReachableOperation<T> {
+public class OPRCKOperation<T where T: NSOperation, T: CKOperationType>: ComposedOperation<T> {
 
-    override init(_ operation: T, connectivity: Reachability.Connectivity = .AnyConnectionKind) {
-        super.init(operation, connectivity: connectivity)
+    override init(operation composed: T) {
+        super.init(operation: composed)
         name = "OPRCKOperation<\(T.self)>"
     }
+    
 }
 
 // MARK: - Cloud Kit Error Recovery
@@ -214,14 +215,10 @@ public final class CloudKitOperation<T where T: NSOperation, T: CKOperationType,
     }
 
     public convenience init(_ body: () -> T?) {
-        self.init(generator: AnyGenerator(body: body), connectivity: .AnyConnectionKind, reachability: ReachabilityManager(DeviceReachability()))
+        self.init(generator: AnyGenerator(body: body))
     }
 
-    convenience init(connectivity: Reachability.Connectivity = .AnyConnectionKind, reachability: SystemReachabilityType, _ body: () -> T?) {
-        self.init(generator: AnyGenerator(body: body), connectivity: .AnyConnectionKind, reachability: reachability)
-    }
-
-    init<G where G: GeneratorType, G.Element == T>(generator gen: G, connectivity: Reachability.Connectivity = .AnyConnectionKind, reachability: SystemReachabilityType) {
+    init<G where G: GeneratorType, G.Element == T>(generator gen: G) {
 
         // Creates a standard random delay between retries
         let strategy: WaitStrategy = .Random((0.1, 1.0))
@@ -229,8 +226,7 @@ public final class CloudKitOperation<T where T: NSOperation, T: CKOperationType,
 
         // Maps the generator to wrap the target operation.
         let generator = MapGenerator(gen) { operation -> OPRCKOperation<T> in
-            let op = OPRCKOperation(operation, connectivity: connectivity)
-            op.reachability = reachability
+            let op = OPRCKOperation(operation: operation)
             return op
         }
 
@@ -265,23 +261,19 @@ public final class CloudKitOperation<T where T: NSOperation, T: CKOperationType,
 
 class CloudKitOperationGenerator<T where T: NSOperation, T: CKOperationType, T: AssociatedErrorType, T.Error: CloudKitErrorType>: GeneratorType {
 
-    let connectivity: Reachability.Connectivity
-    let reachability: SystemReachabilityType
     let recovery: CloudKitRecovery<T>
 
     var generator: AnyGenerator<T>
     var more: Bool = true
 
-    init<G where G: GeneratorType, G.Element == T>(generator: G, connectivity: Reachability.Connectivity = .AnyConnectionKind, reachability: SystemReachabilityType) {
+    init<G where G: GeneratorType, G.Element == T>(generator: G) {
         self.generator = AnyGenerator(generator)
-        self.connectivity = connectivity
-        self.reachability = reachability
         self.recovery = CloudKitRecovery<T>()
     }
 
     func next() -> CloudKitOperation<T>? {
         guard more else { return .None }
-        let operation = CloudKitOperation(generator: generator, connectivity: connectivity, reachability: reachability)
+        let operation = CloudKitOperation(generator: generator)
         operation.recovery = recovery
         return operation
     }
@@ -297,17 +289,13 @@ public class BatchedCloudKitOperation<T where T: NSOperation, T: CKBatchedOperat
     }
 
     public convenience init(enableBatchProcessing enable: Bool = true, _ body: () -> T?) {
-        self.init(generator: AnyGenerator(body: body), enableBatchProcessing: enable, connectivity: .AnyConnectionKind, reachability: ReachabilityManager(DeviceReachability()))
+        self.init(generator: AnyGenerator(body: body), enableBatchProcessing: enable)
     }
 
-    convenience init(enableBatchProcessing enable: Bool = true, connectivity: Reachability.Connectivity = .AnyConnectionKind, reachability: SystemReachabilityType, _ body: () -> T?) {
-        self.init(generator: AnyGenerator(body: body), enableBatchProcessing: enable, connectivity: connectivity, reachability: reachability)
-    }
-
-    init<G where G: GeneratorType, G.Element == T>(generator gen: G, enableBatchProcessing enable: Bool = true, connectivity: Reachability.Connectivity = .AnyConnectionKind, reachability: SystemReachabilityType) {
+    init<G where G: GeneratorType, G.Element == T>(generator gen: G, enableBatchProcessing enable: Bool = true) {
 
         enableBatchProcessing = enable
-        generator = CloudKitOperationGenerator(generator: gen, connectivity: connectivity, reachability: reachability)
+        generator = CloudKitOperationGenerator(generator: gen)
 
         // Creates a standard fixed delay between batches (not reties)
         let strategy: WaitStrategy = .Fixed(0.1)

--- a/Sources/Features/Shared/CloudKit/CloudKitOperation.swift
+++ b/Sources/Features/Shared/CloudKit/CloudKitOperation.swift
@@ -17,7 +17,7 @@ public class OPRCKOperation<T where T: NSOperation, T: CKOperationType>: Compose
         super.init(operation: composed)
         name = "OPRCKOperation<\(T.self)>"
     }
-    
+
 }
 
 // MARK: - Cloud Kit Error Recovery

--- a/Tests/Features/CloudKitOperationTests.swift
+++ b/Tests/Features/CloudKitOperationTests.swift
@@ -449,7 +449,6 @@ class OPRCKDiscoverAllContactsOperationTests: CKTests {
         super.setUp()
         target = TestDiscoverAllContactsOperation(result: [])
         operation = OPRCKOperation(target)
-        operation.reachability = manager
     }
 
     func test__execution_after_cancellation() {
@@ -506,7 +505,6 @@ class OPRCKDiscoverUserInfosOperationTests: CKTests {
         super.setUp()
         target = TestDiscoverUserInfosOperation(userInfosByEmailAddress: [:], userInfoByRecordID: [:])
         operation = OPRCKOperation(target)
-        operation.reachability = manager
     }
 
     func test__get_email_addresses() {
@@ -579,7 +577,6 @@ class OPRCKFetchNotificationChangesOperationTests: CKTests {
         token = "i'm a server token"
         target = TestFetchNotificationChangesOperation(token: token)
         operation = OPRCKOperation(target)
-        operation.reachability = manager
     }
 
     func test__get_set_notification_changed_block() {
@@ -637,7 +634,6 @@ class OPRCKMarkNotificationsReadOperationTests: CKTests {
         toMark = [ "this-is-an-id", "this-is-another-id" ]
         target = TestMarkNotificationsReadOperation(markIDsToRead: toMark)
         operation = OPRCKOperation(target)
-        operation.reachability = manager
     }
 
     func test__get_notification_id() {
@@ -686,7 +682,6 @@ class OPRCKModifyBadgeOperationTests: CKTests {
         badge = 9
         target = TestModifyBadgeOperation(value: badge)
         operation = OPRCKOperation(target)
-        operation.reachability = manager
     }
 
     func test__get_badge_value() {
@@ -733,7 +728,6 @@ class OPRCKFetchRecordChangesOperationTests: CKTests {
         super.setUp()
         target = TestFetchRecordChangesOperation()
         operation = OPRCKOperation(target)
-        operation.reachability = manager
     }
 
     func test__get_record_zone_id() {
@@ -802,7 +796,6 @@ class OPRCKFetchRecordZonesOperationTests: CKTests {
         super.setUp()
         target = TestFetchRecordZonesOperation()
         operation = OPRCKOperation(target)
-        operation.reachability = manager
     }
 
     func test__get_record_zone_ids() {
@@ -849,7 +842,6 @@ class OPRCKFetchRecordsOperationTests: CKTests {
         super.setUp()
         target = TestFetchRecordsOperation()
         operation = OPRCKOperation(target)
-        operation.reachability = manager
     }
 
     func test__get_record_ids() {
@@ -918,7 +910,6 @@ class OPRCKFetchSubscriptionsOperationTests: CKTests {
         super.setUp()
         target = TestFetchSubscriptionsOperation()
         operation = OPRCKOperation(target)
-        operation.reachability = manager
     }
 
     func test__get_subscription_ids() {
@@ -965,7 +956,6 @@ class OPRCKModifyRecordZonesOperationTests: CKTests {
         super.setUp()
         target = TestModifyRecordZonesOperation()
         operation = OPRCKOperation(target)
-        operation.reachability = manager
     }
 
     func test__get_zones_to_save() {
@@ -1024,7 +1014,6 @@ class OPRCKModifyRecordsOperationTests: CKTests {
         super.setUp()
         target = TestModifyRecordsOperation()
         operation = OPRCKOperation(target)
-        operation.reachability = manager
     }
 
     func test__get_records_to_save() {
@@ -1135,7 +1124,6 @@ class OPRCKModifySubscriptionsOperationTests: CKTests {
         super.setUp()
         target = TestModifySubscriptionsOperation()
         operation = OPRCKOperation(target)
-        operation.reachability = manager
     }
 
     func test__get_subscriptions_to_save() {
@@ -1194,7 +1182,6 @@ class OPRCKQueryOperationTests: CKTests {
         super.setUp()
         target = TestQueryOperation()
         operation = OPRCKOperation(target)
-        operation.reachability = manager
     }
 
     func test__get_query() {
@@ -1274,7 +1261,7 @@ class CloudKitOperationDiscoverAllContractsTests: CKTests {
 
     override func setUp() {
         super.setUp()
-        operation = CloudKitOperation(reachability: manager) { TestDiscoverAllContactsOperation(result: []) }
+        operation = CloudKitOperation() { TestDiscoverAllContactsOperation(result: []) }
     }
 
     func test__execution_after_cancellation() {
@@ -1303,7 +1290,7 @@ class CloudKitOperationDiscoverAllContractsTests: CKTests {
     }
 
     func test__error_without_completion_block() {
-        operation = CloudKitOperation(reachability: manager) {
+        operation = CloudKitOperation() {
             let op = TestDiscoverAllContactsOperation(result: [])
             op.error = NSError(domain: CKErrorDomain, code: CKErrorCode.InternalError.rawValue, userInfo: nil)
             return op
@@ -1315,7 +1302,7 @@ class CloudKitOperationDiscoverAllContractsTests: CKTests {
 
     func test__error_with_completion_block() {
 
-        operation = CloudKitOperation(reachability: manager) {
+        operation = CloudKitOperation() {
             let op = TestDiscoverAllContactsOperation(result: [])
             op.error = NSError(domain: CKErrorDomain, code: CKErrorCode.InternalError.rawValue, userInfo: nil)
             return op
@@ -1331,7 +1318,7 @@ class CloudKitOperationDiscoverAllContractsTests: CKTests {
 
     func test__error_which_retries_using_retry_after_key() {
         var shouldError = true
-        operation = CloudKitOperation(reachability: manager) {
+        operation = CloudKitOperation() {
             let op = TestDiscoverAllContactsOperation(result: [])
             if shouldError {
                 let userInfo = [CKErrorRetryAfterKey: NSNumber(double: 1.0)]
@@ -1354,7 +1341,7 @@ class CloudKitOperationDiscoverAllContractsTests: CKTests {
 
     func test__error_which_retries_without_retry_after_key() {
         var shouldError = true
-        operation = CloudKitOperation(reachability: manager) {
+        operation = CloudKitOperation() {
             let op = TestDiscoverAllContactsOperation(result: [])
             if shouldError {
                 op.error = NSError(
@@ -1377,7 +1364,7 @@ class CloudKitOperationDiscoverAllContractsTests: CKTests {
     func test__error_which_retries_with_custom_handler() {
 
         var shouldError = true
-        operation = CloudKitOperation(reachability: manager) {
+        operation = CloudKitOperation() {
             let op = TestDiscoverAllContactsOperation(result: [])
             if shouldError {
                 op.error = NSError(
@@ -1406,7 +1393,7 @@ class CloudKitOperationDiscoverAllContractsTests: CKTests {
     }
 
     func test__error_which_is_not_cloud_kit_error() {
-        operation = CloudKitOperation(reachability: manager) {
+        operation = CloudKitOperation() {
             let op = TestDiscoverAllContactsOperation(result: [])
             op.error = NSError(
                 domain: CNErrorDomain,
@@ -1423,7 +1410,6 @@ class CloudKitOperationDiscoverAllContractsTests: CKTests {
         XCTAssertTrue(operation.finished)
         XCTAssertEqual(operation.errors.count, 1)
     }
-
 }
 
 class CloudKitOperationDiscoverUserInfosOperationTests: CKTests {
@@ -1432,7 +1418,7 @@ class CloudKitOperationDiscoverUserInfosOperationTests: CKTests {
 
     override func setUp() {
         super.setUp()
-        operation = CloudKitOperation(reachability: manager) { TestDiscoverUserInfosOperation(userInfosByEmailAddress: [:], userInfoByRecordID: [:]) }
+        operation = CloudKitOperation() { TestDiscoverUserInfosOperation(userInfosByEmailAddress: [:], userInfoByRecordID: [:]) }
     }
 
     func test__execution_after_cancellation() {
@@ -1477,7 +1463,7 @@ class CloudKitOperationDiscoverUserInfosOperationTests: CKTests {
     }
 
     func test__error_without_completion_block() {
-        operation = CloudKitOperation(reachability: manager) {
+        operation = CloudKitOperation() {
             let op = TestDiscoverUserInfosOperation(userInfosByEmailAddress: [:], userInfoByRecordID: [:])
             op.error = NSError(domain: CKErrorDomain, code: CKErrorCode.InternalError.rawValue, userInfo: nil)
             return op
@@ -1489,7 +1475,7 @@ class CloudKitOperationDiscoverUserInfosOperationTests: CKTests {
     }
 
     func test__error_with_completion_block() {
-        operation = CloudKitOperation(reachability: manager) {
+        operation = CloudKitOperation() {
             let op = TestDiscoverUserInfosOperation(userInfosByEmailAddress: [:], userInfoByRecordID: [:])
             op.error = NSError(domain: CKErrorDomain, code: CKErrorCode.InternalError.rawValue, userInfo: nil)
             return op
@@ -1508,7 +1494,7 @@ class CloudKitOperationFetchNotificationChangesOperationTests: CKTests {
 
     override func setUp() {
         super.setUp()
-        operation = CloudKitOperation(reachability: manager) {
+        operation = CloudKitOperation() {
             let op = TestFetchNotificationChangesOperation(token: "i'm a server token")
             op.moreComing = true
             op.changedNotifications = [ "Hello", "World" ]
@@ -1548,7 +1534,7 @@ class CloudKitOperationFetchNotificationChangesOperationTests: CKTests {
     }
 
     func test__error_without_completion_block() {
-        operation = CloudKitOperation(reachability: manager) {
+        operation = CloudKitOperation() {
             let op = TestFetchNotificationChangesOperation(token: "i'm a server token")
             op.error = NSError(domain: CKErrorDomain, code: CKErrorCode.InternalError.rawValue, userInfo: nil)
             return op
@@ -1560,7 +1546,7 @@ class CloudKitOperationFetchNotificationChangesOperationTests: CKTests {
     }
 
     func test__error_with_completion_block() {
-        operation = CloudKitOperation(reachability: manager) {
+        operation = CloudKitOperation() {
             let op = TestFetchNotificationChangesOperation(token: "i'm a server token")
             op.error = NSError(domain: CKErrorDomain, code: CKErrorCode.InternalError.rawValue, userInfo: nil)
             return op
@@ -1581,7 +1567,7 @@ class CloudKitOperationMarkNotificationsReadOperationTests: CKTests {
     override func setUp() {
         super.setUp()
         notificationIDs = [ "a-notification-id", "another-notification-id" ]
-        operation = CloudKitOperation(reachability: manager) { TestMarkNotificationsReadOperation() }
+        operation = CloudKitOperation() { TestMarkNotificationsReadOperation() }
         operation.notificationIDs = notificationIDs
     }
 
@@ -1607,7 +1593,7 @@ class CloudKitOperationMarkNotificationsReadOperationTests: CKTests {
     }
 
     func test__error_without_completion_block() {
-        operation = CloudKitOperation(reachability: manager) {
+        operation = CloudKitOperation() {
             let op = TestMarkNotificationsReadOperation()
             op.error = NSError(domain: CKErrorDomain, code: CKErrorCode.InternalError.rawValue, userInfo: nil)
             return op
@@ -1619,7 +1605,7 @@ class CloudKitOperationMarkNotificationsReadOperationTests: CKTests {
     }
 
     func test__error_with_completion_block() {
-        operation = CloudKitOperation(reachability: manager) {
+        operation = CloudKitOperation() {
             let op = TestMarkNotificationsReadOperation()
             op.error = NSError(domain: CKErrorDomain, code: CKErrorCode.InternalError.rawValue, userInfo: nil)
             return op
@@ -1639,7 +1625,7 @@ class CloudKitOperationModifyBadgeCompletionTests: CKTests {
 
     override func setUp() {
         super.setUp()
-        operation = CloudKitOperation(reachability: manager) { TestModifyBadgeOperation() }
+        operation = CloudKitOperation() { TestModifyBadgeOperation() }
         operation.badgeValue = badgeValue
     }
 
@@ -1665,7 +1651,7 @@ class CloudKitOperationModifyBadgeCompletionTests: CKTests {
     }
 
     func test__error_without_completion_block() {
-        operation = CloudKitOperation(reachability: manager) {
+        operation = CloudKitOperation() {
             let op = TestModifyBadgeOperation()
             op.error = NSError(domain: CKErrorDomain, code: CKErrorCode.InternalError.rawValue, userInfo: nil)
             return op
@@ -1677,7 +1663,7 @@ class CloudKitOperationModifyBadgeCompletionTests: CKTests {
     }
 
     func test__error_with_completion_block() {
-        operation = CloudKitOperation(reachability: manager) {
+        operation = CloudKitOperation() {
             let op = TestModifyBadgeOperation()
             op.error = NSError(domain: CKErrorDomain, code: CKErrorCode.InternalError.rawValue, userInfo: nil)
             return op
@@ -1708,7 +1694,7 @@ class CloudKitOperationFetchRecordChangesTests: CKTests {
         resultsLimit = 10
         keys = [ "desired-key-1",  "desired-key-2" ]
         zoneID = "I'm a zone id"
-        operation = CloudKitOperation(reachability: manager) { TestFetchRecordChangesOperation() }
+        operation = CloudKitOperation() { TestFetchRecordChangesOperation() }
         operation.container = container
         operation.database = db
         operation.previousServerChangeToken = token
@@ -1755,7 +1741,7 @@ class CloudKitOperationFetchRecordChangesTests: CKTests {
     }
 
     func test__error_without_completion_block() {
-        operation = CloudKitOperation(reachability: manager) {
+        operation = CloudKitOperation() {
             let op = TestFetchRecordChangesOperation()
             op.error = NSError(domain: CKErrorDomain, code: CKErrorCode.InternalError.rawValue, userInfo: nil)
             return op
@@ -1767,7 +1753,7 @@ class CloudKitOperationFetchRecordChangesTests: CKTests {
     }
 
     func test__error_with_completion_block() {
-        operation = CloudKitOperation(reachability: manager) {
+        operation = CloudKitOperation() {
             let op = TestFetchRecordChangesOperation()
             op.error = NSError(domain: CKErrorDomain, code: CKErrorCode.InternalError.rawValue, userInfo: nil)
             return op
@@ -1788,7 +1774,7 @@ class CloudKitOperationFetchRecordZonesTests: CKTests {
     override func setUp() {
         super.setUp()
         zoneIDs = [ "a-record-zone", "another-record-zone" ]
-        operation = CloudKitOperation(reachability: manager) { TestFetchRecordZonesOperation() }
+        operation = CloudKitOperation() { TestFetchRecordZonesOperation() }
         operation.recordZoneIDs = zoneIDs
     }
 
@@ -1814,7 +1800,7 @@ class CloudKitOperationFetchRecordZonesTests: CKTests {
     }
 
     func test__error_without_completion_block() {
-        operation = CloudKitOperation(reachability: manager) {
+        operation = CloudKitOperation() {
             let op = TestFetchRecordZonesOperation()
             op.error = NSError(domain: CKErrorDomain, code: CKErrorCode.InternalError.rawValue, userInfo: nil)
             return op
@@ -1826,7 +1812,7 @@ class CloudKitOperationFetchRecordZonesTests: CKTests {
     }
 
     func test__error_with_completion_block() {
-        operation = CloudKitOperation(reachability: manager) {
+        operation = CloudKitOperation() {
             let op = TestFetchRecordZonesOperation()
             op.error = NSError(domain: CKErrorDomain, code: CKErrorCode.InternalError.rawValue, userInfo: nil)
             return op
@@ -1847,7 +1833,7 @@ class CloudKitOperationFetchRecordsTests: CKTests {
     override func setUp() {
         super.setUp()
         recordIDs = [ "a-record-id", "another-record-id" ]
-        operation = CloudKitOperation(reachability: manager) { TestFetchRecordsOperation() }
+        operation = CloudKitOperation() { TestFetchRecordsOperation() }
         operation.recordIDs = recordIDs
     }
 
@@ -1877,7 +1863,7 @@ class CloudKitOperationFetchRecordsTests: CKTests {
     }
 
     func test__error_without_completion_block() {
-        operation = CloudKitOperation(reachability: manager) {
+        operation = CloudKitOperation() {
             let op = TestFetchRecordsOperation()
             op.error = NSError(domain: CKErrorDomain, code: CKErrorCode.InternalError.rawValue, userInfo: nil)
             return op
@@ -1889,7 +1875,7 @@ class CloudKitOperationFetchRecordsTests: CKTests {
     }
 
     func test__error_with_completion_block() {
-        operation = CloudKitOperation(reachability: manager) {
+        operation = CloudKitOperation() {
             let op = TestFetchRecordsOperation()
             op.error = NSError(domain: CKErrorDomain, code: CKErrorCode.InternalError.rawValue, userInfo: nil)
             return op
@@ -1910,7 +1896,7 @@ class CloudKitOperationFetchSubscriptionsTests: CKTests {
     override func setUp() {
         super.setUp()
         subscriptionIDs = [ "a-subscription-id", "another-subscription-id" ]
-        operation = CloudKitOperation(reachability: manager) { TestFetchSubscriptionsOperation() }
+        operation = CloudKitOperation() { TestFetchSubscriptionsOperation() }
         operation.subscriptionIDs = subscriptionIDs
     }
 
@@ -1936,7 +1922,7 @@ class CloudKitOperationFetchSubscriptionsTests: CKTests {
     }
 
     func test__error_without_completion_block() {
-        operation = CloudKitOperation(reachability: manager) {
+        operation = CloudKitOperation() {
             let op = TestFetchSubscriptionsOperation()
             op.error = NSError(domain: CKErrorDomain, code: CKErrorCode.InternalError.rawValue, userInfo: nil)
             return op
@@ -1948,7 +1934,7 @@ class CloudKitOperationFetchSubscriptionsTests: CKTests {
     }
 
     func test__error_with_completion_block() {
-        operation = CloudKitOperation(reachability: manager) {
+        operation = CloudKitOperation() {
             let op = TestFetchSubscriptionsOperation()
             op.error = NSError(domain: CKErrorDomain, code: CKErrorCode.InternalError.rawValue, userInfo: nil)
             return op
@@ -1971,7 +1957,7 @@ class CloudKitOperationModifyRecordZonesTests: CKTests {
         super.setUp()
         zonesToSave = [ "a-record-zone", "another-record-zone" ]
         zoneIDsToDelete = [ "a-record-zone-id", "another-record-zone-id" ]
-        operation = CloudKitOperation(reachability: manager) { TestModifyRecordZonesOperation() }
+        operation = CloudKitOperation() { TestModifyRecordZonesOperation() }
         operation.recordZonesToSave = zonesToSave
         operation.recordZoneIDsToDelete = zoneIDsToDelete
     }
@@ -1999,7 +1985,7 @@ class CloudKitOperationModifyRecordZonesTests: CKTests {
     }
 
     func test__error_without_completion_block() {
-        operation = CloudKitOperation(reachability: manager) {
+        operation = CloudKitOperation() {
             let op = TestModifyRecordZonesOperation()
             op.error = NSError(domain: CKErrorDomain, code: CKErrorCode.InternalError.rawValue, userInfo: nil)
             return op
@@ -2011,7 +1997,7 @@ class CloudKitOperationModifyRecordZonesTests: CKTests {
     }
 
     func test__error_with_completion_block() {
-        operation = CloudKitOperation(reachability: manager) {
+        operation = CloudKitOperation() {
             let op = TestModifyRecordZonesOperation()
             op.error = NSError(domain: CKErrorDomain, code: CKErrorCode.InternalError.rawValue, userInfo: nil)
             return op
@@ -2041,7 +2027,7 @@ class CloudKitOperationModifyRecordsTests: CKTests {
         clientChangeToken = "I'm a client change token".dataUsingEncoding(NSUTF8StringEncoding)
         atomic = true
 
-        operation = CloudKitOperation(reachability: manager) { TestModifyRecordsOperation() }
+        operation = CloudKitOperation() { TestModifyRecordsOperation() }
         operation.recordsToSave = recordsToSave
         operation.recordIDsToDelete = recordIDsToDelete
         operation.savePolicy = policy
@@ -2079,7 +2065,7 @@ class CloudKitOperationModifyRecordsTests: CKTests {
     }
 
     func test__error_without_completion_block() {
-        operation = CloudKitOperation(reachability: manager) {
+        operation = CloudKitOperation() {
             let op = TestModifyRecordsOperation()
             op.error = NSError(domain: CKErrorDomain, code: CKErrorCode.InternalError.rawValue, userInfo: nil)
             return op
@@ -2091,7 +2077,7 @@ class CloudKitOperationModifyRecordsTests: CKTests {
     }
 
     func test__error_with_completion_block() {
-        operation = CloudKitOperation(reachability: manager) {
+        operation = CloudKitOperation() {
             let op = TestModifyRecordsOperation()
             op.error = NSError(domain: CKErrorDomain, code: CKErrorCode.InternalError.rawValue, userInfo: nil)
             return op
@@ -2115,7 +2101,7 @@ class CloudKitOperationModifySubscriptionsTests: CKTests {
         subscriptionsToSave = [ "a-subscription", "another-subscription" ]
         subscriptionIDsToDelete = [ "a-subscription-id", "another-subscription-id" ]
 
-        operation = CloudKitOperation(reachability: manager) { TestModifySubscriptionsOperation() }
+        operation = CloudKitOperation() { TestModifySubscriptionsOperation() }
         operation.subscriptionsToSave = subscriptionsToSave
         operation.subscriptionIDsToDelete = subscriptionIDsToDelete
     }
@@ -2143,7 +2129,7 @@ class CloudKitOperationModifySubscriptionsTests: CKTests {
     }
 
     func test__error_without_completion_block() {
-        operation = CloudKitOperation(reachability: manager) {
+        operation = CloudKitOperation() {
             let op = TestModifySubscriptionsOperation()
             op.error = NSError(domain: CKErrorDomain, code: CKErrorCode.InternalError.rawValue, userInfo: nil)
             return op
@@ -2155,7 +2141,7 @@ class CloudKitOperationModifySubscriptionsTests: CKTests {
     }
 
     func test__error_with_completion_block() {
-        operation = CloudKitOperation(reachability: manager) {
+        operation = CloudKitOperation() {
             let op = TestModifySubscriptionsOperation()
             op.error = NSError(domain: CKErrorDomain, code: CKErrorCode.InternalError.rawValue, userInfo: nil)
             return op
@@ -2180,7 +2166,7 @@ class CloudKitOperationQueryTests: CKTests {
         query = "I'm a query"
         cursor = "I'm a cursor"
         zoneID = "a-zone-id"
-        operation = CloudKitOperation(reachability: manager) { TestQueryOperation() }
+        operation = CloudKitOperation() { TestQueryOperation() }
         operation.query = query
         operation.cursor = cursor
         operation.zoneID = zoneID
@@ -2212,7 +2198,7 @@ class CloudKitOperationQueryTests: CKTests {
     }
 
     func test__error_without_completion_block() {
-        operation = CloudKitOperation(reachability: manager) {
+        operation = CloudKitOperation() {
             let op = TestQueryOperation()
             op.error = NSError(domain: CKErrorDomain, code: CKErrorCode.InternalError.rawValue, userInfo: nil)
             return op
@@ -2224,7 +2210,7 @@ class CloudKitOperationQueryTests: CKTests {
     }
 
     func test__error_with_completion_block() {
-        operation = CloudKitOperation(reachability: manager) {
+        operation = CloudKitOperation() {
             let op = TestQueryOperation()
             op.error = NSError(domain: CKErrorDomain, code: CKErrorCode.InternalError.rawValue, userInfo: nil)
             return op
@@ -2255,7 +2241,7 @@ class BatchedFetchNotificationChangesOperationTests: CKTests {
         error = .None
         numberOfBatches = 3
         count = 0
-        operation = BatchedCloudKitOperation(reachability: manager, createNextOperation)
+        operation = BatchedCloudKitOperation(createNextOperation)
     }
 
     func createNextOperation() -> Target? {
@@ -2309,7 +2295,7 @@ class BatchedFetchRecordChangesOperationTests: CKTests {
         super.setUp()
         numberOfBatches = 3
         count = 0
-        operation = BatchedCloudKitOperation(reachability: manager, createNextOperation)
+        operation = BatchedCloudKitOperation(createNextOperation)
     }
 
     func createNextOperation() -> Target {
@@ -2363,7 +2349,6 @@ class CloudKitRecoveryTests: CKTests {
         super.setUp()
         let target = TestDiscoverUserInfosOperation(userInfosByEmailAddress: [:], userInfoByRecordID: [:])
         operation = OPRCKOperation(target)
-        operation.reachability = manager
         recovery = CloudKitRecovery()
     }
 

--- a/Tests/Features/CloudKitOperationTests.swift
+++ b/Tests/Features/CloudKitOperationTests.swift
@@ -1261,7 +1261,7 @@ class CloudKitOperationDiscoverAllContractsTests: CKTests {
 
     override func setUp() {
         super.setUp()
-        operation = CloudKitOperation() { TestDiscoverAllContactsOperation(result: []) }
+        operation = CloudKitOperation { TestDiscoverAllContactsOperation(result: []) }
     }
 
     func test__execution_after_cancellation() {
@@ -1290,7 +1290,7 @@ class CloudKitOperationDiscoverAllContractsTests: CKTests {
     }
 
     func test__error_without_completion_block() {
-        operation = CloudKitOperation() {
+        operation = CloudKitOperation {
             let op = TestDiscoverAllContactsOperation(result: [])
             op.error = NSError(domain: CKErrorDomain, code: CKErrorCode.InternalError.rawValue, userInfo: nil)
             return op
@@ -1302,7 +1302,7 @@ class CloudKitOperationDiscoverAllContractsTests: CKTests {
 
     func test__error_with_completion_block() {
 
-        operation = CloudKitOperation() {
+        operation = CloudKitOperation {
             let op = TestDiscoverAllContactsOperation(result: [])
             op.error = NSError(domain: CKErrorDomain, code: CKErrorCode.InternalError.rawValue, userInfo: nil)
             return op
@@ -1318,7 +1318,7 @@ class CloudKitOperationDiscoverAllContractsTests: CKTests {
 
     func test__error_which_retries_using_retry_after_key() {
         var shouldError = true
-        operation = CloudKitOperation() {
+        operation = CloudKitOperation {
             let op = TestDiscoverAllContactsOperation(result: [])
             if shouldError {
                 let userInfo = [CKErrorRetryAfterKey: NSNumber(double: 1.0)]
@@ -1341,7 +1341,7 @@ class CloudKitOperationDiscoverAllContractsTests: CKTests {
 
     func test__error_which_retries_without_retry_after_key() {
         var shouldError = true
-        operation = CloudKitOperation() {
+        operation = CloudKitOperation {
             let op = TestDiscoverAllContactsOperation(result: [])
             if shouldError {
                 op.error = NSError(
@@ -1364,7 +1364,7 @@ class CloudKitOperationDiscoverAllContractsTests: CKTests {
     func test__error_which_retries_with_custom_handler() {
 
         var shouldError = true
-        operation = CloudKitOperation() {
+        operation = CloudKitOperation {
             let op = TestDiscoverAllContactsOperation(result: [])
             if shouldError {
                 op.error = NSError(
@@ -1393,7 +1393,7 @@ class CloudKitOperationDiscoverAllContractsTests: CKTests {
     }
 
     func test__error_which_is_not_cloud_kit_error() {
-        operation = CloudKitOperation() {
+        operation = CloudKitOperation {
             let op = TestDiscoverAllContactsOperation(result: [])
             op.error = NSError(
                 domain: CNErrorDomain,
@@ -1418,7 +1418,7 @@ class CloudKitOperationDiscoverUserInfosOperationTests: CKTests {
 
     override func setUp() {
         super.setUp()
-        operation = CloudKitOperation() { TestDiscoverUserInfosOperation(userInfosByEmailAddress: [:], userInfoByRecordID: [:]) }
+        operation = CloudKitOperation { TestDiscoverUserInfosOperation(userInfosByEmailAddress: [:], userInfoByRecordID: [:]) }
     }
 
     func test__execution_after_cancellation() {
@@ -1463,7 +1463,7 @@ class CloudKitOperationDiscoverUserInfosOperationTests: CKTests {
     }
 
     func test__error_without_completion_block() {
-        operation = CloudKitOperation() {
+        operation = CloudKitOperation {
             let op = TestDiscoverUserInfosOperation(userInfosByEmailAddress: [:], userInfoByRecordID: [:])
             op.error = NSError(domain: CKErrorDomain, code: CKErrorCode.InternalError.rawValue, userInfo: nil)
             return op
@@ -1475,7 +1475,7 @@ class CloudKitOperationDiscoverUserInfosOperationTests: CKTests {
     }
 
     func test__error_with_completion_block() {
-        operation = CloudKitOperation() {
+        operation = CloudKitOperation {
             let op = TestDiscoverUserInfosOperation(userInfosByEmailAddress: [:], userInfoByRecordID: [:])
             op.error = NSError(domain: CKErrorDomain, code: CKErrorCode.InternalError.rawValue, userInfo: nil)
             return op
@@ -1494,7 +1494,7 @@ class CloudKitOperationFetchNotificationChangesOperationTests: CKTests {
 
     override func setUp() {
         super.setUp()
-        operation = CloudKitOperation() {
+        operation = CloudKitOperation {
             let op = TestFetchNotificationChangesOperation(token: "i'm a server token")
             op.moreComing = true
             op.changedNotifications = [ "Hello", "World" ]
@@ -1534,7 +1534,7 @@ class CloudKitOperationFetchNotificationChangesOperationTests: CKTests {
     }
 
     func test__error_without_completion_block() {
-        operation = CloudKitOperation() {
+        operation = CloudKitOperation {
             let op = TestFetchNotificationChangesOperation(token: "i'm a server token")
             op.error = NSError(domain: CKErrorDomain, code: CKErrorCode.InternalError.rawValue, userInfo: nil)
             return op
@@ -1546,7 +1546,7 @@ class CloudKitOperationFetchNotificationChangesOperationTests: CKTests {
     }
 
     func test__error_with_completion_block() {
-        operation = CloudKitOperation() {
+        operation = CloudKitOperation {
             let op = TestFetchNotificationChangesOperation(token: "i'm a server token")
             op.error = NSError(domain: CKErrorDomain, code: CKErrorCode.InternalError.rawValue, userInfo: nil)
             return op
@@ -1567,7 +1567,7 @@ class CloudKitOperationMarkNotificationsReadOperationTests: CKTests {
     override func setUp() {
         super.setUp()
         notificationIDs = [ "a-notification-id", "another-notification-id" ]
-        operation = CloudKitOperation() { TestMarkNotificationsReadOperation() }
+        operation = CloudKitOperation { TestMarkNotificationsReadOperation() }
         operation.notificationIDs = notificationIDs
     }
 
@@ -1593,7 +1593,7 @@ class CloudKitOperationMarkNotificationsReadOperationTests: CKTests {
     }
 
     func test__error_without_completion_block() {
-        operation = CloudKitOperation() {
+        operation = CloudKitOperation {
             let op = TestMarkNotificationsReadOperation()
             op.error = NSError(domain: CKErrorDomain, code: CKErrorCode.InternalError.rawValue, userInfo: nil)
             return op
@@ -1605,7 +1605,7 @@ class CloudKitOperationMarkNotificationsReadOperationTests: CKTests {
     }
 
     func test__error_with_completion_block() {
-        operation = CloudKitOperation() {
+        operation = CloudKitOperation {
             let op = TestMarkNotificationsReadOperation()
             op.error = NSError(domain: CKErrorDomain, code: CKErrorCode.InternalError.rawValue, userInfo: nil)
             return op
@@ -1625,7 +1625,7 @@ class CloudKitOperationModifyBadgeCompletionTests: CKTests {
 
     override func setUp() {
         super.setUp()
-        operation = CloudKitOperation() { TestModifyBadgeOperation() }
+        operation = CloudKitOperation { TestModifyBadgeOperation() }
         operation.badgeValue = badgeValue
     }
 
@@ -1651,7 +1651,7 @@ class CloudKitOperationModifyBadgeCompletionTests: CKTests {
     }
 
     func test__error_without_completion_block() {
-        operation = CloudKitOperation() {
+        operation = CloudKitOperation {
             let op = TestModifyBadgeOperation()
             op.error = NSError(domain: CKErrorDomain, code: CKErrorCode.InternalError.rawValue, userInfo: nil)
             return op
@@ -1663,7 +1663,7 @@ class CloudKitOperationModifyBadgeCompletionTests: CKTests {
     }
 
     func test__error_with_completion_block() {
-        operation = CloudKitOperation() {
+        operation = CloudKitOperation {
             let op = TestModifyBadgeOperation()
             op.error = NSError(domain: CKErrorDomain, code: CKErrorCode.InternalError.rawValue, userInfo: nil)
             return op
@@ -1694,7 +1694,7 @@ class CloudKitOperationFetchRecordChangesTests: CKTests {
         resultsLimit = 10
         keys = [ "desired-key-1",  "desired-key-2" ]
         zoneID = "I'm a zone id"
-        operation = CloudKitOperation() { TestFetchRecordChangesOperation() }
+        operation = CloudKitOperation { TestFetchRecordChangesOperation() }
         operation.container = container
         operation.database = db
         operation.previousServerChangeToken = token
@@ -1741,7 +1741,7 @@ class CloudKitOperationFetchRecordChangesTests: CKTests {
     }
 
     func test__error_without_completion_block() {
-        operation = CloudKitOperation() {
+        operation = CloudKitOperation {
             let op = TestFetchRecordChangesOperation()
             op.error = NSError(domain: CKErrorDomain, code: CKErrorCode.InternalError.rawValue, userInfo: nil)
             return op
@@ -1753,7 +1753,7 @@ class CloudKitOperationFetchRecordChangesTests: CKTests {
     }
 
     func test__error_with_completion_block() {
-        operation = CloudKitOperation() {
+        operation = CloudKitOperation {
             let op = TestFetchRecordChangesOperation()
             op.error = NSError(domain: CKErrorDomain, code: CKErrorCode.InternalError.rawValue, userInfo: nil)
             return op
@@ -1774,7 +1774,7 @@ class CloudKitOperationFetchRecordZonesTests: CKTests {
     override func setUp() {
         super.setUp()
         zoneIDs = [ "a-record-zone", "another-record-zone" ]
-        operation = CloudKitOperation() { TestFetchRecordZonesOperation() }
+        operation = CloudKitOperation { TestFetchRecordZonesOperation() }
         operation.recordZoneIDs = zoneIDs
     }
 
@@ -1800,7 +1800,7 @@ class CloudKitOperationFetchRecordZonesTests: CKTests {
     }
 
     func test__error_without_completion_block() {
-        operation = CloudKitOperation() {
+        operation = CloudKitOperation {
             let op = TestFetchRecordZonesOperation()
             op.error = NSError(domain: CKErrorDomain, code: CKErrorCode.InternalError.rawValue, userInfo: nil)
             return op
@@ -1812,7 +1812,7 @@ class CloudKitOperationFetchRecordZonesTests: CKTests {
     }
 
     func test__error_with_completion_block() {
-        operation = CloudKitOperation() {
+        operation = CloudKitOperation {
             let op = TestFetchRecordZonesOperation()
             op.error = NSError(domain: CKErrorDomain, code: CKErrorCode.InternalError.rawValue, userInfo: nil)
             return op
@@ -1833,7 +1833,7 @@ class CloudKitOperationFetchRecordsTests: CKTests {
     override func setUp() {
         super.setUp()
         recordIDs = [ "a-record-id", "another-record-id" ]
-        operation = CloudKitOperation() { TestFetchRecordsOperation() }
+        operation = CloudKitOperation { TestFetchRecordsOperation() }
         operation.recordIDs = recordIDs
     }
 
@@ -1863,7 +1863,7 @@ class CloudKitOperationFetchRecordsTests: CKTests {
     }
 
     func test__error_without_completion_block() {
-        operation = CloudKitOperation() {
+        operation = CloudKitOperation {
             let op = TestFetchRecordsOperation()
             op.error = NSError(domain: CKErrorDomain, code: CKErrorCode.InternalError.rawValue, userInfo: nil)
             return op
@@ -1875,7 +1875,7 @@ class CloudKitOperationFetchRecordsTests: CKTests {
     }
 
     func test__error_with_completion_block() {
-        operation = CloudKitOperation() {
+        operation = CloudKitOperation {
             let op = TestFetchRecordsOperation()
             op.error = NSError(domain: CKErrorDomain, code: CKErrorCode.InternalError.rawValue, userInfo: nil)
             return op
@@ -1896,7 +1896,7 @@ class CloudKitOperationFetchSubscriptionsTests: CKTests {
     override func setUp() {
         super.setUp()
         subscriptionIDs = [ "a-subscription-id", "another-subscription-id" ]
-        operation = CloudKitOperation() { TestFetchSubscriptionsOperation() }
+        operation = CloudKitOperation { TestFetchSubscriptionsOperation() }
         operation.subscriptionIDs = subscriptionIDs
     }
 
@@ -1922,7 +1922,7 @@ class CloudKitOperationFetchSubscriptionsTests: CKTests {
     }
 
     func test__error_without_completion_block() {
-        operation = CloudKitOperation() {
+        operation = CloudKitOperation {
             let op = TestFetchSubscriptionsOperation()
             op.error = NSError(domain: CKErrorDomain, code: CKErrorCode.InternalError.rawValue, userInfo: nil)
             return op
@@ -1934,7 +1934,7 @@ class CloudKitOperationFetchSubscriptionsTests: CKTests {
     }
 
     func test__error_with_completion_block() {
-        operation = CloudKitOperation() {
+        operation = CloudKitOperation {
             let op = TestFetchSubscriptionsOperation()
             op.error = NSError(domain: CKErrorDomain, code: CKErrorCode.InternalError.rawValue, userInfo: nil)
             return op
@@ -1957,7 +1957,7 @@ class CloudKitOperationModifyRecordZonesTests: CKTests {
         super.setUp()
         zonesToSave = [ "a-record-zone", "another-record-zone" ]
         zoneIDsToDelete = [ "a-record-zone-id", "another-record-zone-id" ]
-        operation = CloudKitOperation() { TestModifyRecordZonesOperation() }
+        operation = CloudKitOperation { TestModifyRecordZonesOperation() }
         operation.recordZonesToSave = zonesToSave
         operation.recordZoneIDsToDelete = zoneIDsToDelete
     }
@@ -1985,7 +1985,7 @@ class CloudKitOperationModifyRecordZonesTests: CKTests {
     }
 
     func test__error_without_completion_block() {
-        operation = CloudKitOperation() {
+        operation = CloudKitOperation {
             let op = TestModifyRecordZonesOperation()
             op.error = NSError(domain: CKErrorDomain, code: CKErrorCode.InternalError.rawValue, userInfo: nil)
             return op
@@ -1997,7 +1997,7 @@ class CloudKitOperationModifyRecordZonesTests: CKTests {
     }
 
     func test__error_with_completion_block() {
-        operation = CloudKitOperation() {
+        operation = CloudKitOperation {
             let op = TestModifyRecordZonesOperation()
             op.error = NSError(domain: CKErrorDomain, code: CKErrorCode.InternalError.rawValue, userInfo: nil)
             return op
@@ -2027,7 +2027,7 @@ class CloudKitOperationModifyRecordsTests: CKTests {
         clientChangeToken = "I'm a client change token".dataUsingEncoding(NSUTF8StringEncoding)
         atomic = true
 
-        operation = CloudKitOperation() { TestModifyRecordsOperation() }
+        operation = CloudKitOperation { TestModifyRecordsOperation() }
         operation.recordsToSave = recordsToSave
         operation.recordIDsToDelete = recordIDsToDelete
         operation.savePolicy = policy
@@ -2065,7 +2065,7 @@ class CloudKitOperationModifyRecordsTests: CKTests {
     }
 
     func test__error_without_completion_block() {
-        operation = CloudKitOperation() {
+        operation = CloudKitOperation {
             let op = TestModifyRecordsOperation()
             op.error = NSError(domain: CKErrorDomain, code: CKErrorCode.InternalError.rawValue, userInfo: nil)
             return op
@@ -2077,7 +2077,7 @@ class CloudKitOperationModifyRecordsTests: CKTests {
     }
 
     func test__error_with_completion_block() {
-        operation = CloudKitOperation() {
+        operation = CloudKitOperation {
             let op = TestModifyRecordsOperation()
             op.error = NSError(domain: CKErrorDomain, code: CKErrorCode.InternalError.rawValue, userInfo: nil)
             return op
@@ -2101,7 +2101,7 @@ class CloudKitOperationModifySubscriptionsTests: CKTests {
         subscriptionsToSave = [ "a-subscription", "another-subscription" ]
         subscriptionIDsToDelete = [ "a-subscription-id", "another-subscription-id" ]
 
-        operation = CloudKitOperation() { TestModifySubscriptionsOperation() }
+        operation = CloudKitOperation { TestModifySubscriptionsOperation() }
         operation.subscriptionsToSave = subscriptionsToSave
         operation.subscriptionIDsToDelete = subscriptionIDsToDelete
     }
@@ -2129,7 +2129,7 @@ class CloudKitOperationModifySubscriptionsTests: CKTests {
     }
 
     func test__error_without_completion_block() {
-        operation = CloudKitOperation() {
+        operation = CloudKitOperation {
             let op = TestModifySubscriptionsOperation()
             op.error = NSError(domain: CKErrorDomain, code: CKErrorCode.InternalError.rawValue, userInfo: nil)
             return op
@@ -2141,7 +2141,7 @@ class CloudKitOperationModifySubscriptionsTests: CKTests {
     }
 
     func test__error_with_completion_block() {
-        operation = CloudKitOperation() {
+        operation = CloudKitOperation {
             let op = TestModifySubscriptionsOperation()
             op.error = NSError(domain: CKErrorDomain, code: CKErrorCode.InternalError.rawValue, userInfo: nil)
             return op
@@ -2166,7 +2166,7 @@ class CloudKitOperationQueryTests: CKTests {
         query = "I'm a query"
         cursor = "I'm a cursor"
         zoneID = "a-zone-id"
-        operation = CloudKitOperation() { TestQueryOperation() }
+        operation = CloudKitOperation { TestQueryOperation() }
         operation.query = query
         operation.cursor = cursor
         operation.zoneID = zoneID
@@ -2198,7 +2198,7 @@ class CloudKitOperationQueryTests: CKTests {
     }
 
     func test__error_without_completion_block() {
-        operation = CloudKitOperation() {
+        operation = CloudKitOperation {
             let op = TestQueryOperation()
             op.error = NSError(domain: CKErrorDomain, code: CKErrorCode.InternalError.rawValue, userInfo: nil)
             return op
@@ -2210,7 +2210,7 @@ class CloudKitOperationQueryTests: CKTests {
     }
 
     func test__error_with_completion_block() {
-        operation = CloudKitOperation() {
+        operation = CloudKitOperation {
             let op = TestQueryOperation()
             op.error = NSError(domain: CKErrorDomain, code: CKErrorCode.InternalError.rawValue, userInfo: nil)
             return op

--- a/Tests/Features/CloudKitOperationTests.swift
+++ b/Tests/Features/CloudKitOperationTests.swift
@@ -353,7 +353,7 @@ class OPRCKOperationTests: CKTests {
     override func setUp() {
         super.setUp()
         target = TestCloudOperation()
-        operation = OPRCKOperation(target)
+        operation = OPRCKOperation(operation: target)
     }
 
     func test__get_countainer() {
@@ -383,7 +383,7 @@ class OPRCKDatabaseOperationTests: CKTests {
     override func setUp() {
         super.setUp()
         target = TestDatabaseOperation()
-        operation = OPRCKOperation(target)
+        operation = OPRCKOperation(operation: target)
     }
 
     func test__get_database() {
@@ -448,7 +448,7 @@ class OPRCKDiscoverAllContactsOperationTests: CKTests {
     override func setUp() {
         super.setUp()
         target = TestDiscoverAllContactsOperation(result: [])
-        operation = OPRCKOperation(target)
+        operation = OPRCKOperation(operation: target)
     }
 
     func test__execution_after_cancellation() {
@@ -504,7 +504,7 @@ class OPRCKDiscoverUserInfosOperationTests: CKTests {
     override func setUp() {
         super.setUp()
         target = TestDiscoverUserInfosOperation(userInfosByEmailAddress: [:], userInfoByRecordID: [:])
-        operation = OPRCKOperation(target)
+        operation = OPRCKOperation(operation: target)
     }
 
     func test__get_email_addresses() {
@@ -576,7 +576,7 @@ class OPRCKFetchNotificationChangesOperationTests: CKTests {
         super.setUp()
         token = "i'm a server token"
         target = TestFetchNotificationChangesOperation(token: token)
-        operation = OPRCKOperation(target)
+        operation = OPRCKOperation(operation: target)
     }
 
     func test__get_set_notification_changed_block() {
@@ -633,7 +633,7 @@ class OPRCKMarkNotificationsReadOperationTests: CKTests {
         super.setUp()
         toMark = [ "this-is-an-id", "this-is-another-id" ]
         target = TestMarkNotificationsReadOperation(markIDsToRead: toMark)
-        operation = OPRCKOperation(target)
+        operation = OPRCKOperation(operation: target)
     }
 
     func test__get_notification_id() {
@@ -681,7 +681,7 @@ class OPRCKModifyBadgeOperationTests: CKTests {
         super.setUp()
         badge = 9
         target = TestModifyBadgeOperation(value: badge)
-        operation = OPRCKOperation(target)
+        operation = OPRCKOperation(operation: target)
     }
 
     func test__get_badge_value() {
@@ -727,7 +727,7 @@ class OPRCKFetchRecordChangesOperationTests: CKTests {
     override func setUp() {
         super.setUp()
         target = TestFetchRecordChangesOperation()
-        operation = OPRCKOperation(target)
+        operation = OPRCKOperation(operation: target)
     }
 
     func test__get_record_zone_id() {
@@ -795,7 +795,7 @@ class OPRCKFetchRecordZonesOperationTests: CKTests {
     override func setUp() {
         super.setUp()
         target = TestFetchRecordZonesOperation()
-        operation = OPRCKOperation(target)
+        operation = OPRCKOperation(operation: target)
     }
 
     func test__get_record_zone_ids() {
@@ -841,7 +841,7 @@ class OPRCKFetchRecordsOperationTests: CKTests {
     override func setUp() {
         super.setUp()
         target = TestFetchRecordsOperation()
-        operation = OPRCKOperation(target)
+        operation = OPRCKOperation(operation: target)
     }
 
     func test__get_record_ids() {
@@ -909,7 +909,7 @@ class OPRCKFetchSubscriptionsOperationTests: CKTests {
     override func setUp() {
         super.setUp()
         target = TestFetchSubscriptionsOperation()
-        operation = OPRCKOperation(target)
+        operation = OPRCKOperation(operation: target)
     }
 
     func test__get_subscription_ids() {
@@ -955,7 +955,7 @@ class OPRCKModifyRecordZonesOperationTests: CKTests {
     override func setUp() {
         super.setUp()
         target = TestModifyRecordZonesOperation()
-        operation = OPRCKOperation(target)
+        operation = OPRCKOperation(operation: target)
     }
 
     func test__get_zones_to_save() {
@@ -1013,7 +1013,7 @@ class OPRCKModifyRecordsOperationTests: CKTests {
     override func setUp() {
         super.setUp()
         target = TestModifyRecordsOperation()
-        operation = OPRCKOperation(target)
+        operation = OPRCKOperation(operation: target)
     }
 
     func test__get_records_to_save() {
@@ -1123,7 +1123,7 @@ class OPRCKModifySubscriptionsOperationTests: CKTests {
     override func setUp() {
         super.setUp()
         target = TestModifySubscriptionsOperation()
-        operation = OPRCKOperation(target)
+        operation = OPRCKOperation(operation: target)
     }
 
     func test__get_subscriptions_to_save() {
@@ -1181,7 +1181,7 @@ class OPRCKQueryOperationTests: CKTests {
     override func setUp() {
         super.setUp()
         target = TestQueryOperation()
-        operation = OPRCKOperation(target)
+        operation = OPRCKOperation(operation: target)
     }
 
     func test__get_query() {
@@ -2348,7 +2348,7 @@ class CloudKitRecoveryTests: CKTests {
     override func setUp() {
         super.setUp()
         let target = TestDiscoverUserInfosOperation(userInfosByEmailAddress: [:], userInfoByRecordID: [:])
-        operation = OPRCKOperation(target)
+        operation = OPRCKOperation(operation: target)
         recovery = CloudKitRecovery()
     }
 

--- a/Tests/Features/CloudKitOperationTests.swift
+++ b/Tests/Features/CloudKitOperationTests.swift
@@ -350,28 +350,41 @@ class OPRCKOperationTests: CKTests {
     var target: TestCloudOperation!
     var operation: OPRCKOperation<TestCloudOperation>!
 
+    var timeoutObserver: TimeoutObserver? {
+        return operation.willExecuteObservers.flatMap({ $0 as? TimeoutObserver }).first
+    }
+
     override func setUp() {
         super.setUp()
         target = TestCloudOperation()
         operation = OPRCKOperation(operation: target)
     }
 
-    func test__get_countainer() {
+    func test__get_container() {
         let container = "I'm a test container!"
         target.container = container
         XCTAssertEqual(operation.container, container)
     }
 
-    func test__set_database() {
+    func test__set_container() {
         let container = "I'm a test container!"
         operation.container = container
         XCTAssertEqual(target.container, container)
     }
 
-    func test__set_get_countainer() {
+    func test__set_get_container() {
         let container = "I'm a test container!"
         operation.container = container
         XCTAssertEqual(operation.container, container)
+    }
+
+    func test__timeout() {
+        XCTAssertEqual(timeoutObserver?.timeout ?? 0, 300)
+    }
+
+    func test__no_timeout() {
+        operation = OPRCKOperation(operation: target, timeout: .None)
+        XCTAssertNil(timeoutObserver)
     }
 }
 


### PR DESCRIPTION
Instead add a `TimeoutObserver` with a default timeout. As mentioned in #294. 