### PR TITLE
Exposing the alert property as public for customization.

### DIFF
--- a/Sources/Core/iOS/AlertOperation.swift
+++ b/Sources/Core/iOS/AlertOperation.swift
@@ -35,7 +35,7 @@ public class AlertOperation<From: PresentingViewController>: Operation {
     private var uiOperation: UIOperation<UIAlertController, From>
 
     /// Access the presented `UIAlertController`.
-    private var alert: UIAlertController {
+    public var alert: UIAlertController {
         return uiOperation.controller
     }
 


### PR DESCRIPTION
This also fixes a bug where it wasn't possible to set a barButtonItem on an ActionSheet while presenting as a popover.