### PR TITLE
Make GroupOperation's internal queue non-public, and expose appropriate properties on GroupOperation

### DIFF
--- a/Sources/Core/Shared/GroupOperation.swift
+++ b/Sources/Core/Shared/GroupOperation.swift
@@ -47,9 +47,9 @@ public class GroupOperation: Operation, OperationQueueDelegate {
     private var isGroupFinishing = false
     private let groupFinishLock = NSRecursiveLock()
     private var isAddingOperationsGroup = dispatch_group_create()
-
-    /// - returns: the OperationQueue the group runs operations on.
-    public let queue = OperationQueue()
+    private var groupSuspendLock = NSLock()
+    private var isGroupSuspended = false
+    internal let queue = OperationQueue()   // internal for testing
 
     /// - returns: the operations which have been added to the queue
     public private(set) var operations: [NSOperation] {
@@ -69,6 +69,77 @@ public class GroupOperation: Operation, OperationQueueDelegate {
             let (nsops, ops) = operations.splitNSOperationsAndOperations
             nsops.forEach { $0.setQualityOfServiceFromUserIntent(userIntent) }
             ops.forEach { $0.userIntent = userIntent }
+        }
+    }
+
+    /**
+     The maximum number of child operations that can execute at the same time.
+
+     The value in this property affects only the operations that the current GroupOperation has
+     executing at the same time. Other operation queues and GroupOperations can also execute
+     their maximum number of operations in parallel.
+
+     Reducing the number of concurrent operations does not affect any operations that are
+     currently executing.
+
+     Specifying the value NSOperationQueueDefaultMaxConcurrentOperationCount (which is recommended)
+     causes the system to set the maximum number of operations based on system conditions.
+
+     The default value of this property is NSOperationQueueDefaultMaxConcurrentOperationCount.
+    */
+    public final var maxConcurrentOperationCount: Int {
+        get {
+            return queue.maxConcurrentOperationCount
+        }
+        set {
+            queue.maxConcurrentOperationCount = newValue
+        }
+    }
+
+    /**
+     A Boolean value indicating whether the Group is actively scheduling operations for execution.
+
+     When the value of this property is false, the GroupOperation actively starts child operations
+     that are ready to execute once the GroupOperation has been executed.
+
+     Setting this property to true prevents the GroupOperation from starting any child operations,
+     but already executing child operations continue to execute.
+
+     You may continue to add operations to a GroupOperation that is suspended but those operations
+     are not scheduled for execution until you change this property to false.
+
+     The default value of this property is false.
+    */
+    public final var suspended: Bool {
+        get {
+            return groupSuspendLock.withCriticalScope { isGroupSuspended }
+        }
+        set {
+            groupSuspendLock.withCriticalScope {
+                isGroupSuspended = newValue
+                queue.suspended = newValue
+            }
+        }
+    }
+
+    /**
+     The default service level to apply to the GroupOperation and its child operations.
+
+     This property specifies the service level applied to the GroupOperation itself, and to
+     operation objects added to the GroupOperation.
+
+     If the added operation object has an explicit service level set, that value is used instead.
+
+     For more, see the NSOperation and NSOperationQueue documentation for `qualityOfService`.
+    */
+    @available(OSX 10.10, iOS 8.0, tvOS 8.0, watchOS 2.0, *)
+    public final override var qualityOfService: NSQualityOfService {
+        get {
+            return queue.qualityOfService
+        }
+        set {
+            super.qualityOfService = newValue
+            queue.qualityOfService = newValue
         }
     }
 
@@ -115,7 +186,11 @@ public class GroupOperation: Operation, OperationQueueDelegate {
         _addOperations(operations.filter { !self.queue.operations.contains($0) }, addToOperationsArray: false)
         _addCanFinishOperation(canFinishOperation)
         queue.addOperation(finishingOperation)
-        queue.suspended = false
+        groupSuspendLock.withCriticalScope {
+            if !isGroupSuspended {
+                queue.suspended = false
+            }
+        }
     }
 
     /**

--- a/Sources/Core/Shared/GroupOperation.swift
+++ b/Sources/Core/Shared/GroupOperation.swift
@@ -148,7 +148,7 @@ public class GroupOperation: Operation, OperationQueueDelegate {
 
     - parameter operations: an array of `NSOperation`s.
     */
-    public init(operations ops: [NSOperation]) {
+    public init(underlyingQueue: dispatch_queue_t? = .None, operations ops: [NSOperation]) {
         _operations = Protector<[NSOperation]>(ops)
         // GroupOperation handles calling finish() on cancellation once all of its children have cancelled and finished
         // and its finishingOperation has finished.
@@ -157,6 +157,7 @@ public class GroupOperation: Operation, OperationQueueDelegate {
         name = "Group Operation"
         queue.suspended = true
         queue.delegate = self
+        queue.underlyingQueue = underlyingQueue
         userIntent = operations.userIntent
         addObserver(DidCancelObserver { [unowned self] operation in
             if operation === self {

--- a/Sources/Core/Shared/ResultInjection.swift
+++ b/Sources/Core/Shared/ResultInjection.swift
@@ -214,13 +214,13 @@ extension AutomaticInjectionOperationType where Self: Operation {
 /// Protocol for non-Operation types to conform to yet enjoy scheduling in Operation
 public protocol Executor: ResultOperationType, AutomaticInjectionOperationType {
 
-    /** 
+    /**
      Will be called to execute the _work_. When the work is finished, the
-     finish block should be invoked. If any errors were encounted pass 
-     them into the finish block. If the work produces a result, the value 
+     finish block should be invoked. If any errors were encounted pass
+     them into the finish block. If the work produces a result, the value
      should be made available at the `result` property before invoking the
      finish block.
-     
+
      - parameter finish: a closure which receives an ErrorType?
     */
     func execute(finish: ErrorType? -> Void)

--- a/Tests/Core/GroupOperationTests.swift
+++ b/Tests/Core/GroupOperationTests.swift
@@ -425,8 +425,8 @@ class GroupOperationTests: OperationTests {
     func test__group_operation_ignores_queue_delegate_calls_from_other_queues() {
         class PoorlyWrittenGroupOperationSubclass: GroupOperation {
             private var subclassQueue = OperationQueue()
-            override init(operations: [NSOperation]) {
-                super.init(operations: operations)
+            override init(underlyingQueue: dispatch_queue_t? = .None, operations: [NSOperation]) {
+                super.init(underlyingQueue: underlyingQueue, operations: operations)
                 subclassQueue.delegate = self
             }
             override func execute() {

--- a/Tests/Core/GroupOperationTests.swift
+++ b/Tests/Core/GroupOperationTests.swift
@@ -462,5 +462,202 @@ class GroupOperationTests: OperationTests {
         
         XCTAssertFalse(addedOperationFromOtherQueue)
     }
+
+    func test__group_operation_suspended() {
+        let group = GroupOperation(operations: [])
+        let firstOperation = BlockOperation(block: { [unowned group] continuation in
+            group.suspended = true
+            continuation(error: nil)
+        })
+        let secondOperation = TestOperation(delay: 0.0)
+        secondOperation.addDependency(firstOperation)
+
+        weak var firstOpDidFinishExpectation = expectationWithDescription("Test: \(#function); firstOperation Did Finish")
+        firstOperation.addObserver(DidFinishObserver { operation, errors in
+            NSOperationQueue.mainQueue().addOperationWithBlock {
+                guard let firstOpDidFinishExpectation = firstOpDidFinishExpectation else { return }
+                firstOpDidFinishExpectation.fulfill()
+            }
+        })
+
+        group.addOperations([firstOperation, secondOperation])
+
+        runOperation(group)
+
+        waitForExpectationsWithTimeout(3, handler: nil)
+        XCTAssertTrue(group.suspended)
+        XCTAssertFalse(group.finished)
+        XCTAssertTrue(firstOperation.finished)
+        XCTAssertFalse(secondOperation.finished)
+
+        weak var groupDidFinishExpectation = expectationWithDescription("Test: \(#function); group operation Did Finish")
+        group.addObserver(DidFinishObserver { observedOperation, errors in
+            NSOperationQueue.mainQueue().addOperationWithBlock {
+                guard let groupDidFinishExpectation = groupDidFinishExpectation else { return }
+                groupDidFinishExpectation.fulfill()
+            }
+        })
+
+        group.suspended = false
+
+        waitForExpectationsWithTimeout(3, handler: nil)
+        XCTAssertFalse(group.suspended)
+        XCTAssertTrue(group.finished)
+        XCTAssertTrue(firstOperation.finished)
+        XCTAssertTrue(secondOperation.finished)
+    }
+    
+    func test__group_operation_suspended_before_execute() {
+        let child = TestOperation(delay: 0.0)
+        let group = GroupOperation(operations: [child])
+        group.suspended = true
+
+        let childOperationWillExecuteGroup = dispatch_group_create()
+        dispatch_group_enter(childOperationWillExecuteGroup)
+        child.addObserver(WillExecuteObserver { operation in
+            dispatch_group_leave(childOperationWillExecuteGroup)
+        })
+
+        let groupOperationWillExecuteGroup = dispatch_group_create()
+        dispatch_group_enter(groupOperationWillExecuteGroup)
+        group.addObserver(WillExecuteObserver { operation in
+            dispatch_group_leave(groupOperationWillExecuteGroup)
+        })
+
+        weak var expectation = expectationWithDescription("Test: \(#function); DidFinish Group")
+        group.addObserver(DidFinishObserver { observedOperation, errors in
+            NSOperationQueue.mainQueue().addOperationWithBlock {
+                guard let expectation = expectation else { return }
+                expectation.fulfill()
+            }
+        })
+
+        runOperation(group)
+
+        let groupExecuteWait = dispatch_time(DISPATCH_TIME_NOW, Int64(3.0 * Double(NSEC_PER_SEC)))
+        XCTAssertEqual(dispatch_group_wait(groupOperationWillExecuteGroup, groupExecuteWait), 0, "Group Operation has not yet executed.")
+
+        let childWait = dispatch_time(DISPATCH_TIME_NOW, Int64(1.5 * Double(NSEC_PER_SEC)))
+        XCTAssertNotEqual(dispatch_group_wait(childOperationWillExecuteGroup, childWait), 0, "Child operation executed when GroupOperation was suspended.")
+
+        XCTAssertFalse(child.finished)
+        XCTAssertFalse(group.finished)
+
+        group.suspended = false
+
+        waitForExpectationsWithTimeout(3, handler: nil)
+        XCTAssertTrue(child.finished)
+        XCTAssertTrue(group.finished)
+    }
+}
+
+class GroupOperationMaxConcurrentOperationCountTests: OperationTests {
+
+    private class ConcurrencyRegistrar {
+        private let _sharedRunningOperations = Protector([NSOperation]())
+        private let _maxConcurrentOperationsDetectedCount = Protector(Int(0))
+        var maxConcurrentOperationsDetectedCount: Int {
+            get {
+                return _maxConcurrentOperationsDetectedCount.read { $0 }
+            }
+        }
+        private func recordOperationsCount(currentOperationsCount: Int) {
+            _maxConcurrentOperationsDetectedCount.write { (inout ward: Int) in
+                if currentOperationsCount > ward {
+                    ward = currentOperationsCount
+                }
+            }
+        }
+        func registerRunning(op: NSOperation) {
+            _sharedRunningOperations.write { (inout ward: [NSOperation]) in
+                ward.append(op)
+                self.recordOperationsCount(ward.count)
+            }
+        }
+        func deregisterRunning(op: NSOperation) {
+            _sharedRunningOperations.write { (inout ward: [NSOperation]) in
+                if let foundOperation = ward.indexOf(op) {
+                    ward.removeAtIndex(foundOperation)
+                }
+            }
+        }
+        func atLeastOneOperationIsRunning(otherThan exception: NSOperation? = nil) -> Bool {
+            return _sharedRunningOperations.read { ward -> Bool in
+                for op in ward {
+                    if op !== exception {
+                        return true
+                    }
+                }
+                return false
+            }
+        }
+    }
+    private class RegistersWhenRunningOperation: Operation {
+        private weak var concurrencyRegistrar: ConcurrencyRegistrar?
+        private let microsecondsToSleep: useconds_t
+        init(microsecondsToSleep: useconds_t, registrar: ConcurrencyRegistrar) {
+            self.concurrencyRegistrar = registrar
+            self.microsecondsToSleep = microsecondsToSleep
+            super.init()
+        }
+        override func execute() {
+            concurrencyRegistrar?.registerRunning(self)
+            usleep(microsecondsToSleep)
+            concurrencyRegistrar?.deregisterRunning(self)
+            finish()
+        }
+    }
+
+    func test__group_operation_maxConcurrentOperationCount_1() {
+        let childDelayMicroseconds: useconds_t = 500000 // 0.5 seconds
+        let concurrency = ConcurrencyRegistrar()
+        let children = (0..<3).map { _ in RegistersWhenRunningOperation(microsecondsToSleep: childDelayMicroseconds, registrar: concurrency) }
+        let group = GroupOperation(operations: children)
+        group.maxConcurrentOperationCount = 1
+
+        weak var expectation = expectationWithDescription("Test: \(#function); DidFinish Group")
+        group.addObserver(DidFinishObserver { observedOperation, errors in
+            NSOperationQueue.mainQueue().addOperationWithBlock {
+                guard let expectation = expectation else { return }
+                expectation.fulfill()
+            }
+        })
+
+        let startTime = CFAbsoluteTimeGetCurrent()
+        runOperation(group)
+        waitForExpectationsWithTimeout(4, handler: nil)
+        let endTime = CFAbsoluteTimeGetCurrent()
+        let duration = Double(endTime) - Double(startTime)
+
+        XCTAssertEqual(concurrency.maxConcurrentOperationsDetectedCount, 1)
+        for i in children.enumerate() {
+            XCTAssertTrue(i.element.finished, "Child operation [\(i.index)] did not finish")
+        }
+        XCTAssertGreaterThanOrEqual(duration, Double(useconds_t(children.count) * childDelayMicroseconds) / 1000000.0)
+    }
+
+    func test__group_operation_maxConcurrentOperationCount_2() {
+        let childDelayMicroseconds: useconds_t = 500000 // 0.5 seconds
+        let concurrency = ConcurrencyRegistrar()
+        let children = (0..<3).map { _ in RegistersWhenRunningOperation(microsecondsToSleep: childDelayMicroseconds, registrar: concurrency) }
+        let group = GroupOperation(operations: children)
+        group.maxConcurrentOperationCount = 2
+
+        weak var expectation = expectationWithDescription("Test: \(#function); DidFinish Group")
+        group.addObserver(DidFinishObserver { observedOperation, errors in
+            NSOperationQueue.mainQueue().addOperationWithBlock {
+                guard let expectation = expectation else { return }
+                expectation.fulfill()
+            }
+        })
+
+        runOperation(group)
+        waitForExpectationsWithTimeout(4, handler: nil)
+
+        XCTAssertEqual(concurrency.maxConcurrentOperationsDetectedCount, 2)
+        for i in children.enumerate() {
+            XCTAssertTrue(i.element.finished, "Child operation [\(i.index)] did not finish")
+        }
+    }
 }
 


### PR DESCRIPTION
- Make `GroupOperation.queue` internal, instead of public. (Internal so it can be tested.)
- Expose appropriate run-time editable properties of the GroupOperation’s queue as properties on GroupOperation.
> - public var maxConcurrentOperationCount: Int
> - public var suspended: Bool
> - public var qualityOfService: NSQualityOfService

- Add tests.

Per discussion in: https://github.com/danthorpe/Operations/pull/293

-----

#### Discussion:

Per discussion in:
https://github.com/danthorpe/Operations/pull/293

`GroupOperation.queue` probably shouldn’t be public, but there are run-time editable properties of the queue that ought to be configurable by framework consumers. Thus, this PR exposes those properties directly on GroupOperation.

The following properties of NSOperationQueue seem sensible to expose:

```swift
public var maxConcurrentOperationCount: Int
public var suspended: Bool
public var qualityOfService: NSQualityOfService
```

The following methods of NSOperationQueue do **not** seem sensible to expose:

```swift
public func cancelAllOperations()
```
**Why:** Use GroupOperation.cancel() instead.

```swift
public func waitUntilAllOperationsAreFinished()
```
**Why:** Use a DidFinishObserver on GroupOperation instead (and waiting on the queue itself is probably not what anyone should do, as the GroupOperation’s queue is an implementation detail of GroupOperation).