### PR TITLE
CloudKitOperation: ability to add configuration to the next (retry) operation

### DIFF
--- a/Sources/Features/Shared/CloudKit/CloudKitOperation.swift
+++ b/Sources/Features/Shared/CloudKit/CloudKitOperation.swift
@@ -330,6 +330,95 @@ class CloudKitOperationGenerator<T where T: NSOperation, T: CKOperationType, T: 
     }
 }
 
+/**
+ # BatchedCloudKitOperation
+ 
+ BatchedCloudKitOperation is a generic operation which can be used to configure and schedule
+ the execution of a batch of an Apple CKOperation subclass that returns "moreComing".
+ 
+ Internally, BatchedCloudKitOperation composes CloudKitOperations. Its job is to repeat
+ instances of CloudKitOperation while moreComing == true.
+ 
+ ## Initialization
+ 
+ BatchedCloudKitOperation is initialized just like CloudKitOperation.
+ 
+ For supported CKOperations, it is possible to swap CloudKitOperation for BatchedCloudKitOperation:
+ 
+ ```swift
+ // this:
+ let operation = CloudKitOperation { CKFetchRecordChangesOperation() }
+ // becomes:
+ let operation = BatchedCloudKitOperation { CKFetchRecordChangesOperation() }
+ ```
+ 
+ ## Configuration
+ 
+ Most CKOperation subclasses need various properties setting before they are added to a queue. Sometimes
+ these can be done via their initializers. However, it is also possible to set the properties directly.
+ This can be done directly onto the BatchedCloudKitOperation, just like CloudKitOperation.
+ 
+ For example, given the above:
+ 
+ ```swift
+ let container = CKContainer.defaultContainer()
+ operation.container = container
+ operation.database = container.privateCloudDatabase
+ ```
+ 
+ This will set the container and the database through the BatchedCloudKitOperation into each underlying
+ CloudKitOperation-wrapped CKOperation instance in the batch.
+ 
+ ### Configuring Follow-Up Operations in the Batch
+ 
+ For most batched CKOperations, you will want/need to change some state for the "next" operation.
+ You can do this using setConfigureNextOperationBlock().
+ 
+ For example, given the above:
+ 
+ ```swift
+ operation.setConfigureNextOperationBlock { nextOperation in
+    // the next operation must receive an updated serverChangeToken from the last operation
+    nextOperation.previousServerChangeToken = lastServerChangeToken
+ }
+ ```
+ 
+ where `lastServerChangeToken` is the serverChangeToken most recently received by the operation's
+ `fetchRecordChangesCompletionBlock`. (See the following section on completion.)
+ 
+ ## Completion
+ 
+ Since BatchedCloudKitOperation composes CloudKitOperations, you must follow the same guidelines from
+ CloudKitOperation to always set the completion block.
+ 
+ For example, given the above:
+ 
+ ```swift
+ operation.setFetchRecordChangesCompletionBlock { serverChangeToken, clientChangeTokenData in
+ // Do something, such as storing the new serverChangeToken
+ }
+ ```
+ 
+ For CloudKitOperation's automatic error handling to kick in, the happy path must be set (as above).
+ 
+ **IMPORTANT:**
+ 
+ Because BatchedCloudKitOperation composes CloudKitOperations, your completion handler **may be called
+ multiple times** (i.e. once for each underlying CloudKitOperation that is completed in the batch).
+ 
+ Therefore, you MUST ensure that your completion handler does not make assumptions about the completion
+ status of the BatchedCloudKitOperation.
+ 
+ If you need to handle the completion of the BatchedCloudKitOperation itself, use a Will/DidFinishObserver.
+ 
+ ### Error Handling
+ 
+ See the documentation for CloudKitOperation Error Handling.
+ 
+ BatchedCloudKitOperation provides a convenience setErrorHandlerForCode method, which sets the error
+ handling for every CloudKitOperation in the batch.
+ 
+ */
 public class BatchedCloudKitOperation<T where T: NSOperation, T: CKBatchedOperationType, T: AssociatedErrorType, T.Error: CloudKitErrorType>: RepeatedOperation<CloudKitOperation<T>> {
 
     typealias PayLoad = RepeatedPayload<CloudKitOperation<T>>

--- a/Tests/Features/CloudKitOperationTests.swift
+++ b/Tests/Features/CloudKitOperationTests.swift
@@ -2422,14 +2422,14 @@ class BatchedFetchRecordChangesOperationTests: CKTests {
         }
 
         operation.setPrepareForNextOperationHandler { addConfigureBlock in
-            addConfigureBlock { retryOperation in
-                retryOperation.previousServerChangeToken = currentServerChangeToken
+            addConfigureBlock { nextOperation in
+                nextOperation.previousServerChangeToken = currentServerChangeToken
                 // simulate the next server change token
                 if let currentServerChangeToken = currentServerChangeToken {
-                    retryOperation.operation.token = "\(currentServerChangeToken).\(self.count)"
+                    nextOperation.operation.token = "\(currentServerChangeToken).\(self.count)"
                 }
                 else {
-                    retryOperation.operation.token = "firstTokenAfterNil"
+                    nextOperation.operation.token = "firstTokenAfterNil"
                 }
             }
         }

--- a/Tests/Features/CloudKitOperationTests.swift
+++ b/Tests/Features/CloudKitOperationTests.swift
@@ -1447,8 +1447,7 @@ class CloudKitOperationDiscoverAllContractsTests: CKTests {
         var userInfosByRecordID: [TestDiscoverUserInfosOperation.RecordID: TestDiscoverUserInfosOperation.DiscoveredUserInfo]? = .None
 
         var shouldError = true
-        let operation: CloudKitOperation<TestDiscoverUserInfosOperation> =
-            CloudKitOperation(strategy: .Immediate) {
+        let operation: CloudKitOperation<TestDiscoverUserInfosOperation> = CloudKitOperation(strategy: .Immediate) {
             let op = TestDiscoverUserInfosOperation(userInfosByEmailAddress: [:], userInfoByRecordID: [:])
             if shouldError {
                 op.error = NSError(
@@ -1461,13 +1460,11 @@ class CloudKitOperationDiscoverAllContractsTests: CKTests {
             return op
         }
         operation.setDiscoverUserInfosCompletionBlock { _, _ in }
-        operation.setPrepareForRetryHandler { addConfigureBlock in
-            addConfigureBlock { retryOperation in
-                // retry operation gets a new completion block that stores the result values
-                retryOperation.setDiscoverUserInfosCompletionBlock { byAddress, byRecordID in
-                    userInfosByAddress = byAddress
-                    userInfosByRecordID = byRecordID
-                }
+        operation.setFinallyConfigureRetryOperationBlock { retryOperation in
+            // retry operation gets a new completion block that stores the result values
+            retryOperation.setDiscoverUserInfosCompletionBlock { byAddress, byRecordID in
+                userInfosByAddress = byAddress
+                userInfosByRecordID = byRecordID
             }
         }
 
@@ -2421,16 +2418,14 @@ class BatchedFetchRecordChangesOperationTests: CKTests {
             self.count += 1
         }
 
-        operation.setPrepareForNextOperationHandler { addConfigureBlock in
-            addConfigureBlock { nextOperation in
-                nextOperation.previousServerChangeToken = currentServerChangeToken
-                // simulate the next server change token
-                if let currentServerChangeToken = currentServerChangeToken {
-                    nextOperation.operation.token = "\(currentServerChangeToken).\(self.count)"
-                }
-                else {
-                    nextOperation.operation.token = "firstTokenAfterNil"
-                }
+        operation.setConfigureNextOperationBlock { nextOperation in
+            nextOperation.previousServerChangeToken = currentServerChangeToken
+            // simulate the next server change token
+            if let currentServerChangeToken = currentServerChangeToken {
+                nextOperation.operation.token = "\(currentServerChangeToken).\(self.count)"
+            }
+            else {
+                nextOperation.operation.token = "firstTokenAfterNil"
             }
         }
 


### PR DESCRIPTION
~~This PR adds two new public methods:~~

## Please see the updated API descriptions in the comments below.

### ~~CloudKitOperation:~~

#### ~~**CloudKitOperation.setPrepareForRetryHandler()**:~~
~~Sets a handler block which receives a closure that can be used to add configuration blocks to the retry operation.~~

~~This will be useful for some of the new (iOS 10 / macOS 10.12) CloudKit operations that use pipelining, like [CKFetchRecordZoneChangesOperation](https://developer.apple.com/reference/cloudkit/ckfetchrecordzonechangesoperation) (where the client code may want to update the previousServerChangeToken for a zone in the event of prior partial success that was persisted).~~

~~Hypothetical pseudo-code example (doesn't work yet because support for the new CloudKit operations isn't yet included):~~
```swift
// note: this example is outdated - do not use
// 
// operation.setPrepareForRetryHandler { addConfigureBlock in
//     addConfigureBlock { nextOperation in
//         // only retry with zones that haven't completed
//         // and ensure that the per-zone previousServerChangeToken is the last-processed one
//         let incompleteZones = zones.filter { (recordZoneID) -> Bool in
//             return !(zoneCompleted[recordZoneID] ?? false)
//         }
//         nextOperation.recordZoneIDs = incompleteZones
// 
 //        var optionsForIncompleteZones: [CKRecordZoneID: CKFetchRecordZoneChangesOptions] = [:]
//         for zone in incompleteZones {
//             let options = CKFetchRecordZoneChangesOptions()
//             options.previousServerChangeToken = currentChangeTokens[zone]
//             optionsForIncompleteZones[zone] = options
//         }
//         nextOperation.optionsByRecordZoneID = optionsForIncompleteZones
//     }
// }
```

### ~~BatchedCloudKitOperation:~~

#### ~~**BatchedCloudKitOperation.setPrepareForNextOperationHandler()**:~~

~~Sets a handler block which receives a closure that can be used to add configuration blocks to the next CloudKitOperation<T> (i.e. when the current CloudKitOperation returns with moreComing == true)~~

~~For example, if the "next" operation needs to use the updated serverChangeToken:~~
```swift
// batchedOperation.setPrepareForNextOperationHandler { addConfigureBlock in
//     addConfigureBlock { nextOperation in
//         nextOperation.previousServerChangeToken = currentServerChangeToken // <-- (retrieved/persisted elsewhere)
//     }
// }
```