### PR TITLE
Swift/3.0

### DIFF
--- a/Sources/Core/Shared/Support.swift
+++ b/Sources/Core/Shared/Support.swift
@@ -134,11 +134,7 @@ public extension DispatchQueue {
      - parameter block: a throwing block returning T.
      */
     func sync<T>(execute block: () throws -> T) rethrows -> T {
-        var result: T!
-        try sync {
-            result = try block()
-        }
-        return result
+		return try block()
     }
 }
 

--- a/Sources/Core/Shared/Support.swift
+++ b/Sources/Core/Shared/Support.swift
@@ -103,7 +103,7 @@ public enum Queue {
         return DispatchQueue(label: named, attributes: [.concurrent, qos_attributes])
     }
 }
-
+/*
 public extension DispatchQueue {
 
     /**
@@ -137,7 +137,7 @@ public extension DispatchQueue {
 		return try block()
     }
 }
-
+*/
 
 
 

--- a/Sources/Core/Shared/ThreadSafety.swift
+++ b/Sources/Core/Shared/ThreadSafety.swift
@@ -29,7 +29,7 @@ struct Lock: ReadWriteLock {
     }
 
     mutating func write(_ block: () -> Void, completion: (() -> Void)?) {
-        queue.async {
+		queue.async(flags: .barrier) {
             block()
             if let completion = completion {
                 Queue.main.queue.async(execute: completion)


### PR DESCRIPTION
I fixed some problems that were preventing my code from running under Swift 3.0.

1) In Support.swift, I first modified the code for DispatchQueue.sync to remove an endless loop where it called itself. Then I ended up commenting out the code. It seems to work whether it is commented out or not.

2) In ThreadSafety.swift I added the .barrier flag. Otherwise, spawned operations never launch because the observer does not get added or at least there is a race condition. 