### PR TITLE
Fix for OperationQueue.delegate crash (SR-192)

### DIFF
--- a/Tests/Core/StressTests.swift
+++ b/Tests/Core/StressTests.swift
@@ -44,6 +44,46 @@ class StressTest: OperationTests {
         waitForOperation(operation)
         XCTAssertTrue(operation.didExecute)
     }
+    
+    func test__SR_192_OperationQueue_delegate_weak_var_thread_safety() {
+        //
+        // (SR-192): Weak properties are not thread safe when reading
+        // https://bugs.swift.org/browse/SR-192
+        //
+        // Affects: Swift < 3
+        // Fixed in: Swift 3.0+
+        // Without the code fix (marked with SR-192) in OperationQueue.swift, 
+        // this test will crash with EXC_BAD_ACCESS, or sometimes other errors.
+        //
+        class TestDelegate: OperationQueueDelegate {
+            func operationQueue(queue: OperationQueue, willAddOperation operation: NSOperation) { /* do nothing */ }
+            func operationQueue(queue: OperationQueue, willFinishOperation operation: NSOperation, withErrors errors: [ErrorType]) { /* do nothing */ }
+            func operationQueue(queue: OperationQueue, didFinishOperation operation: NSOperation, withErrors errors: [ErrorType]) { /* do nothing */ }
+        }
+        
+        let expectation = expectationWithDescription("Test: \(#function)")
+        var success = false
+        
+        dispatch_async(Queue.Initiated.queue) {
+            let group = dispatch_group_create()
+            for _ in 0..<1000000 {
+                let testQueue = OperationQueue()
+                testQueue.delegate = TestDelegate()
+                dispatch_group_async(group, dispatch_get_global_queue(0, 0), {
+                    let _ = testQueue.delegate
+                })
+                dispatch_group_async(group, dispatch_get_global_queue(0, 0), {
+                    let _ = testQueue.delegate
+                })
+            }
+            dispatch_group_wait(group,DISPATCH_TIME_FOREVER)
+            success = true
+            expectation.fulfill()
+        }
+        
+        waitForExpectationsWithTimeout(60, handler: nil)
+        XCTAssertTrue(success)
+    }
 
 }
 


### PR DESCRIPTION
##### Sometimes visible as:
`EXC_BAD_ACCESS` in `swift_unknownWeakLoadStrong`
`EXC_BAD_ACCESS` in `OSAtomicDequeue`
`EXC_BAD_ACCESS` in `swift_unknownWeakDestroy` [in OperationQueue.deinit]

##### Cause:
Race condition involving the weak `delegate` property of `OperationQueue`, caused by a bug in Swift:
[**(SR-192):** Weak properties are not thread safe when reading](https://bugs.swift.org/browse/SR-192)

Should be fixed in Swift 3.0+ (see https://github.com/apple/swift/pull/1454), but is not fixed in Swift 2.2.1/2.3 (and unlikely to be).

##### Simple, quick repro case:

```swift
class TestDelegate: OperationQueueDelegate {
    func operationQueue(queue: OperationQueue, willAddOperation operation: NSOperation) { /* do nothing */ }
    func operationQueue(queue: OperationQueue, willFinishOperation operation: NSOperation, withErrors errors: [ErrorType]) { /* do nothing */ }
    func operationQueue(queue: OperationQueue, didFinishOperation operation: NSOperation, withErrors errors: [ErrorType]) { /* do nothing */ }
}

for i in 0..<1000000 {
    print(i)
    let testQueue = OperationQueue()
    testQueue.delegate = TestDelegate()
    dispatch_async(dispatch_get_global_queue(0, 0), {
        let _ = testQueue.delegate
    })
    dispatch_async(dispatch_get_global_queue(0, 0), {
        let _ = testQueue.delegate
    })
}
```

##### Reproducible in practice:
_**YES.**_ Will sometimes take millions of GroupOperations until it triggers, but the crash is sporadically reproducible on two Macs here (dozens of times thus far).

##### Solution:
This PR wraps the public `delegate` property with an NSLock. It also sets it to nil first-thing in `deinit` to safely deinitialize it.

It avoids all of this on Swift 3.0+, where it shouldn’t be needed.* 
_*I haven't yet had a chance to test this on Swift 3.0._

##### Notes:

Because the issue can be triggered by concurrent reads of a weak property, the Protector class (Read/Write lock) is not appropriate.

Also adds `test__SR_192_OperationQueue_delegate_weak_var_thread_safety` to `StressTest.swift`.