### PR TITLE
Dependency gets added twice if it is a direct and indirect dependency

### DIFF
--- a/Sources/Core/Shared/Operation.swift
+++ b/Sources/Core/Shared/Operation.swift
@@ -96,7 +96,10 @@ public class Operation: NSOperation {
     internal private(set) var conditions = Set<Condition>()
 
     internal var indirectDependencies: Set<NSOperation> {
-        return Set(conditions.flatMap { $0.directDependencies })
+        return Set(conditions
+            .flatMap { $0.directDependencies }
+            .filter { !directDependencies.contains($0) }
+        )
     }
 
     // Internal operation properties which are used to manage the scheduling of dependencies

--- a/Tests/Core/ConditionTests.swift
+++ b/Tests/Core/ConditionTests.swift
@@ -152,4 +152,19 @@ class ConditionTests: OperationTests {
         
         XCTAssertEqual(operation.dependencies.count, 4)
     }
+
+    func test__target_and_condition_have_same_dependency() {
+        let dependency = TestOperation()
+        let condition = TrueCondition(name: "Condition")
+        condition.addDependency(dependency)
+
+        let operation = TestOperation()
+        operation.addCondition(condition)
+        operation.addDependency(dependency)
+
+        waitForOperations(operation, dependency)
+
+        XCTAssertTrue(dependency.didExecute)
+        XCTAssertTrue(operation.didExecute)
+    }
 }


### PR DESCRIPTION
Essentially, if you have operation, with a dependency, and you create a condition, which has the same dependency, that dependency will get added to the queue twice (because it is added when the operation with the condition is added).

Therefore, when processing conditions, and their dependencies (i.e. the target operations _indirect dependencies_ the target operation's _direct dependencies_ must be removed from consideration.