### PR TITLE
AlertOperation has unnecessary mutual exclusion

### DIFF
--- a/Sources/Core/Shared/MutuallyExclusive.swift
+++ b/Sources/Core/Shared/MutuallyExclusive.swift
@@ -26,9 +26,3 @@ public final class MutuallyExclusive<T>: Condition {
         completion(.Satisfied)
     }
 }
-
-/// A non-constructible type to be used with `MutuallyExclusive<T>`
-public enum Alert { }
-
-/// A condition to indicate that the associated operation may present an alert
-public typealias AlertPresentation = MutuallyExclusive<Alert>

--- a/Sources/Core/iOS/AlertOperation.swift
+++ b/Sources/Core/iOS/AlertOperation.swift
@@ -51,7 +51,6 @@ public class AlertOperation<From: PresentingViewController>: Operation {
         uiOperation = UIOperation(controller: controller, displayControllerFrom: .Present(from))
         super.init()
         name = "Alert<\(From.self)>"
-        addCondition(AlertPresentation())
         addCondition(MutuallyExclusive<UIViewController>())
     }
 

--- a/Sources/Features/iOS/UserNotificationCondition.swift
+++ b/Sources/Features/iOS/UserNotificationCondition.swift
@@ -134,7 +134,7 @@ public class UserNotificationPermissionOperation: Operation {
         self.registrar = registrar
         super.init()
         name = "User Notification Permissions Operation"
-        addCondition(AlertPresentation())
+        addCondition(MutuallyExclusive<UserNotificationPermissionOperation>())
     }
 
     public override func execute() {

--- a/Tests/Core/MutualExclusiveTests.swift
+++ b/Tests/Core/MutualExclusiveTests.swift
@@ -11,24 +11,24 @@ import XCTest
 
 class MutualExclusiveTests: OperationTests {
 
-    func test__alert_presentation_name() {
-        let condition = AlertPresentation()
-        XCTAssertEqual(condition.name, "MutuallyExclusive<Alert>")
+    func test__mutual_eclusive_name() {
+        let condition = MutuallyExclusive<Operation>()
+        XCTAssertEqual(condition.name, "MutuallyExclusive<Operation>")
     }
 
     func test__alert_presentation_is_mutually_exclusive() {
-        let condition = AlertPresentation()
+        let condition = MutuallyExclusive<Operation>()
         XCTAssertTrue(condition.mutuallyExclusive)
     }
 
     func test__alert_presentation_evaluation_satisfied() {
-        let condition = AlertPresentation()
+        let condition = MutuallyExclusive<Operation>()
         condition.evaluate(TestOperation()) { result in
             switch result {
             case .Satisfied:
                 return XCTAssertTrue(true)
             default:
-                return XCTFail("Alert presentation condition should evaluate true.")
+                return XCTFail("Condition should evaluate true.")
             }
         }
     }


### PR DESCRIPTION
[AlertOperation](https://github.com/danthorpe/Operations/blob/9f72b42e7834e1a7d563e9430bd89a6d36c43cd1/Sources/Core/iOS/AlertOperation.swift#L54-L55) has two mutual exclusions. It really only needs the second one I believe:

```
addCondition(AlertPresentation())
addCondition(MutuallyExclusive<UIViewController>())
```

That'll make sure that other alert operations aren't run at the same time, in addition to any other `UIViewController` related operations.