### PR TITLE
GatedOperation does not cancel composed operation when closed

### DIFF
--- a/Sources/Core/Shared/GatedOperation.swift
+++ b/Sources/Core/Shared/GatedOperation.swift
@@ -32,6 +32,7 @@ public class GatedOperation<T: NSOperation>: ComposedOperation<T> {
     public init(_ operation: T, gate: GateBlockType) {
         self.gate = gate
         super.init(operation: operation)
+        name = "Gated <\(T.self)>"
     }
 
     /**
@@ -41,11 +42,10 @@ public class GatedOperation<T: NSOperation>: ComposedOperation<T> {
      closed, the operation does not "fail" i.e. finish with errors.
     */
     public override func execute() {
-        if gate() {
-            super.execute()
-        }
-        else {
-            finish()
+        defer { super.execute() }
+        guard gate() else {
+            operation.cancel()
+            return
         }
     }
 }

--- a/Tests/Core/GatedOperationTests.swift
+++ b/Tests/Core/GatedOperationTests.swift
@@ -11,23 +11,23 @@ import XCTest
 
 class GatedOperationTests: OperationTests {
 
-    func test__when_gate_is_closed_operation_is_not_performed() {
+    func test__when_gate_is_closed_operation_is_cancelled() {
+        let gate = GatedOperation(TestOperation()) { false }
 
-        let gate = GatedOperation(TestOperation()) { return false }
         addCompletionBlockToTestOperation(gate, withExpectation: expectationWithDescription("Test: \(#function)"))
-
         runOperation(gate)
 
         waitForExpectationsWithTimeout(5, handler: nil)
         XCTAssertTrue(gate.finished)
+        XCTAssertTrue(gate.operation.cancelled)
         XCTAssertFalse(gate.operation.didExecute)
     }
 
     func test__when_gate_is_open_operation_is_performed() {
-        let gate = GatedOperation(TestOperation()) { return true }
+        let gate = GatedOperation(TestOperation()) { true }
+
         addCompletionBlockToTestOperation(gate, withExpectation: expectationWithDescription("Test: \(#function), Gate"))
         addCompletionBlockToTestOperation(gate.operation, withExpectation: expectationWithDescription("Test: \(#function), Operation"))
-
         runOperation(gate)
 
         waitForExpectationsWithTimeout(5, handler: nil)
@@ -36,4 +36,70 @@ class GatedOperationTests: OperationTests {
         XCTAssertTrue(gate.operation.finished)
     }
 
+    func test__wheen_composed_is_dependency_and_gate_is_open__dependent_is_performed_after_composed() {
+        let operation = TestOperation()
+        let composed = TestOperation()
+        operation.addDependency(composed)
+        let gate = GatedOperation(composed) { true }
+
+        waitForOperations(operation, gate)
+
+        XCTAssertTrue(gate.finished)
+        XCTAssertTrue(composed.didExecute)
+        XCTAssertTrue(composed.finished)
+
+        XCTAssertTrue(operation.finished)
+        XCTAssertTrue(operation.didExecute)
+    }
+
+    func test__when_gate_is_dependency_and_gate_is_open__dependent_is_performed_after_gate() {
+        let operation = TestOperation()
+        let composed = TestOperation()
+        let gate = GatedOperation(composed) { true }
+        operation.addDependency(gate)
+
+        waitForOperations(operation, gate)
+
+        XCTAssertTrue(gate.finished)
+        XCTAssertTrue(composed.didExecute)
+        XCTAssertTrue(composed.finished)
+
+        XCTAssertTrue(operation.finished)
+        XCTAssertTrue(operation.didExecute)
+    }
+
+    func test__when_composed_is_dependency_and_gate_is_closed__dependent_is_still_performed() {
+        /// - Note - Remember that regardless of how a dependency finishes, dependent operations
+        /// will still become ready and execute.
+
+        let composed = TestOperation()
+        let operation = TestOperation()
+        operation.addDependency(composed)
+        let gate = GatedOperation(composed) { false }
+
+        waitForOperations(gate, operation)
+
+        XCTAssertTrue(gate.finished)
+        XCTAssertFalse(composed.didExecute)
+        XCTAssertTrue(composed.cancelled)
+
+        XCTAssertTrue(operation.finished)
+        XCTAssertTrue(operation.didExecute)
+    }
+
+    func test__when_gate_is_dependency_and_gate_is_closed__dependent_is_still_performed() {
+        let operation = TestOperation()
+        let composed = TestOperation()
+        let gate = GatedOperation(composed) { false }
+        operation.addDependency(gate)
+
+        waitForOperations(gate, operation)
+
+        XCTAssertTrue(gate.finished)
+        XCTAssertFalse(composed.didExecute)
+        XCTAssertTrue(composed.cancelled)
+
+        XCTAssertTrue(operation.finished)
+        XCTAssertTrue(operation.didExecute)
+    }
 }

--- a/Tests/Core/GatedOperationTests.swift
+++ b/Tests/Core/GatedOperationTests.swift
@@ -36,7 +36,7 @@ class GatedOperationTests: OperationTests {
         XCTAssertTrue(gate.operation.finished)
     }
 
-    func test__wheen_composed_is_dependency_and_gate_is_open__dependent_is_performed_after_composed() {
+    func test__when_composed_is_dependency_and_gate_is_open__dependent_is_performed_after_composed() {
         let operation = TestOperation()
         let composed = TestOperation()
         operation.addDependency(composed)


### PR DESCRIPTION
Currently the composed operation in a `GatedOperation` is not cancelled if the gate is closed. This means that any operations which depend on it or are waiting for it to ultimately finish will get stuck.

So, it's logic should change slightly so that if the gate is closed, it gets cancelled, but `GatedOperation` should always run to completion. 