### PR TITLE
Support composing simple types for Result injection

### DIFF
--- a/Sources/Core/Shared/GroupOperation.swift
+++ b/Sources/Core/Shared/GroupOperation.swift
@@ -263,13 +263,13 @@ public class GroupOperation: Operation, OperationQueueDelegate {
                 dispatch_group_enter(isAddingOperationsGroup)
                 return true
             }
-            
+
             guard shouldContinue else { return }
 
             willAddChildOperationObservers.forEach { $0.groupOperation(self, willAddChildOperation: operation) }
 
             canFinishOperation.addDependency(operation)
-            
+
             groupFinishLock.withCriticalScope {
                 dispatch_group_leave(isAddingOperationsGroup)
             }

--- a/Sources/Core/Shared/Queue.swift
+++ b/Sources/Core/Shared/Queue.swift
@@ -118,7 +118,7 @@ public enum Queue {
 
     /**
      Initialize a Queue with a given NSQualityOfService.
-     
+
      - parameter qos: a NSQualityOfService value
      - returns: a Queue with an equivalent quality of service
      */
@@ -139,7 +139,7 @@ public enum Queue {
 
     /**
      Initialize a Queue with a given GCD quality of service class.
-     
+
      - parameter qos: a qos_class_t value
      - returns: a Queue with an equivalent quality of service
      */

--- a/Sources/Core/Shared/ResultInjection.swift
+++ b/Sources/Core/Shared/ResultInjection.swift
@@ -172,9 +172,11 @@ extension AutomaticInjectionOperationType where Self: Operation {
      queue.addOperations(fetch, processing)
      ```
 
+     - parameter dep: an operation of type T
+     - returns: the receiver
     */
-    public func injectResultFromDependency<T where T: Operation, T: ResultOperationType, T.Result == Requirement>(dep: T) {
-        injectResultFromDependency(dep) { [weak self] operation, dependency, errors in
+    public func injectResultFromDependency<T where T: Operation, T: ResultOperationType, T.Result == Requirement>(dep: T) -> Self {
+        return injectResultFromDependency(dep) { [weak self] operation, dependency, errors in
             if errors.isEmpty {
                 self?.requirement = dependency.result
             }
@@ -182,5 +184,87 @@ extension AutomaticInjectionOperationType where Self: Operation {
                 self?.cancelWithError(AutomaticInjectionError.DependencyFinishedWithErrors(errors))
             }
         }
+    }
+
+    /**
+     Inject the result from the dependency as the requirement of the receiver.
+     Additionally this method requires that the dependency must not fail or be
+     cancelled.
+
+    ```swift
+     return operation
+        .requireResultFromDependency(foo)
+        .requireResultFromDependency(bar)
+        .requireResultFromDependency(baz)
+        .requireResultFromDependency(bat)
+     ```
+
+     - parameter dep: an operation of type T
+     - returns: the receiver
+    */
+    public func requireResultFromDependency<T where T: Operation, T: ResultOperationType, T.Result == Requirement>(dep: T) -> Self {
+        if conditions.filter({ return $0 is NoFailedDependenciesCondition }).count < 1 {
+            addCondition(NoFailedDependenciesCondition())
+        }
+        return injectResultFromDependency(dep)
+    }
+}
+
+
+/// Protocol for non-Operation types to conform to yet enjoy scheduling in Operation
+public protocol Executor: ResultOperationType, AutomaticInjectionOperationType {
+
+    /// Will be called to execute the _work_. If an error is encountered, it should throw
+    func execute() throws
+
+    /// Will be called to signal that the _work_ should be cancelled.
+    func cancel()
+}
+
+/**
+ Execute is an Operation which is intended to compose other types which _perform work_. These
+ types must conform to Executor protocol, and essentially expose API to trigger execution of
+ the work, support cancellation, and extend protocols for result injection.
+
+ Execute is initialized with an instance of such a class. When the operation is ready, it will
+ call execute on the Executor, and catch any thrown errors. If the operation is cancelled, it
+ will call cancel on the executor.
+ */
+public final class Execute<E: Executor>: Operation, ResultOperationType, AutomaticInjectionOperationType {
+
+    /// - returns: executor, the instance of the Executor
+    public let executor: E
+
+    /// - returns: the Executor.Result
+    public var result: E.Result {
+        return executor.result
+    }
+
+    /// - returns: the Executor.Requirement
+    public var requirement: E.Requirement {
+        get { return executor.requirement }
+        set { executor.requirement = newValue }
+    }
+
+    /**
+     Initialize the operation with the executor.
+
+     - parametere [unnamed]: an instance of Executor
+    */
+    public init(_ executor: E) {
+        self.executor = executor
+        super.init()
+        addObserver(DidCancelObserver { [unowned self] operation in
+            if self === operation {
+                self.executor.cancel()
+            }
+        })
+    }
+
+    public final override func execute() {
+        var e: ErrorType? = .None
+        defer { finish(e) }
+        do { try executor.execute() }
+        catch { e = error }
     }
 }

--- a/Sources/Features/Shared/TaskOperation.swift
+++ b/Sources/Features/Shared/TaskOperation.swift
@@ -50,7 +50,7 @@ public class TaskOperation: Operation {
 
     /**
      Initializes TaskOperation with an NSTask.
-     
+
      - parameter task: the NSTask
      - parameter taskDidExitCleanly: a TaskDidExitCleanly closure with a default.
     */


### PR DESCRIPTION
Adopting _Operations_ might be considered a risky proposition - it's a "framework" with all the associated issues that come with adding 3rd party dependencies.

One way which might make this less burdensome would be if there was an `Operation` type which composed simple functionality type for Result Injection.