### PR TITLE
Sample: GroupOperation with committed / uncommitted errors

### DIFF
--- a/Sources/Features/Shared/CloudKit/CloudKitOperation.swift
+++ b/Sources/Features/Shared/CloudKit/CloudKitOperation.swift
@@ -243,7 +243,8 @@ public final class CloudKitOperation<T where T: NSOperation, T: CKOperationType,
             guard let _recovery = _recovery, (delay, configure) = _recovery.recoverWithInfo(info, payload: payload) else { return .None }
             let (_, operation) = payload
             configure(operation)
-            return (delay, operation)
+            // TODO: If CloudKitRecovery returned a non-nil _recovery, consider the errors handled
+            return ((delay, operation), adjustedErrors: [] /* TODO: <--- this should be the errors, set as handled */ )
         }
 
         recovery = _recovery

--- a/Tests/Core/RetryOperationTests.swift
+++ b/Tests/Core/RetryOperationTests.swift
@@ -73,7 +73,7 @@ class RetryOperationTests: OperationTests {
     }
 
     func test__retry_operation_with_payload_generator() {
-        operation = RetryOperation(generator: AnyGenerator(body: producerWithDelay(2)), retry: { $1 })
+        operation = RetryOperation(generator: AnyGenerator(body: producerWithDelay(2)), retry: { ($1, adjustedErrors: $0.errors) })
 
         addCompletionBlockToTestOperation(operation, withExpectation: expectationWithDescription("Test: \(#function)"))
         runOperation(operation)
@@ -95,7 +95,7 @@ class RetryOperationTests: OperationTests {
     }
 
     func test__retry_operation_where_generator_returns_nil() {
-        operation = RetryOperation(maxCount: 12, strategy: .Fixed(0.01), AnyGenerator(body: producer(11))) { $1 } // Includes the retry block
+        operation = RetryOperation(maxCount: 12, strategy: .Fixed(0.01), AnyGenerator(body: producer(11))) { ($1, adjustedErrors: $0.errors) } // Includes the retry block
 
         addCompletionBlockToTestOperation(operation, withExpectation: expectationWithDescription("Test: \(#function)"))
         runOperation(operation)
@@ -128,7 +128,7 @@ class RetryOperationTests: OperationTests {
             retryAggregateErrors = info.aggregateErrors
             retryCount = info.count
             didRunBlockCount += 1
-            return recommended
+            return (recommended, adjustedErrors: info.errors)
         }
 
         operation = RetryOperation(AnyGenerator(body: producer(3)), retry: retry)

--- a/Tests/Features/CloudKitOperationTests.swift
+++ b/Tests/Features/CloudKitOperationTests.swift
@@ -1401,7 +1401,7 @@ class CloudKitOperationDiscoverAllContractsTests: CKTests {
         waitForOperation(operation)
 
         XCTAssertTrue(operation.finished)
-        XCTAssertEqual(operation.errors.count, 1)
+        XCTAssertEqual(operation.errors.count, 0) // TODO: Modify to check handled vs non-handled errors
         XCTAssertTrue(didRunCustomHandler)
     }
 


### PR DESCRIPTION
Allows subclasses to commit changes to prior errors - for example, if
they’ve “handled” them.

**Note:** This is just a quick proof of concept. 

But it does fix this particular issue with CloudKitOperation and the recovery handlers. (_Not
a complete implementation, though - just erases the “handled” errors, instead of committing them as handled._)