### PR TITLE
Executor must allow for asynchronous work

### DIFF
--- a/Sources/Core/Shared/ResultInjection.swift
+++ b/Sources/Core/Shared/ResultInjection.swift
@@ -214,8 +214,16 @@ extension AutomaticInjectionOperationType where Self: Operation {
 /// Protocol for non-Operation types to conform to yet enjoy scheduling in Operation
 public protocol Executor: ResultOperationType, AutomaticInjectionOperationType {
 
-    /// Will be called to execute the _work_. If an error is encountered, it should throw
-    func execute() throws
+    /** 
+     Will be called to execute the _work_. When the work is finished, the
+     finish block should be invoked. If any errors were encounted pass 
+     them into the finish block. If the work produces a result, the value 
+     should be made available at the `result` property before invoking the
+     finish block.
+     
+     - parameter finish: a closure which receives an ErrorType?
+    */
+    func execute(finish: ErrorType? -> Void)
 
     /// Will be called to signal that the _work_ should be cancelled.
     func cancel()
@@ -262,9 +270,6 @@ public final class Execute<E: Executor>: Operation, ResultOperationType, Automat
     }
 
     public final override func execute() {
-        var e: ErrorType? = .None
-        defer { finish(e) }
-        do { try executor.execute() }
-        catch { e = error }
+        executor.execute(finish)
     }
 }

--- a/Tests/Core/ResultInjectionTests.swift
+++ b/Tests/Core/ResultInjectionTests.swift
@@ -114,9 +114,9 @@ class ExecuteTests: OperationTests {
         var didExecute = false
         var didCancel = false
 
-        func execute() throws {
+        func execute(finish: ErrorType? -> Void) {
             didExecute = true
-            if let e = error { throw e }
+            finish(error)
         }
 
         func cancel() {
@@ -132,9 +132,9 @@ class ExecuteTests: OperationTests {
     class DoubleStringExecutor: TestExecutor, Executor {
         var requirement: String = "yup"
         var result: String = "nope"
-        override func execute() throws {
-            try super.execute()
+        override func execute(finish: ErrorType? -> Void) {
             result = "\(requirement) \(requirement)"
+            super.execute(finish)
         }
     }
 


### PR DESCRIPTION
Slight oversight from #362 which only supports synchronous _work_.