### PR TITLE
Add support for Condition to fail yet not result in an error

### DIFF
--- a/Sources/Core/Shared/Condition.swift
+++ b/Sources/Core/Shared/Condition.swift
@@ -8,6 +8,35 @@
 
 import Foundation
 
+/**
+ The result of an OperationCondition. Either the condition is
+ satisfied, indicated by `.Satisfied` or it has failed. In the
+ failure case, an `ErrorType` must be associated with the result.
+ */
+public enum ConditionResult {
+
+    /// Indicates that the condition is satisfied
+    case Satisfied
+
+    /// Indicates that the condition failed, but can be ignored
+    case Ignored(ErrorType)
+
+    /// Indicates that the condition failed with an associated error.
+    case Failed(ErrorType)
+}
+
+internal extension ConditionResult {
+
+    var error: ErrorType? {
+        switch self {
+        case .Failed(let error):
+            return error
+        default:
+            return .None
+        }
+    }
+}
+
 public protocol ConditionType {
 
     var mutuallyExclusive: Bool { get set }
@@ -97,7 +126,6 @@ public class Condition: Operation, ConditionType, ResultOperationType {
     }
 }
 
-
 public class TrueCondition: Condition {
 
     public init(name: String = "True Condition", mutuallyExclusive: Bool = false) {
@@ -123,7 +151,6 @@ public class FalseCondition: Condition {
         completion(.Failed(ConditionError.FalseCondition))
     }
 }
-
 
 /**
  Class which can be used to compose a Condition, it is designed to be subclassed.
@@ -183,6 +210,28 @@ public class ComposedCondition<C: Condition>: Condition, AutomaticInjectionOpera
     override func removeDirectDependency(directDependency: NSOperation) {
         condition.removeDirectDependency(directDependency)
         super.removeDirectDependency(directDependency)
+    }
+}
+
+public class IgnoredCondition<C: Condition>: ComposedCondition<C> {
+
+
+    /// Public override of initializer.
+    public override init(_ condition: C) {
+        super.init(condition)
+        name = condition.name.map { "Ignored<\($0)>" }
+    }
+
+    /// Override of public function
+    public override func evaluate(operation: Operation, completion: CompletionBlockType) {
+        super.evaluate(operation) { composedResult in
+            if case let .Failed(error) = composedResult {
+                completion(.Ignored(error))
+            }
+            else {
+                completion(composedResult)
+            }
+        }
     }
 }
 

--- a/Sources/Core/Shared/NegatedCondition.swift
+++ b/Sources/Core/Shared/NegatedCondition.swift
@@ -38,6 +38,8 @@ public final class NegatedCondition<C: Condition>: ComposedCondition<C> {
             switch composedResult {
             case .Satisfied:
                 completion(.Failed(NegatedConditionError.ConditionSatisfied(name)))
+            case .Ignored(_):
+                completion(composedResult)
             case .Failed(_):
                 completion(.Satisfied)
             }

--- a/Sources/Core/Shared/OperationCondition.swift
+++ b/Sources/Core/Shared/OperationCondition.swift
@@ -8,32 +8,6 @@
 
 import Foundation
 
-/**
-The result of an OperationCondition. Either the condition is
-satisfied, indicated by `.Satisfied` or it has failed. In the
-failure case, an `ErrorType` must be associated with the result.
-*/
-public enum ConditionResult {
-
-    /// Indicates that the condition is satisfied
-    case Satisfied
-
-    /// Indicates that the condition failed with an associated error.
-    case Failed(ErrorType)
-}
-
-internal extension ConditionResult {
-
-    var error: ErrorType? {
-        switch self {
-        case .Failed(let error):
-            return error
-        default:
-            return .None
-        }
-    }
-}
-
 public typealias OperationConditionResult = ConditionResult
 
 /**

--- a/Tests/Core/ConditionTests.swift
+++ b/Tests/Core/ConditionTests.swift
@@ -167,4 +167,37 @@ class ConditionTests: OperationTests {
         XCTAssertTrue(dependency.didExecute)
         XCTAssertTrue(operation.didExecute)
     }
+
+    func test__ignored_failing_condition_does_not_result_in_operation_failure() {
+        let operation1 = TestOperation()
+        let operation2 = TestOperation()
+        operation1.addCondition(IgnoredCondition(FalseCondition()))
+        operation2.addCondition(FalseCondition())
+        waitForOperations(operation1, operation2)
+        XCTAssertTrue(operation1.didExecute)
+        XCTAssertFalse(operation1.failed)
+        XCTAssertFalse(operation2.didExecute)
+        XCTAssertTrue(operation2.failed)
+    }
+
+    func test__ignored_satisfied_condition_does_not_result_in_operation_failure() {
+        let operation1 = TestOperation()
+        let operation2 = TestOperation()
+        operation1.addCondition(IgnoredCondition(TrueCondition()))
+        operation2.addCondition(TrueCondition())
+        waitForOperations(operation1, operation2)
+        XCTAssertTrue(operation1.didExecute)
+        XCTAssertFalse(operation1.failed)
+        XCTAssertTrue(operation2.didExecute)
+        XCTAssertFalse(operation2.failed)
+    }
+
+    func test__ignored_ignored_condition_does_not_result_in_operation_failure() {
+        let operation = TestOperation()
+        operation.addCondition(IgnoredCondition(IgnoredCondition(FalseCondition())))
+        waitForOperation(operation)
+        XCTAssertTrue(operation.didExecute)
+        XCTAssertFalse(operation.failed)
+    }
 }
+


### PR DESCRIPTION
A common scenario is to use a `Condition` to encapsulate business logic, to separate functionality from logic. However, at the moment this means that the operation will finish (get cancelled) with an error. This in turn is typically interpreted as an error.

So, to support "ignoring" operations using `Condition`s we can add an extra case to `ConditionResult` for `.Ignored`.