### PR TITLE
Made UserIntent enum objc accessbile

### DIFF
--- a/Sources/Core/Shared/Operation.swift
+++ b/Sources/Core/Shared/Operation.swift
@@ -66,7 +66,7 @@ public class Operation: NSOperation {
 
      - see: https://developer.apple.com/library/ios/documentation/Performance/Conceptual/EnergyGuide-iOS/PrioritizeWorkWithQoS.html#//apple_ref/doc/uid/TP40015243-CH39
     */
-    public enum UserIntent: Int {
+    @objc public enum UserIntent: Int {
         case None = 0, SideEffect, Initiated
 
         internal var qos: NSQualityOfService {


### PR DESCRIPTION
This fixes #339.

I've tested it inside my own project to make sure it is accessible to Objective-C code. Wasn't sure how to write a test in that since this project is just Swift.