### PR TITLE
"Operation: Thread Safety"

### DIFF
--- a/Operations.xcodeproj/project.pbxproj
+++ b/Operations.xcodeproj/project.pbxproj
@@ -312,6 +312,9 @@
 		65FD67B91CC389A5009E2C88 /* BlockOperationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65FD67B81CC389A5009E2C88 /* BlockOperationTests.swift */; };
 		65FD67BA1CC389A5009E2C88 /* BlockOperationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65FD67B81CC389A5009E2C88 /* BlockOperationTests.swift */; };
 		65FD67BB1CC389A5009E2C88 /* BlockOperationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65FD67B81CC389A5009E2C88 /* BlockOperationTests.swift */; };
+		EEBEC4F11D2C35F500769018 /* KVONotificationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEBEC4F01D2C35F500769018 /* KVONotificationTests.swift */; };
+		EEBEC4F21D2C35F500769018 /* KVONotificationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEBEC4F01D2C35F500769018 /* KVONotificationTests.swift */; };
+		EEBEC4F31D2C35F500769018 /* KVONotificationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEBEC4F01D2C35F500769018 /* KVONotificationTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -471,6 +474,7 @@
 		65FD67B11CC38877009E2C88 /* StressTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StressTests.swift; sourceTree = "<group>"; };
 		65FD67B31CC38933009E2C88 /* BasicTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BasicTests.swift; sourceTree = "<group>"; };
 		65FD67B81CC389A5009E2C88 /* BlockOperationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BlockOperationTests.swift; sourceTree = "<group>"; };
+		EEBEC4F01D2C35F500769018 /* KVONotificationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = KVONotificationTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -746,6 +750,7 @@
 				65C98C761C284EA600BA76B7 /* FunctionalOperationsTests.swift */,
 				6526170F1C11F5EB00654091 /* GatedOperationTests.swift */,
 				652617101C11F5EB00654091 /* GroupOperationTests.swift */,
+				EEBEC4F01D2C35F500769018 /* KVONotificationTests.swift */,
 				652617111C11F5EB00654091 /* LoggingObserverTests.swift */,
 				652617121C11F5EB00654091 /* LoggingTests.swift */,
 				652617131C11F5EB00654091 /* MutualExclusiveTests.swift */,
@@ -1340,6 +1345,7 @@
 				652619201C11FC3D00654091 /* ComposedOperationTests.swift in Sources */,
 				652619281C11FC3D00654091 /* NoFailedDependenciesConditionTests.swift in Sources */,
 				6565FFEA1C98C860008B5248 /* ProfilerTests.swift in Sources */,
+				EEBEC4F11D2C35F500769018 /* KVONotificationTests.swift in Sources */,
 				65C98C771C284EA600BA76B7 /* FunctionalOperationsTests.swift in Sources */,
 				652619251C11FC3D00654091 /* MutualExclusiveTests.swift in Sources */,
 				652619291C11FC3D00654091 /* OperationTests.swift in Sources */,
@@ -1480,6 +1486,7 @@
 				6526192F1C11FC3E00654091 /* BlockConditionTests.swift in Sources */,
 				652619301C11FC3E00654091 /* ComposedOperationTests.swift in Sources */,
 				652619381C11FC3E00654091 /* NoFailedDependenciesConditionTests.swift in Sources */,
+				EEBEC4F21D2C35F500769018 /* KVONotificationTests.swift in Sources */,
 				652619351C11FC3E00654091 /* MutualExclusiveTests.swift in Sources */,
 				65691C9F1C21A29C00AF06B4 /* ResultInjectionTests.swift in Sources */,
 				65B9E0821CB85C53009161AD /* URLSessionTaskOperationTests.swift in Sources */,
@@ -1571,6 +1578,7 @@
 				65C98C791C284EA600BA76B7 /* FunctionalOperationsTests.swift in Sources */,
 				652619451C11FC3F00654091 /* MutualExclusiveTests.swift in Sources */,
 				6526194D1C11FCFF00654091 /* AuthorizationTests.swift in Sources */,
+				EEBEC4F31D2C35F500769018 /* KVONotificationTests.swift in Sources */,
 				652619571C11FCFF00654091 /* ReachabilityTests.swift in Sources */,
 				65FD67B61CC38933009E2C88 /* BasicTests.swift in Sources */,
 				652619491C11FC3F00654091 /* OperationTests.swift in Sources */,

--- a/Sources/Core/Shared/GroupOperation.swift
+++ b/Sources/Core/Shared/GroupOperation.swift
@@ -8,6 +8,8 @@
 
 import Foundation
 
+// swiftlint:disable file_length
+
 /**
 An `Operation` subclass which enables the grouping
 of other operations. Use `GroupOperation`s to associate
@@ -256,7 +258,7 @@ public class GroupOperation: Operation, OperationQueueDelegate {
         if operation !== finishingOperation {
             groupFinishLock.withCriticalScope {
                 assert(!isGroupFinishing, "Cannot add new operations to a group after the group has started to finish.")
-                
+
                 willAddChildOperationObservers.forEach { $0.groupOperation(self, willAddChildOperation: operation) }
 
                 canFinishOperation.addDependency(operation)
@@ -424,9 +426,9 @@ private extension GroupOperation {
      - a CanFinishOperation which manages handling GroupOperation internal state and has every child
        operation as a dependency
      - a finishingOperation, which has the CanFinishOperation as a dependency
-     
-     The purpose of this is to handle the possibility that GroupOperation.addOperation() or 
-     GroupOperation.queue.addOperation() are called right after all current child operations have 
+
+     The purpose of this is to handle the possibility that GroupOperation.addOperation() or
+     GroupOperation.queue.addOperation() are called right after all current child operations have
      completed (i.e. after the CanFinishOperation has been set to ready), but *prior* to being able
      to process that the GroupOperation is finishing (i.e. prior to the CanFinishOperation executing and
      acquiring the GroupOperation.groupFinishLock to set state).
@@ -434,7 +436,7 @@ private extension GroupOperation {
     private class CanFinishOperation: NSOperation {
         private weak var parent: GroupOperation?
         private var _finished = false
-        
+
         init(parentGroupOperation: GroupOperation) {
             self.parent = parentGroupOperation
             super.init()
@@ -470,7 +472,7 @@ private extension GroupOperation {
                         // GroupOperation's new CanFinishOperation.
 
                         let newCanFinishOp = GroupOperation.CanFinishOperation(parentGroupOperation: parent)
-                        
+
                         nonFinishedOperations.forEach { op in
                             newCanFinishOp.addDependency(op)
                         }

--- a/Sources/Core/Shared/GroupOperation.swift
+++ b/Sources/Core/Shared/GroupOperation.swift
@@ -93,7 +93,7 @@ public class GroupOperation: Operation, OperationQueueDelegate {
      starting the queue, and adding the finishing operation.
     */
     public override func execute() {
-        addOperations(operations.filter { !self.queue.operations.contains($0) })
+        _addOperations(operations.filter { !self.queue.operations.contains($0) }, addToOperationsArray: false)
         queue.addOperation(finishingOperation)
         queue.suspended = false
     }
@@ -122,10 +122,16 @@ public class GroupOperation: Operation, OperationQueueDelegate {
      - parameter operations: an array of `NSOperation` instances.
      */
     public func addOperations(additional: [NSOperation]) {
+        _addOperations(additional, addToOperationsArray: true)
+    }
+
+    private func _addOperations(additional: [NSOperation], addToOperationsArray: Bool = true) {
         if additional.count > 0 {
             additional.forEachOperation { $0.log.severity = log.severity }
             queue.addOperations(additional)
-            operations.appendContentsOf(additional)
+            if addToOperationsArray {
+                operations.appendContentsOf(additional)
+            }
         }
     }
 

--- a/Sources/Core/Shared/GroupOperation.swift
+++ b/Sources/Core/Shared/GroupOperation.swift
@@ -81,7 +81,6 @@ public class GroupOperation: Operation, OperationQueueDelegate {
                     nsops.forEach { $0.cancel() }
                     ops.forEach { $0.cancelWithError(OperationError.ParentOperationCancelledWithErrors(errors)) }
                 }
-                self.queue.cancelAllOperations()
             }
         })
     }

