### PR TITLE
Prevent adding indirect dependencies which are already added

### DIFF
--- a/Sources/Core/Shared/OperationQueue.swift
+++ b/Sources/Core/Shared/OperationQueue.swift
@@ -110,6 +110,8 @@ public class OperationQueue: NSOperationQueue {
     public override func addOperation(operation: NSOperation) {
         if let operation = operation as? Operation {
 
+            operation.log.verbose("Adding to queue")
+
             /// Add an observer so that any produced operations are added to the queue
             operation.addObserver(ProducedOperationObserver { [weak self] op, produced in
                 if let q = self {
@@ -155,8 +157,11 @@ public class OperationQueue: NSOperationQueue {
                 // If there are dependencies
                 if indirectDependencies.count > 0 {
 
+                    // Filter out the indirect dependencies which have already been added to the queue
+                    let indirectDependenciesToProcess = indirectDependencies.filter { !self.operations.contains($0) }
+
                     // Iterate through the indirect dependencies
-                    indirectDependencies.forEach {
+                    indirectDependenciesToProcess.forEach {
 
                         // Indirect dependencies are executed after
                         // any previous mutually exclusive operation(s)
@@ -172,7 +177,7 @@ public class OperationQueue: NSOperationQueue {
                     }
 
                     // Add indirect dependencies
-                    addOperations(indirectDependencies)
+                    addOperations(indirectDependenciesToProcess)
                 }
 
                 // Add the evaluator


### PR DESCRIPTION
Consider the following dependency diagram:

```
                         ┌─────────────────┐     ┌─────────────────┐
                    ┌────│   Operation 1   │◀────│   Operation 2   │
                    │    └─────────────────┘     └─────────────────┘
                    │             ◇                       ◇         
                    │             │                       │         
                    │             ▼                       │         
                    │    ┌─────────────────┐              │         
                    ┌────│   Condition 1   │              │         
                    │    └─────────────────┘              ▼         
┌───────────────┐   │                            ┌─────────────────┐
│  Dependency   │◀───────────────────────────────│   Condition 2   │
└───────────────┘                                └─────────────────┘
```

Here we have two operations, each with a condition. Both conditions share a common dependency. One operation is also dependent on this dependency, while the other operation is dependent on the first operation.

In this case, the dependency is a direct dependency of operation 1, and an indirect dependency of operation 2.

This may seem like a contrived example, but it's actually probably not that uncommon. Consider that the dependency might be downloading a file, the conditions might be validating or querying in some way, and the operation are to process it.

The problem here, is that the dependency must only be added to the queue once. When the operations are added to the queue with the dependency (because it's a direct dependency) of Operation 1, we must ensure that the dependency is not also added to the queue via operation 2, because it is an indirect dependency.