### PR TITLE
Deferred mutual exclusivity

### DIFF
--- a/Tests/Core/MutualExclusiveTests.swift
+++ b/Tests/Core/MutualExclusiveTests.swift
@@ -100,12 +100,7 @@ class MutualExclusiveTests: OperationTests {
         operation2Dependency.name = "Dependency 2"
         operation2.addDependency(operation2Dependency)
 
-        addCompletionBlockToTestOperation(operation1)
-        addCompletionBlockToTestOperation(operation2)
-        addCompletionBlockToTestOperation(operation1Dependency)
-        addCompletionBlockToTestOperation(operation2Dependency)
-        runOperations(operation1, operation2Dependency, operation2, operation1Dependency)
-        waitForExpectationsWithTimeout(3, handler: nil)
+        waitForOperations(operation1, operation2, operation1Dependency, operation2Dependency)
 
         XCTAssertEqual(text, "Star Wars\nA long time ago, in a galaxy far, far away.")
     }

--- a/Tests/Features/WebpageOperationTests.swift
+++ b/Tests/Features/WebpageOperationTests.swift
@@ -54,7 +54,7 @@ class WebpageOperationTests: OperationTests {
 
         runOperation(operation)
 
-        waitForExpectationsWithTimeout(5, handler: nil)
+        waitForExpectationsWithTimeout(3, handler: nil)
         XCTAssertTrue(didPresentWebpage)
     }
 }


### PR DESCRIPTION
Given an operation which has a `Condition` which is mutually exclusive, currently the operation would be gain this exclusion lock when it is added to the queue.

This doesn't seem like it would be ideal, because it is very easy to create a deadlock where an operation is mutually exclusive with a child or dependent operation.  The child cannot start until the parent finishes, and the parent is waiting for the child to finish before it starts.
 