--- a/Sources/Core/Shared/GroupOperation.swift
+++ b/Sources/Core/Shared/GroupOperation.swift
@@ -246,6 +246,19 @@ public class GroupOperation: Operation, OperationQueueDelegate {
             queue.suspended = true
         }
     }
+
+    public func operationQueue(queue: OperationQueue, willProduceOperation operation: NSOperation) {
+
+        // ensure that produced operations are added to GroupOperation's
+        // internal operations array (and cancelled if appropriate)
+        print("will produce operation: \(operation.operationName)")
+        stateLock.withCriticalScope {
+            if cancelled {
+                operation.cancel()
+            }
+            operations.append(operation)
+        }
+    }
 }
 
 public extension GroupOperation {

--- a/Sources/Core/Shared/GroupOperation.swift
+++ b/Sources/Core/Shared/GroupOperation.swift
@@ -166,17 +166,17 @@ public class GroupOperation: Operation, OperationQueueDelegate {
             }
 
             var handledCancelled = false
-            if self.cancelled {
+            if cancelled {
                 additional.forEachOperation { $0.cancel() }
                 handledCancelled = true
             }
-            let logSeverity = self.log.severity
+            let logSeverity = log.severity
             additional.forEachOperation { $0.log.severity = logSeverity }
 
-            self.queue.addOperations(additional)
+            queue.addOperations(additional)
 
             if addToOperationsArray {
-                self._operations.appendContentsOf(additional)
+                _operations.appendContentsOf(additional)
             }
 
             if !handledCancelled && self.cancelled {

--- a/Sources/Core/Shared/GroupOperation.swift
+++ b/Sources/Core/Shared/GroupOperation.swift
@@ -208,6 +208,8 @@ public class GroupOperation: Operation, OperationQueueDelegate {
      when there are no more operations in the group.
      */
     public func operationQueue(queue: OperationQueue, willAddOperation operation: NSOperation) {
+        guard queue === self.queue else { return }
+
         assert(!finishingOperation.executing, "Cannot add new operations to a group after the group has started to finish.")
         assert(!finishingOperation.finished, "Cannot add new operations to a group after the group has completed.")
 
@@ -225,6 +227,7 @@ public class GroupOperation: Operation, OperationQueueDelegate {
      notified (using `operationDidFinish` that a child operation has finished.
      */
     public func operationQueue(queue: OperationQueue, willFinishOperation operation: NSOperation, withErrors errors: [ErrorType]) {
+        guard queue === self.queue else { return }
 
         if !errors.isEmpty {
             if willAttemptRecoveryFromErrors(errors, inOperation: operation) {
@@ -240,6 +243,7 @@ public class GroupOperation: Operation, OperationQueueDelegate {
     }
 
     public func operationQueue(queue: OperationQueue, didFinishOperation operation: NSOperation, withErrors errors: [ErrorType]) {
+        guard queue === self.queue else { return }
 
         if operation === finishingOperation {
             finish(fatalErrors)
@@ -248,6 +252,7 @@ public class GroupOperation: Operation, OperationQueueDelegate {
     }
 
     public func operationQueue(queue: OperationQueue, willProduceOperation operation: NSOperation) {
+        guard queue === self.queue else { return }
 
         // ensure that produced operations are added to GroupOperation's
         // internal operations array (and cancelled if appropriate)

--- a/Sources/Core/Shared/GroupOperation.swift
+++ b/Sources/Core/Shared/GroupOperation.swift
@@ -179,7 +179,7 @@ public class GroupOperation: Operation, OperationQueueDelegate {
                 _operations.appendContentsOf(additional)
             }
 
-            if !handledCancelled && self.cancelled {
+            if !handledCancelled && cancelled {
                 // It is possible that the cancellation happened before adding the
                 // additional operations to the operations array.
                 // Thus, ensure that all additional operations are cancelled.

--- a/Sources/Core/Shared/GroupOperation.swift
+++ b/Sources/Core/Shared/GroupOperation.swift
@@ -70,8 +70,9 @@ public class GroupOperation: Operation, OperationQueueDelegate {
         queue.suspended = true
         queue.delegate = self
         userIntent = operations.userIntent
-        addObserver(WillCancelObserver { [unowned self] operation, errors in
+        addObserver(DidCancelObserver { [unowned self] operation in
             if operation === self {
+                let errors = operation.errors
                 if errors.isEmpty {
                     self.operations.forEach { $0.cancel() }
                 }

--- a/Sources/Core/Shared/Logging.swift
+++ b/Sources/Core/Shared/Logging.swift
@@ -238,19 +238,19 @@ class _Logger<Manager: LogManagerType>: LoggerType {
  current Logger (parentLogger) configuration at the time it is created.
  */
 class _LoggerOperationContext: LoggerType {
-    
+
     /// - returns: the log severity of this logger instance.
     var severity: LogSeverity
-    
+
     /// - returns: a `Bool` to enable/disable this logger instance. Defaults to true
     var enabled: Bool
-    
+
     /// - returns: a `LoggerBlockType` which receives the message to log
     var logger: LoggerBlockType
-    
+
     /// - returns: a String?, the name of the operation.
     var operationName: String? = .None
-    
+
     init(parentLogger: LoggerType, operationName: String) {
         self.operationName = operationName
         self.severity = parentLogger.severity
@@ -330,12 +330,12 @@ public class LogManager: LogManagerType {
 
     var logger: LoggerBlockType {
         get {
-            return logger_lock.read{ () -> LoggerBlockType in
+            return loggerLock.read { () -> LoggerBlockType in
                 return self._logger
             }
         }
         set {
-            logger_lock.write {
+            loggerLock.write {
                 self._logger = newValue
             }
         }
@@ -352,7 +352,7 @@ public class LogManager: LogManagerType {
     /// Private protected properties
     private var _severity: Protector<LogSeverity>
     private var _enabled: Protector<Bool>
-    private var logger_lock: ReadWriteLock = Lock()
+    private var loggerLock: ReadWriteLock = Lock()
     private var _logger: LoggerBlockType
 }
 

--- a/Sources/Core/Shared/Logging.swift
+++ b/Sources/Core/Shared/Logging.swift
@@ -233,6 +233,32 @@ class _Logger<Manager: LogManagerType>: LoggerType {
     }
 }
 
+/**
+ This is a simple class which owns a logging block and a copy of the
+ current Logger (parentLogger) configuration at the time it is created.
+ */
+class _LoggerOperationContext: LoggerType {
+    
+    /// - returns: the log severity of this logger instance.
+    var severity: LogSeverity
+    
+    /// - returns: a `Bool` to enable/disable this logger instance. Defaults to true
+    var enabled: Bool
+    
+    /// - returns: a `LoggerBlockType` which receives the message to log
+    var logger: LoggerBlockType
+    
+    /// - returns: a String?, the name of the operation.
+    var operationName: String? = .None
+    
+    init(parentLogger: LoggerType, operationName: String) {
+        self.operationName = operationName
+        self.severity = parentLogger.severity
+        self.enabled = parentLogger.enabled
+        self.logger = parentLogger.logger
+    }
+}
+
 typealias Logger = _Logger<LogManager>
 
 /**
@@ -284,11 +310,50 @@ public class LogManager: LogManagerType {
     }
 
     let queue = Queue.Utility.serial("me.danthorpe.Operations.Logger")
-    var enabled: Bool = true
-    var severity: LogSeverity = .Warning
-    var logger: LoggerBlockType = { message, severity, file, function, line in
-        print("\(LogManager.metadataForFile(file, function: function, line: line))\(message)")
+    var enabled: Bool {
+        get { return _enabled.read { $0 } }
+        set {
+            _enabled.write { (value) in
+                value = newValue
+            }
+        }
     }
+
+    var severity: LogSeverity {
+        get { return _severity.read { $0 } }
+        set {
+            _severity.write { (value) in
+                value = newValue
+            }
+        }
+    }
+
+    var logger: LoggerBlockType {
+        get {
+            return logger_lock.read{ () -> LoggerBlockType in
+                return self._logger
+            }
+        }
+        set {
+            logger_lock.write {
+                self._logger = newValue
+            }
+        }
+    }
+
+    init() {
+        _enabled = Protector<Bool>(true)
+        _severity = Protector<LogSeverity>(.Warning)
+        _logger = { message, severity, file, function, line in
+            print("\(LogManager.metadataForFile(file, function: function, line: line))\(message)")
+        }
+    }
+
+    /// Private protected properties
+    private var _severity: Protector<LogSeverity>
+    private var _enabled: Protector<Bool>
+    private var logger_lock: ReadWriteLock = Lock()
+    private var _logger: LoggerBlockType
 }
 
 public extension NSOperation {

--- a/Sources/Core/Shared/Operation.swift
+++ b/Sources/Core/Shared/Operation.swift
@@ -88,7 +88,7 @@ public class Operation: NSOperation {
     /// - returns: a unique String which can be used to identify the operation instance
     public let identifier = NSUUID().UUIDString
 
-    internal let stateLock = NSRecursiveLock()
+    private let stateLock = NSRecursiveLock()
     private var _log = Protector<LoggerType>(Logger())
     private var _state = State.Initialized
     private var _internalErrors = [ErrorType]()

--- a/Sources/Core/Shared/Operation.swift
+++ b/Sources/Core/Shared/Operation.swift
@@ -382,8 +382,6 @@ public class Operation: NSOperation {
             didChangeValueForKey(NSOperationKeyPaths.Cancelled.rawValue)
         }
     }
-        }
-    }
 }
 
 // swiftlint:enable type_body_length

--- a/Sources/Core/Shared/Operation.swift
+++ b/Sources/Core/Shared/Operation.swift
@@ -222,6 +222,17 @@ public class Operation: NSOperation {
      responsible for calling finish() in *ALL* cases, including when the
      operation is cancelled.
 
+     You can react to cancellation using WillCancelObserver/DidCancelObserver
+     and/or checking periodically during execute with something like:
+
+     ```swift
+     guard !cancelled else {
+        // do any necessary clean-up
+        finish()    // always call finish if automatic finishing is disabled
+        return
+     }
+     ```
+
     */
     public init(disableAutomaticFinishing: Bool) {
         self.disableAutomaticFinishing = disableAutomaticFinishing

--- a/Sources/Core/Shared/Operation.swift
+++ b/Sources/Core/Shared/Operation.swift
@@ -89,7 +89,7 @@ public class Operation: NSOperation {
     public let identifier = NSUUID().UUIDString
 
     internal let stateLock = NSRecursiveLock()
-    private lazy var _log: LoggerType = Logger()
+    private var _log = Protector<LoggerType>(Logger())
     private var _state = State.Initialized
     private var _internalErrors = [ErrorType]()
     private var _isTransitioningToExecuting = false
@@ -185,11 +185,13 @@ public class Operation: NSOperation {
     */
     public var log: LoggerType {
         get {
-            _log.operationName = operationName
-            return _log
+            let operationName = self.operationName
+            return _log.read { _LoggerOperationContext(parentLogger: $0, operationName: operationName) }
         }
         set {
-            _log = newValue
+            _log.write { (inout ward: LoggerType) in
+                ward = newValue
+            }
         }
     }
 

--- a/Sources/Core/Shared/Operation.swift
+++ b/Sources/Core/Shared/Operation.swift
@@ -578,6 +578,12 @@ public extension Operation {
         willExecuteObservers.forEach { $0.willExecuteOperation(self) }
         
         let doExecute = stateLock.withCriticalScope { () -> Bool in
+            assert(!executing, "Operation is attempting to execute, but is already executing.")
+            
+            // Check to see if the operation has now been finished 
+            // by an observer (or anything else)
+            guard state <= .Pending else { return false }
+            
             // Check to see if the operation has now been cancelled
             // by an observer
             guard (_internalErrors.isEmpty && !cancelled) || disableAutomaticFinishing else {

--- a/Sources/Core/Shared/OperationQueue.swift
+++ b/Sources/Core/Shared/OperationQueue.swift
@@ -114,8 +114,8 @@ public class OperationQueue: NSOperationQueue {
             operation.addObserver(ProducedOperationObserver { [weak self] op, produced in
                 if let q = self {
                     q.delegate?.operationQueue(q, willProduceOperation: produced)
+                    q.addOperation(produced)
                 }
-                self?.addOperation(produced)
             })
 
             /// Add an observer to invoke the will finish delegate method

--- a/Sources/Core/Shared/OperationQueue.swift
+++ b/Sources/Core/Shared/OperationQueue.swift
@@ -41,6 +41,16 @@ public protocol OperationQueueDelegate: class {
      - parameter errors: an array of `ErrorType`s.
      */
     func operationQueue(queue: OperationQueue, didFinishOperation operation: NSOperation, withErrors errors: [ErrorType])
+    
+    /**
+     The operation queue will add a new operation via produceOperation().
+     This is for information only, the delegate cannot affect whether the operation
+     is added, or other control flow.
+     
+     - paramter queue: the `OperationQueue`.
+     - paramter operation: the `NSOperation` instance about to be added.
+     */
+    func operationQueue(queue: OperationQueue, willProduceOperation operation: NSOperation)
 }
 
 /**
@@ -102,6 +112,9 @@ public class OperationQueue: NSOperationQueue {
 
             /// Add an observer so that any produced operations are added to the queue
             operation.addObserver(ProducedOperationObserver { [weak self] op, produced in
+                if let q = self {
+                    q.delegate?.operationQueue(q, willProduceOperation: produced)
+                }
                 self?.addOperation(produced)
             })
 

--- a/Sources/Core/Shared/OperationQueue.swift
+++ b/Sources/Core/Shared/OperationQueue.swift
@@ -41,12 +41,12 @@ public protocol OperationQueueDelegate: class {
      - parameter errors: an array of `ErrorType`s.
      */
     func operationQueue(queue: OperationQueue, didFinishOperation operation: NSOperation, withErrors errors: [ErrorType])
-    
+
     /**
      The operation queue will add a new operation via produceOperation().
      This is for information only, the delegate cannot affect whether the operation
      is added, or other control flow.
-     
+
      - paramter queue: the `OperationQueue`.
      - paramter operation: the `NSOperation` instance about to be added.
      */

--- a/Sources/Core/Shared/Queue.swift
+++ b/Sources/Core/Shared/Queue.swift
@@ -115,6 +115,50 @@ public enum Queue {
     public func concurrent(named: String) -> dispatch_queue_t {
         return dispatch_queue_create(named, dispatch_queue_attr_make_with_qos_class(DISPATCH_QUEUE_CONCURRENT, qos_class, QOS_MIN_RELATIVE_PRIORITY))
     }
+
+    /**
+     Initialize a Queue with a given NSQualityOfService.
+     
+     - parameter qos: a NSQualityOfService value
+     - returns: a Queue with an equivalent quality of service
+     */
+    public init(qos: NSQualityOfService) {
+        switch qos {
+        case .Background:
+            self = .Background
+        case .Default:
+            self = .Default
+        case .UserInitiated:
+            self = .Initiated
+        case .UserInteractive:
+            self = .Interactive
+        case .Utility:
+            self = .Utility
+        }
+    }
+
+    /**
+     Initialize a Queue with a given GCD quality of service class.
+     
+     - parameter qos: a qos_class_t value
+     - returns: a Queue with an equivalent quality of service
+     */
+    public init(qos: qos_class_t) {
+        switch qos {
+        case qos_class_main():
+            self = .Main
+        case QOS_CLASS_BACKGROUND:
+            self = .Background
+        case QOS_CLASS_USER_INITIATED:
+            self = .Initiated
+        case QOS_CLASS_USER_INTERACTIVE:
+            self = .Interactive
+        case QOS_CLASS_UTILITY:
+            self = .Utility
+        default:
+            self = .Default
+        }
+    }
 }
 
 internal let mainQueueScheduler = Queue.Scheduler(queue: Queue.Main.queue)

--- a/Sources/Core/Shared/RepeatedOperation.swift
+++ b/Sources/Core/Shared/RepeatedOperation.swift
@@ -299,6 +299,7 @@ public class RepeatedOperation<T where T: NSOperation>: GroupOperation {
      can prevent another operation from being added.
     */
     public func addNextOperation(@autoclosure shouldAddNext: () -> Bool = true) -> Bool {
+        guard !cancelled else { return false }
         guard shouldAddNext(), let payload = next() else { return false }
 
         log.verbose("will add next operation: \(payload.operation)")

--- a/Sources/Core/Shared/RepeatedOperation.swift
+++ b/Sources/Core/Shared/RepeatedOperation.swift
@@ -299,8 +299,7 @@ public class RepeatedOperation<T where T: NSOperation>: GroupOperation {
      can prevent another operation from being added.
     */
     public func addNextOperation(@autoclosure shouldAddNext: () -> Bool = true) -> Bool {
-        guard !cancelled else { return false }
-        guard shouldAddNext(), let payload = next() else { return false }
+        guard !cancelled && shouldAddNext(), let payload = next() else { return false }
 
         log.verbose("will add next operation: \(payload.operation)")
 

--- a/Sources/Extras/AddressBook/iOS/AddressBookOperations.swift
+++ b/Sources/Extras/AddressBook/iOS/AddressBookOperations.swift
@@ -20,11 +20,13 @@ public class AddressBookOperation: Operation {
     public override init() {
         registrar = SystemAddressBookRegistrar()
         addressBook = AddressBook(registrar: registrar)
+        super.init()
     }
 
     init(registrar: AddressBookPermissionRegistrar) {
         self.addressBook = AddressBook(registrar: registrar)
         self.registrar = registrar
+        super.init()
     }
 
     final func requestAccess() {

--- a/Tests/Core/BasicTests.swift
+++ b/Tests/Core/BasicTests.swift
@@ -466,10 +466,3 @@ private class TestHandlesFinishOperation: Operation {
     }
 }
 
-extension CollectionType {
-    /// Returns the element at the specified index if it is within bounds, otherwise nil.
-    func get(safe index: Index) -> Generator.Element? {
-        return indices.contains(index) ? self[index] : nil
-    }
-}
-}

--- a/Tests/Core/GroupOperationTests.swift
+++ b/Tests/Core/GroupOperationTests.swift
@@ -259,10 +259,10 @@ class GroupOperationTests: OperationTests {
         XCTAssertEqual(group.operations[0], child1)
     }
 
-    func test__group_operation__does_not_finish_before_child_blockoperations_are_finished() {
+    func test__group_operation__does_not_finish_before_child_operations_have_finished() {
         for _ in 0..<100 {
-            let child1 = BlockOperation { sleep(5) }
-            let child2 = BlockOperation { sleep(5) }
+            let child1 = TestOperation(delay: 1.0)
+            let child2 = TestOperation(delay: 1.0)
             let group = GroupOperation(operations: [ child1, child2 ])
 
             weak var expectation = expectationWithDescription("Test: \(#function)")
@@ -287,8 +287,14 @@ class GroupOperationTests: OperationTests {
 
     func test__group_operation__does_not_finish_before_child_groupoperations_are_finished() {
         for _ in 0..<100 {
-            let child1 = GroupOperation(operations: [BlockOperation { sleep(5) }])
-            let child2 = GroupOperation(operations: [BlockOperation { sleep(5) }])
+            let child1 = GroupOperation(operations: [BlockOperation { (continuation: BlockOperation.ContinuationBlockType) in
+                sleep(5)
+                continuation(error: nil)
+            }])
+            let child2 = GroupOperation(operations: [BlockOperation { (continuation: BlockOperation.ContinuationBlockType) in
+                sleep(5)
+                continuation(error: nil)
+            }])
             let group = GroupOperation(operations: [ child1, child2 ])
 
             weak var expectation = expectationWithDescription("Test: \(#function)")

--- a/Tests/Core/GroupOperationTests.swift
+++ b/Tests/Core/GroupOperationTests.swift
@@ -248,5 +248,15 @@ class GroupOperationTests: OperationTests {
         XCTAssertEqual(test2.userIntent, Operation.UserIntent.SideEffect)
         XCTAssertEqual(test3.qualityOfService, NSQualityOfService.UserInitiated)
     }
+
+    func test__group_operation__initial_operations_only_added_once_to_operations_array() {
+        let child1 = TestOperation()
+        let group = GroupOperation(operations: [child1])
+
+        waitForOperation(group)
+
+        XCTAssertEqual(group.operations.count, 1)
+        XCTAssertEqual(group.operations[0], child1)
+    }
 }
 

--- a/Tests/Core/KVONotificationTests.swift
+++ b/Tests/Core/KVONotificationTests.swift
@@ -1,0 +1,370 @@
+//
+//  KVONotificationTests.swift
+//  Operations
+//
+//  Created by swiftlyfalling on 03/07/2016.
+//  Copyright © 2016 swiftlyfalling. All rights reserved.
+//
+/*
+    The MIT License (MIT)
+
+    Copyright (c) 2016 swiftlyfalling
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE.
+*/
+//
+
+import XCTest
+@testable import Operations
+
+class OperationKVOTests: OperationTests {
+
+    class NSOperationKVOObserver: NSObject {
+
+        let operation: NSOperation
+        private var removedObserved = false
+        private var isFinishedBlock: (() -> Void)?
+
+        enum KeyPath: String {
+            case Cancelled = "isCancelled"
+            case Asynchronous = "isAsynchronous"
+            case Executing = "isExecuting"
+            case Finished = "isFinished"
+            case Ready = "isReady"
+            case Dependencies = "dependencies"
+            case QueuePriority = "queuePriority"
+            case CompletionBlock = "completionBlock"
+        }
+
+        struct KeyPathSets {
+            static let State = Set<String>([KeyPath.Cancelled.rawValue, KeyPath.Executing.rawValue, KeyPath.Finished.rawValue, KeyPath.Ready.rawValue])
+        }
+
+        struct KVONotification {
+            let keyPath: String
+            let time: NSTimeInterval
+        }
+        private var orderOfKVONotifications = Protector<[KVONotification]>([])
+
+
+        init(operation: NSOperation, isFinishedBlock: (() -> Void)? = nil) {
+            self.operation = operation
+            self.isFinishedBlock = isFinishedBlock
+            super.init()
+            operation.addObserver(self, forKeyPath: KeyPath.Cancelled.rawValue, options: [], context: &TestKVOOperationKVOContext)
+            operation.addObserver(self, forKeyPath: KeyPath.Asynchronous.rawValue, options: [], context: &TestKVOOperationKVOContext)
+            operation.addObserver(self, forKeyPath: KeyPath.Executing.rawValue, options: [], context: &TestKVOOperationKVOContext)
+            operation.addObserver(self, forKeyPath: KeyPath.Finished.rawValue, options: [], context: &TestKVOOperationKVOContext)
+            operation.addObserver(self, forKeyPath: KeyPath.Ready.rawValue, options: [], context: &TestKVOOperationKVOContext)
+            operation.addObserver(self, forKeyPath: KeyPath.Dependencies.rawValue, options: [], context: &TestKVOOperationKVOContext)
+            operation.addObserver(self, forKeyPath: KeyPath.QueuePriority.rawValue, options: [], context: &TestKVOOperationKVOContext)
+            operation.addObserver(self, forKeyPath: KeyPath.CompletionBlock.rawValue, options: [], context: &TestKVOOperationKVOContext)
+        }
+
+        deinit {
+            operation.removeObserver(self, forKeyPath: KeyPath.Cancelled.rawValue)
+            operation.removeObserver(self, forKeyPath: KeyPath.Asynchronous.rawValue)
+            operation.removeObserver(self, forKeyPath: KeyPath.Executing.rawValue)
+            operation.removeObserver(self, forKeyPath: KeyPath.Finished.rawValue)
+            operation.removeObserver(self, forKeyPath: KeyPath.Ready.rawValue)
+            operation.removeObserver(self, forKeyPath: KeyPath.Dependencies.rawValue)
+            operation.removeObserver(self, forKeyPath: KeyPath.QueuePriority.rawValue)
+            operation.removeObserver(self, forKeyPath: KeyPath.CompletionBlock.rawValue)
+        }
+
+        var observedKVO: [KVONotification] {
+            return orderOfKVONotifications.read { array in return array }
+        }
+
+        func observedKVOFor(keyPaths: Set<String>) -> [KVONotification] {
+            return observedKVO.filter({ (notification) -> Bool in
+                keyPaths.contains(notification.keyPath)
+            })
+        }
+
+        var frequencyOfKVOKeyPaths: [String: Int] {
+            return observedKVO.reduce([:]) { (accu: [String: Int], element) in
+                let keyPath = element.keyPath
+                var accu = accu
+                accu[keyPath] = accu[keyPath]?.successor() ?? 1
+                return accu
+            }
+        }
+
+        override func observeValueForKeyPath(keyPath: String?, ofObject object: AnyObject?, change: [String : AnyObject]?, context: UnsafeMutablePointer<Void>) {
+
+            guard context == &TestKVOOperationKVOContext else {
+                super.observeValueForKeyPath(keyPath, ofObject: object, change: change, context: context)
+                return
+            }
+            guard object === operation else { return }
+            guard let keyPath = keyPath else { return }
+            if let isFinishedBlock = self.isFinishedBlock where keyPath == KeyPath.Finished.rawValue {
+                orderOfKVONotifications.write( { (array) -> Void in
+                    array.append(KVONotification(keyPath: keyPath, time: NSDate().timeIntervalSinceReferenceDate))
+                    }, completion: {
+                        isFinishedBlock()   // write completion is executed on main queue
+                })
+            }
+            else {
+                orderOfKVONotifications.write { (array) -> Void in
+                    array.append(KVONotification(keyPath: keyPath, time: NSDate().timeIntervalSinceReferenceDate))
+                }
+            }
+        }
+    }
+
+
+    func test__nsoperation_kvo__operation_state_transition_from_initializing_to_pending() {
+        let operation = TestOperation()
+        let kvoObserver = NSOperationKVOObserver(operation: operation)
+        operation.willEnqueue() // trigger state transition from .Initializing -> .Pending
+        let observedKVO = kvoObserver.observedKVOFor(NSOperationKVOObserver.KeyPathSets.State)
+        XCTAssertEqual(observedKVO.count, 0)    // should be no KVO notification on any NSOperation keyPaths for this internal state transition
+    }
+
+    func test__nsoperation_kvo__operation_state_transition_to_executing() {
+        class NoFinishOperation: Operation {
+            override func execute() {
+                // do not finish
+            }
+        }
+        let operation = NoFinishOperation()
+        let kvoObserver = NSOperationKVOObserver(operation: operation)
+        operation.willEnqueue() // trigger state transition from .Initializing -> .Pending
+        operation.start() // trigger state transition from .Pending -> .Executing
+
+        let observedKVO = kvoObserver.observedKVOFor(NSOperationKVOObserver.KeyPathSets.State)
+        // should be a single KVO notification for NSOperation keyPath "isExecuting" for this internal state transition
+        XCTAssertEqual(observedKVO.count, 1)
+        XCTAssertEqual(observedKVO.get(safe: 0)?.keyPath, NSOperationKVOObserver.KeyPath.Executing.rawValue)
+    }
+
+    func test__nsoperation_kvo__operation_state_transition_to_executing_via_queue() {
+        class NoFinishOperation: Operation {
+            var didExecuteExpectation: XCTestExpectation
+            init(didExecuteExpectation: XCTestExpectation) {
+                self.didExecuteExpectation = didExecuteExpectation
+                super.init()
+            }
+            override func execute() {
+                didExecuteExpectation.fulfill()
+                // do not finish
+            }
+        }
+        let didExecuteExpectation = expectationWithDescription("Test: \(#function); DidExecute")
+        let operation = NoFinishOperation(didExecuteExpectation: didExecuteExpectation)
+        let kvoObserver = NSOperationKVOObserver(operation: operation)
+        runOperation(operation) // trigger state transition from .Initializing -> .Executing via the queue
+
+        waitForExpectationsWithTimeout(5, handler: nil)
+
+        let observedKVO = kvoObserver.observedKVOFor(NSOperationKVOObserver.KeyPathSets.State)
+        // should be a single KVO notification for NSOperation keyPath "isExecuting" for this internal state transition
+        XCTAssertEqual(observedKVO.count, 1)
+        XCTAssertEqual(observedKVO.get(safe: 0)?.keyPath, NSOperationKVOObserver.KeyPath.Executing.rawValue)
+
+        addCompletionBlockToTestOperation(operation, withExpectation: expectationWithDescription("Test: \(#function); Did Complete Operation"))
+        operation.finish()
+        waitForExpectationsWithTimeout(5, handler: nil)
+    }
+
+    func test__nsoperation_kvo__operation_cancel_from_initialized() {
+        let operation = TestOperation()
+        let kvoObserver = NSOperationKVOObserver(operation: operation)
+        operation.cancel()
+
+        let observedKVO = kvoObserver.observedKVOFor(NSOperationKVOObserver.KeyPathSets.State)
+        // NOTE: To fully match NSOperation, this should be 2 KVO notifications, in the order: isCancelled, isReady
+        // Because Operation handles cancelled status internally *and* calls super.cancel (to trigger Ready status change),
+        // a total of 3 KVO notifications are generated in the order: isCancelled, isReady, isCancelled
+        // The following tests the first two only.
+        XCTAssertGreaterThanOrEqual(observedKVO.count, 2)
+        XCTAssertEqual(observedKVO.get(safe: 0)?.keyPath, NSOperationKVOObserver.KeyPath.Cancelled.rawValue)
+        XCTAssertEqual(observedKVO.get(safe: 1)?.keyPath, NSOperationKVOObserver.KeyPath.Ready.rawValue)
+    }
+
+    func test__nsoperation_kvo__groupoperation_cancel_from_initialized() {
+        let child = TestOperation(delay: 1.0)
+        let group = GroupOperation(operations: [child])
+        let kvoObserver = NSOperationKVOObserver(operation: group)
+        group.cancel()
+
+        let observedKVO = kvoObserver.observedKVOFor(NSOperationKVOObserver.KeyPathSets.State)
+        // NOTE: To fully match NSOperation, this should be 2 KVO notifications, in the order: isCancelled, isReady
+        // Because Operation handles cancelled status internally *and* calls super.cancel (to trigger Ready status change),
+        // a total of 3 KVO notifications are generated in the order: isCancelled, isReady, isCancelled
+        // The following tests the first two only.
+        XCTAssertGreaterThanOrEqual(observedKVO.count, 2)
+        XCTAssertEqual(observedKVO.get(safe: 0)?.keyPath, NSOperationKVOObserver.KeyPath.Cancelled.rawValue)
+        XCTAssertEqual(observedKVO.get(safe: 1)?.keyPath, NSOperationKVOObserver.KeyPath.Ready.rawValue)
+    }
+
+    func test__nsoperation_kvo__groupoperation_child_cancel_from_initialized() {
+        let child = TestOperation(delay: 1.0)
+        let group = GroupOperation(operations: [child])
+        let kvoObserver = NSOperationKVOObserver(operation: child)
+        group.cancel()
+
+        let observedKVO = kvoObserver.observedKVOFor(NSOperationKVOObserver.KeyPathSets.State)
+        // NOTE: To fully match NSOperation, this should be 2 KVO notifications, in the order: isCancelled, isReady
+        // Because Operation handles cancelled status internally *and* calls super.cancel (to trigger Ready status change),
+        // a total of 3 KVO notifications are generated in the order: isCancelled, isReady, isCancelled
+        // The following tests the first two only.
+        XCTAssertGreaterThanOrEqual(observedKVO.count, 2)
+        XCTAssertEqual(observedKVO.get(safe: 0)?.keyPath, NSOperationKVOObserver.KeyPath.Cancelled.rawValue)
+        XCTAssertEqual(observedKVO.get(safe: 1)?.keyPath, NSOperationKVOObserver.KeyPath.Ready.rawValue)
+    }
+
+    func test__nsoperation_kvo__nsoperation_cancel_from_initialized() {
+        let operation = NSBlockOperation { }
+        let kvoObserver = NSOperationKVOObserver(operation: operation)
+        operation.cancel()
+
+        let observedKVO = kvoObserver.observedKVOFor(NSOperationKVOObserver.KeyPathSets.State)
+        XCTAssertEqual(observedKVO.count, 2)
+        XCTAssertEqual(observedKVO.get(safe: 0)?.keyPath, NSOperationKVOObserver.KeyPath.Cancelled.rawValue)
+        XCTAssertEqual(observedKVO.get(safe: 1)?.keyPath, NSOperationKVOObserver.KeyPath.Ready.rawValue)
+    }
+
+    func test__nsoperation_kvo__operation_cancelled_to_completion() {
+        weak var expectationIsFinishedKVO = expectationWithDescription("Test: \(#function); Did Receive isFinished KVO Notification")
+        let operation = TestOperation()
+        let kvoObserver = NSOperationKVOObserver(operation: operation,
+                                                 isFinishedBlock: {
+                                                    guard let expectationIsFinishedKVO = expectationIsFinishedKVO else { return }
+                                                    expectationIsFinishedKVO.fulfill()
+        })
+        operation.cancel()
+        waitForOperation(operation)
+
+        let observedKVO = kvoObserver.observedKVOFor(NSOperationKVOObserver.KeyPathSets.State)
+        let keyPathFrequency = kvoObserver.frequencyOfKVOKeyPaths
+
+        XCTAssertGreaterThanOrEqual(observedKVO.count, 3)
+
+        // first two KVO notifications should be isCancelled and isReady
+        XCTAssertEqual(observedKVO.get(safe: 0)?.keyPath, NSOperationKVOObserver.KeyPath.Cancelled.rawValue)
+        XCTAssertEqual(observedKVO.get(safe: 1)?.keyPath, NSOperationKVOObserver.KeyPath.Ready.rawValue)
+
+        // it is valid, but not necessary, for a cancelled operation to transition through isExecuting
+
+        // last KVO notification should always be isFinished
+        XCTAssertEqual(observedKVO.last?.keyPath, NSOperationKVOObserver.KeyPath.Finished.rawValue, "Notifications were: \(observedKVO)")
+
+        // isFinished should only be sent once
+        XCTAssertEqual(keyPathFrequency[NSOperationKVOObserver.KeyPath.Finished.rawValue], 1)
+    }
+
+    func test__nsoperation_kvo__groupoperation_cancelled_to_completion() {
+        weak var expectationIsFinishedKVO = expectationWithDescription("Test: \(#function); Did Receive isFinished KVO Notification")
+        let child = TestOperation(delay: 1.0)
+        let group = GroupOperation(operations: [child])
+        let kvoObserver = NSOperationKVOObserver(operation: group,
+                                                 isFinishedBlock: {
+                                                    guard let expectationIsFinishedKVO = expectationIsFinishedKVO else { return }
+                                                    expectationIsFinishedKVO.fulfill()
+        })
+        group.cancel()
+        waitForOperation(group)
+
+        let observedKVO = kvoObserver.observedKVOFor(NSOperationKVOObserver.KeyPathSets.State)
+        let keyPathFrequency = kvoObserver.frequencyOfKVOKeyPaths
+
+        XCTAssertGreaterThanOrEqual(observedKVO.count, 3)
+
+        // first two KVO notifications should be isCancelled and isReady
+        XCTAssertEqual(observedKVO.get(safe: 0)?.keyPath, NSOperationKVOObserver.KeyPath.Cancelled.rawValue)
+        XCTAssertEqual(observedKVO.get(safe: 1)?.keyPath, NSOperationKVOObserver.KeyPath.Ready.rawValue)
+
+        // it is valid, but not necessary, for a cancelled operation to transition through isExecuting
+
+        // last KVO notification should always be isFinished
+        XCTAssertEqual(observedKVO.last?.keyPath, NSOperationKVOObserver.KeyPath.Finished.rawValue)
+
+        // isFinished should only be sent once
+        XCTAssertEqual(keyPathFrequency[NSOperationKVOObserver.KeyPath.Finished.rawValue], 1)
+    }
+
+    func test__nsoperation_kvo__operation_execute_to_completion() {
+        weak var expectationIsFinishedKVO = expectationWithDescription("Test: \(#function); Did Receive isFinished KVO Notification")
+        let operation = TestOperation()
+        let kvoObserver = NSOperationKVOObserver(operation: operation,
+                                                 isFinishedBlock: {
+                                                    guard let expectationIsFinishedKVO = expectationIsFinishedKVO else { return }
+                                                    expectationIsFinishedKVO.fulfill()
+        })
+        waitForOperation(operation)
+
+        let observedKVO = kvoObserver.observedKVOFor(NSOperationKVOObserver.KeyPathSets.State)
+        XCTAssertEqual(observedKVO.count, 3)
+        XCTAssertEqual(observedKVO.get(safe: 0)?.keyPath, NSOperationKVOObserver.KeyPath.Executing.rawValue)
+        XCTAssertEqual(observedKVO.get(safe: 1)?.keyPath, NSOperationKVOObserver.KeyPath.Executing.rawValue)
+        XCTAssertEqual(observedKVO.get(safe: 2)?.keyPath, NSOperationKVOObserver.KeyPath.Finished.rawValue)
+    }
+
+    func test__nsoperation_kvo__groupoperation_execute_to_completion() {
+        weak var expectationIsFinishedKVO = expectationWithDescription("Test: \(#function); Did Receive isFinished KVO Notification")
+        let child = TestOperation(delay: 1.0)
+        let group = GroupOperation(operations: [child])
+        let kvoObserver = NSOperationKVOObserver(operation: group,
+                                                 isFinishedBlock: {
+                                                    guard let expectationIsFinishedKVO = expectationIsFinishedKVO else { return }
+                                                    expectationIsFinishedKVO.fulfill()
+        })
+        waitForOperation(group)
+
+        let observedKVO = kvoObserver.observedKVOFor(NSOperationKVOObserver.KeyPathSets.State)
+        XCTAssertEqual(observedKVO.count, 3)
+        XCTAssertEqual(observedKVO.get(safe: 0)?.keyPath, NSOperationKVOObserver.KeyPath.Executing.rawValue)
+        XCTAssertEqual(observedKVO.get(safe: 1)?.keyPath, NSOperationKVOObserver.KeyPath.Executing.rawValue)
+        XCTAssertEqual(observedKVO.get(safe: 2)?.keyPath, NSOperationKVOObserver.KeyPath.Finished.rawValue)
+    }
+
+    func test__nsoperation_kvo__operation_execute_with_dependencies_to_completion() {
+        weak var expectationIsFinishedKVO = expectationWithDescription("Test: \(#function); Did Receive isFinished KVO Notification")
+        let delay = DelayOperation(interval: 0.1)
+        let operation = TestOperation()
+        let kvoObserver = NSOperationKVOObserver(operation: operation,
+                                                 isFinishedBlock: {
+                                                    guard let expectationIsFinishedKVO = expectationIsFinishedKVO else { return }
+                                                    expectationIsFinishedKVO.fulfill()
+        })
+        operation.addDependency(delay)
+        waitForOperations(delay, operation)
+
+        let observedKVO = kvoObserver.observedKVOFor(NSOperationKVOObserver.KeyPathSets.State.union([NSOperationKVOObserver.KeyPath.Dependencies.rawValue]))
+        XCTAssertEqual(observedKVO.count, 6)
+        XCTAssertEqual(observedKVO.get(safe: 0)?.keyPath, NSOperationKVOObserver.KeyPath.Ready.rawValue)
+        XCTAssertEqual(observedKVO.get(safe: 1)?.keyPath, NSOperationKVOObserver.KeyPath.Dependencies.rawValue)
+        XCTAssertEqual(observedKVO.get(safe: 2)?.keyPath, NSOperationKVOObserver.KeyPath.Ready.rawValue)
+        XCTAssertEqual(observedKVO.get(safe: 3)?.keyPath, NSOperationKVOObserver.KeyPath.Executing.rawValue)
+        XCTAssertEqual(observedKVO.get(safe: 4)?.keyPath, NSOperationKVOObserver.KeyPath.Executing.rawValue)
+        XCTAssertEqual(observedKVO.get(safe: 5)?.keyPath, NSOperationKVOObserver.KeyPath.Finished.rawValue)
+    }
+}
+
+extension CollectionType {
+    /// Returns the element at the specified index if it is within bounds, otherwise nil.
+    func get(safe index: Index) -> Generator.Element? {
+        return indices.contains(index) ? self[index] : nil
+    }
+}
+
+private var TestKVOOperationKVOContext = 0

--- a/Tests/Core/OperationTests.swift
+++ b/Tests/Core/OperationTests.swift
@@ -116,6 +116,7 @@ class TestQueueDelegate: OperationQueueDelegate {
     var did_willAddOperation: Bool = false
     var did_operationWillFinish: Bool = false
     var did_operationDidFinish: Bool = false
+    var did_willProduceOperation: Bool = false
     var did_numberOfErrorThatOperationDidFinish: Int = 0
 
     init(willFinishOperation: FinishBlockType? = .None, didFinishOperation: FinishBlockType? = .None) {
@@ -137,6 +138,10 @@ class TestQueueDelegate: OperationQueueDelegate {
         did_operationDidFinish = true
         did_numberOfErrorThatOperationDidFinish = errors.count
         didFinishOperation?(operation, errors)
+    }
+    
+    func operationQueue(queue: OperationQueue, willProduceOperation operation: NSOperation) {
+        did_willProduceOperation = true
     }
 }
 

--- a/Tests/Core/StressTests.swift
+++ b/Tests/Core/StressTests.swift
@@ -12,6 +12,7 @@ import XCTest
 
 class StressTest: OperationTests {
 
+    let batches = 1
     let batchSize = 10_000
 
     func test__completion_blocks() {
@@ -60,6 +61,7 @@ class StressTest: OperationTests {
             func operationQueue(queue: OperationQueue, willAddOperation operation: NSOperation) { /* do nothing */ }
             func operationQueue(queue: OperationQueue, willFinishOperation operation: NSOperation, withErrors errors: [ErrorType]) { /* do nothing */ }
             func operationQueue(queue: OperationQueue, didFinishOperation operation: NSOperation, withErrors errors: [ErrorType]) { /* do nothing */ }
+            func operationQueue(queue: OperationQueue, willProduceOperation operation: NSOperation) { /* do nothing */ }
         }
         
         let expectation = expectationWithDescription("Test: \(#function)")
@@ -85,6 +87,263 @@ class StressTest: OperationTests {
         waitForExpectationsWithTimeout(60, handler: nil)
         XCTAssertTrue(success)
     }
+    
+    class Counter {
+        private(set) var count: Int32 = 0
+        func increment() -> Int32 {
+            return OSAtomicIncrement32(&count)
+        }
+        func increment_barrier() -> Int32 {
+            return OSAtomicIncrement32Barrier(&count)
+        }
+    }
 
+    func test__block_operation_cancel() {
+        let batchTimeout = Double(batchSize) / 750.0
+        print ("\(#function): Parameters: batch size: \(batchSize); batches: \(batches)")
+        assert(batchSize <= Int(Int32.max), "Test uses OSAtomicIncrement32, and doesn't support batchSize > Int32.max")
+        // NOTE: This test previously crashed most commonly with EXC_BAD_ACCESS.
+
+        (1...batches).forEach { batch in
+            autoreleasepool {
+                let batchStartTime = CFAbsoluteTimeGetCurrent()
+                let cancelCount = Counter()
+                let finishCount = Counter()
+                let operationDispatchGroup = dispatch_group_create()
+                weak var didFinishAllOperationsExpectation = expectationWithDescription("Test: \(#function), Finished All Operations, batch \(batch)")
+
+                (0..<batchSize).forEach { i in
+                    dispatch_group_enter(operationDispatchGroup)
+                    let operationFinishCount = Counter()
+                    let operationCancelCount = Counter()
+                    let operation = BlockOperation { usleep(500) }
+                    operation.addObserver(DidCancelObserver(didCancel: { (operation) in
+                        operationCancelCount.increment_barrier()
+                        cancelCount.increment()
+                    }))
+                    operation.addObserver(DidFinishObserver(didFinish: { (operation, errors) in
+                        let newValue = operationFinishCount.increment_barrier()
+                        finishCount.increment_barrier()
+                        if newValue == 1 {
+                            dispatch_group_leave(operationDispatchGroup)
+                        }
+                    }))
+                    self.queue.addOperation(operation)
+                    operation.cancel()
+                }
+
+                dispatch_group_notify(operationDispatchGroup, dispatch_get_main_queue(), {
+                    guard let didFinishAllOperationsExpectation = didFinishAllOperationsExpectation else { print("Test: \(#function): Finished operations after timeout"); return }
+                    didFinishAllOperationsExpectation.fulfill()
+                })
+                waitForExpectationsWithTimeout(batchTimeout, handler: nil)
+                XCTAssertEqual(Int(cancelCount.count), batchSize)
+                XCTAssertEqual(Int(finishCount.count), batchSize)
+                let batchFinishTime = CFAbsoluteTimeGetCurrent()
+                let batchDuration = batchFinishTime - batchStartTime
+                print ("\(#function): Finished batch: \(batch), in \(batchDuration) seconds")
+            }
+        }
+    }
+
+    func test__group_operation_cancel() {
+        let batchTimeout = Double(batchSize) / 750.0
+        print ("\(#function): Parameters: batch size: \(batchSize); batches: \(batches)")
+
+        (1...batches).forEach { batch in
+            autoreleasepool {
+                let batchStartTime = CFAbsoluteTimeGetCurrent()
+                let queue = OperationQueue()
+                queue.suspended = false
+                let finishCount = Counter()
+                let operationDispatchGroup = dispatch_group_create()
+                weak var didFinishAllOperationsExpectation = expectationWithDescription("Test: \(#function), Finished All Operations, batch \(batch)")
+
+                (0..<batchSize).forEach { _ in
+                    dispatch_group_enter(operationDispatchGroup)
+                    let operationFinishCount = Counter()
+                    let currentGroupOperation = GroupOperation(operations: [TestOperation(delay: 0.0)])
+                    currentGroupOperation.addObserver(DidFinishObserver(didFinish: { (operation, errors) in
+                        let newValue = operationFinishCount.increment_barrier()
+                        finishCount.increment_barrier()
+                        if newValue == 1 {
+                            dispatch_group_leave(operationDispatchGroup)
+                        }
+                    }))
+                    queue.addOperation(currentGroupOperation)
+                    currentGroupOperation.cancel()
+                }
+
+                dispatch_group_notify(operationDispatchGroup, dispatch_get_main_queue(), {
+                    guard let didFinishAllOperationsExpectation = didFinishAllOperationsExpectation else { print("Test: \(#function): Finished operations after timeout"); return }
+                    didFinishAllOperationsExpectation.fulfill()
+                })
+                waitForExpectationsWithTimeout(batchTimeout, handler: nil)
+                XCTAssertEqual(Int(finishCount.count), batchSize)
+                let batchFinishTime = CFAbsoluteTimeGetCurrent()
+                let batchDuration = batchFinishTime - batchStartTime
+                print ("\(#function): Finished batch: \(batch), in \(batchDuration) seconds")
+            }
+        }
+    }
+
+    func test__group_operation_cancel_and_add_operation() {
+        let batchTimeout = Double(batchSize) / 333.0
+        print ("\(#function): Parameters: batch size: \(batchSize); batches: \(batches)")
+        
+        final class TestGroupOperation_AddOperationAfterSuperInit: GroupOperation {
+            let operationsToAddOnExecute: [NSOperation]
+            init(operations: [NSOperation], operationsToAddOnExecute: [NSOperation]) {
+                self.operationsToAddOnExecute = operationsToAddOnExecute
+                super.init(operations:[])
+                self.name = "TestGroupOperation_AddOperationAfterSuperInit"
+                self.addOperations(operations)  // add operations in init, after super.init()
+            }
+            
+            override func execute() {
+                addOperations(operationsToAddOnExecute) // add operations in execute
+                super.execute()
+            }
+        }
+
+        (1...batches).forEach { batch in
+            autoreleasepool {
+                let batchStartTime = CFAbsoluteTimeGetCurrent()
+                let queue = OperationQueue()
+                queue.suspended = false
+                let operationDispatchGroup = dispatch_group_create()
+                weak var didFinishAllOperationsExpectation = expectationWithDescription("Test: \(#function), Finished All Operations, batch \(batch)")
+
+                (0..<batchSize).forEach { i in
+                    dispatch_group_enter(operationDispatchGroup)
+                    let currentGroupOperation = TestGroupOperation_AddOperationAfterSuperInit(operations: [TestOperation()], operationsToAddOnExecute: [TestOperation()])
+                    currentGroupOperation.addCompletionBlock({
+                        dispatch_group_leave(operationDispatchGroup)
+                    })
+                    queue.addOperation(currentGroupOperation)
+                    currentGroupOperation.cancel()
+                }
+
+                dispatch_group_notify(operationDispatchGroup, dispatch_get_main_queue(), {
+                    guard let didFinishAllOperationsExpectation = didFinishAllOperationsExpectation else { print("Test: \(#function): Finished operations after timeout"); return }
+                    didFinishAllOperationsExpectation.fulfill()
+                })
+                waitForExpectationsWithTimeout(batchTimeout, handler: nil)
+                let batchFinishTime = CFAbsoluteTimeGetCurrent()
+                let batchDuration = batchFinishTime - batchStartTime
+                print ("\(#function): Finished batch: \(batch), in \(batchDuration) seconds")
+            }
+        }
+    }
+
+    func test__repeated_operation_cancel() {
+        let batchTimeout = Double(batchSize) / 333.0
+        print ("\(#function): Parameters: batch size: \(batchSize); batches: \(batches)")
+        
+        final class TestOperation3: Operation, Repeatable {
+            init(number: Int) {
+                super.init()
+                name = "TestOperation3_\(number)"
+            }
+            
+            override func execute() {
+                guard !cancelled else { return }
+                sleep(1)
+                finish()
+                return
+            }
+            
+            func shouldRepeat(count: Int) -> Bool {
+                return true
+            }
+        }
+        
+        (1...batches).forEach { batch in
+            autoreleasepool {
+                let batchStartTime = CFAbsoluteTimeGetCurrent()
+                let queue = OperationQueue()
+                queue.suspended = false
+                let operationDispatchGroup = dispatch_group_create()
+                weak var didCreateAllOperationsExpectation = expectationWithDescription("Test: \(#function), Finished Creating Operations, batch \(batch)")
+                weak var didFinishAllOperationsExpectation = expectationWithDescription("Test: \(#function), Finished All Operations, batch \(batch)")
+                
+                let batchSize = self.batchSize
+                dispatch_async(Queue.Default.queue) {
+                    (0..<batchSize).forEach { i in
+                        dispatch_group_enter(operationDispatchGroup)
+                        
+                        let currentGroupOperation = RepeatedOperation<TestOperation3>(strategy: WaitStrategy.Immediate, generator: AnyGenerator(body: { TestOperation3(number: i)
+                        }))
+                        currentGroupOperation.qualityOfService = NSQualityOfService.Default
+                        currentGroupOperation.name = "RepeatedOperation_\(i)"
+                        currentGroupOperation.addCompletionBlock({
+                            dispatch_group_leave(operationDispatchGroup)
+                        })
+                        
+                        queue.addOperation(currentGroupOperation)
+                        currentGroupOperation.cancel()
+                    }
+                    guard let didCreateAllOperationsExpectation = didCreateAllOperationsExpectation else { print("Test: \(#function): Finished creating operations after timeout"); return }
+                    didCreateAllOperationsExpectation.fulfill()
+                }
+
+                dispatch_group_notify(operationDispatchGroup, dispatch_get_main_queue(), {
+                    guard let didFinishAllOperationsExpectation = didFinishAllOperationsExpectation else { print("Test: \(#function): Finished operations after timeout"); return }
+                    didFinishAllOperationsExpectation.fulfill()
+                })
+                waitForExpectationsWithTimeout(batchTimeout, handler: nil)
+                let batchFinishTime = CFAbsoluteTimeGetCurrent()
+                let batchDuration = batchFinishTime - batchStartTime
+                print ("\(#function): Finished batch: \(batch), in \(batchDuration) seconds")
+            }
+        }
+    }
+
+    func test__group_operation__does_not_finish_before_child_operations_are_finished() {
+        let batchTimeout = Double(batchSize) / 750.0
+        print ("\(#function): Parameters: batch size: \(batchSize); batches: \(batches)")
+        
+        (1...batches).forEach { batch in
+            autoreleasepool {
+                let batchStartTime = CFAbsoluteTimeGetCurrent()
+                let child1FinishCount = Counter()
+                let child2FinishCount = Counter()
+                let operationDispatchGroup = dispatch_group_create()
+                weak var didFinishAllOperationsExpectation = expectationWithDescription("Test: \(#function), Finished All Operations, batch \(batch)")
+                
+                (0..<batchSize).forEach { i in
+                    dispatch_group_enter(operationDispatchGroup)
+                    
+                    let child1 = TestOperation(delay: 0.4)
+                    let child2 = TestOperation(delay: 0.4)
+                    let group = GroupOperation(operations: [ child1, child2 ])
+
+                    group.addCompletionBlock {
+                        let child1Finished = child1.finished
+                        let child2Finished = child2.finished
+                        if child1Finished { child1FinishCount.increment_barrier() }
+                        if child2Finished { child2FinishCount.increment_barrier() }
+                        dispatch_group_leave(operationDispatchGroup)
+                    }
+                    
+                    runOperation(group)
+                    group.cancel()
+                }
+                
+                dispatch_group_notify(operationDispatchGroup, dispatch_get_main_queue(), {
+                    guard let didFinishAllOperationsExpectation = didFinishAllOperationsExpectation else { print("Test: \(#function): Finished operations after timeout"); return }
+                    didFinishAllOperationsExpectation.fulfill()
+                })
+                
+                waitForExpectationsWithTimeout(batchTimeout, handler: nil)
+                XCTAssertEqual(Int(child1FinishCount.count), batchSize)
+                XCTAssertEqual(Int(child2FinishCount.count), batchSize)
+                let batchFinishTime = CFAbsoluteTimeGetCurrent()
+                let batchDuration = batchFinishTime - batchStartTime
+                print ("\(#function): Finished batch: \(batch), in \(batchDuration) seconds")
+            }
+        }
+        
+    }
 }
 


### PR DESCRIPTION
This PR aggregates a series of changes made to improve Operation framework thread-safety and behavior.

Problems were identified when trying to cancel GroupOperations. Further testing and examination led to some substantial thread-safety improvements that allow a series of new Stress Tests (also included) to complete without error. (Previously, they would crash, trip asserts, etc.)

Besides thread-safety issues, several other issues were identified and fixed:
- **FIX:** GroupOperation.operations contains the initial operations twice after beginning to execute.
- **FIX:** Extraneous KVO Notifications were being sent for NSOperation keyPaths. KVO notifications are now explicit.
- **FIX:** GroupOperation now only finishes once its child operations have finished.
- **FIX:** GroupOperation now handles cancelling & finishing itself, ensuring that there are not orphaned operations on a queue that never starts if the GroupOperation is cancelled before it executes.
- **FIX:** RepeatedOperation.addNextOperation() did not check if it was cancelled before adding a new child operation. This could lead to an endless loop.
- **FIX:** Logging-related crashes and thread-safety issues.

Numerous new tests that previously exhibited issues, Stress Tests that previously crashed, and a new Operation KVONotification testing framework are included.

(The new Stress Tests also support a `batches` parameter, currently set to 1.)

Additional details on larger fixes below.
