### PR TITLE
Network observer flickering

### DIFF
--- a/Sources/Core/iOS/NetworkObserver.swift
+++ b/Sources/Core/iOS/NetworkObserver.swift
@@ -63,10 +63,10 @@ private class NetworkIndicatorController {
     }
 
     private func updateIndicatorVisibility() {
-        if activityCount > 0 {
+        if activityCount > 0 && networkActivityIndicator.networkActivityIndicatorVisible == false {
             networkIndicatorShouldShow(true)
         }
-        else {
+        else if activityCount == 0 {
             visibilityTimer = Timer(interval: 1.0) {
                 self.networkIndicatorShouldShow(false)
             }


### PR DESCRIPTION
Added tests for **multiple** operations having network observers.

Fixes #335 

I'm not 100% a fan of this implementation. This biggest change here is simply having tests in place that make sure that `networkActivityIndicatorVisible` doesn't get set multiple times unless it is a change in value.

Please feel free to give pointers on what I can do to improve this. I really appreciated seeing the way these tests were originally setup, nicely done. I'll add some questions in the code itself to get a better understanding.

I could reduce the number of methods or override a setter in the controller which manages changing `networkActivityIndicatorVisible` based on if it is a new value, but I'm not sure that provides any better readability.

@danthorpe mentioned in #335 that reducing the methods might make it harder to test. But considering the tests are just looking at starting/stopping operations and what is or isn't set on `networkActivityIndicator` I'm not sure I understand how it would make it harder to test. The public interface would be kept intact.

Again, any suggestions on how to improve this is appreciated and I can take a crack at making those changes.

--

As a side note it is a little unfortunate that `addCompletionBlockToTestOperation` doesn't actually add a completion block, it adds a `DidFinishObserver`. I wonder if changing the naming of that method / adding another method that does add a completion block would be helpful since we have the following a few times in these tests (which is _pretty close_ to `addCompletionBlockToTestOperation`):

```swift
let expectation = expectationWithDescription("Test: \(#function)")
operation.addCompletionBlock {
    let after = dispatch_time(DISPATCH_TIME_NOW, Int64(1.5 * Double(NSEC_PER_SEC)))
    dispatch_after(after, Queue.Main.queue) {
        expectation.fulfill()
    }
}
```