### PR TITLE
Make Operation.cancel() final

### DIFF
--- a/Sources/Core/Shared/Operation.swift
+++ b/Sources/Core/Shared/Operation.swift
@@ -361,7 +361,7 @@ public class Operation: NSOperation {
      */
     public func operationDidCancel() { /* No op */ }
 
-    public override func cancel() {
+    public final override func cancel() {
         let willCancel = stateLock.withCriticalScope { _ -> Bool in
             // Do not cancel if already finished or finishing, or cancelled
             guard state <= .Executing && !_cancelled else { return false }


### PR DESCRIPTION
Per discussion in:
https://github.com/danthorpe/Operations/pull/293
https://github.com/danthorpe/Operations/pull/358#discussion_r70167086

(For a post-3.0 release.)