### PR TITLE
Fixes an issue where by default FRC would return objects instead of faults

### DIFF
--- a/Sources/ProcedureKitCoreData/MakeFetchedResultController.swift
+++ b/Sources/ProcedureKitCoreData/MakeFetchedResultController.swift
@@ -51,7 +51,6 @@ open class MakeFetchedResultControllerProcedure<Result: NSFetchRequestResult>: T
         let fetchRequest: NSFetchRequest<Result> = NSFetchRequest(entityName: entityName)
         fetchRequest.fetchLimit = fetchLimit
         fetchRequest.sortDescriptors = sortDescriptors
-        fetchRequest.returnsObjectsAsFaults = false
 
         super.init(transform: MakeFetchedResultControllerProcedure<Result>.transform(fetchRequest: fetchRequest, sectionNameKeyPath: sectionNameKeyPath, cacheName: cacheName))
         name = "Make FRC \(fetchRequest.entityName ?? "")".trimmingCharacters(in: .whitespaces)


### PR DESCRIPTION
It is best practice to have the main fetch for th FRC to return faults, and then use async fetch requests with prefetching API