### PR TITLE
Add call to didSetInputReady in bind(to: ..)

### DIFF
--- a/Sources/ProcedureKit/ProcedureResult.swift
+++ b/Sources/ProcedureKit/ProcedureResult.swift
@@ -247,7 +247,10 @@ public extension InputProcedure {
 
     func bind<T: InputProcedure>(to target: T) where T.Input == Self.Input {
         addDidSetInputReadyBlockObserver { (procedure) in
-            target.input = procedure.input
+            if case .ready = procedure.input {
+                target.input = procedure.input
+                target.didSetInputReady()
+            }
         }
     }
 }


### PR DESCRIPTION
As described in the linked issue, `bind(to: InputProcedure)` does not call `didSetInputReady` which causes issues if the procedure, that receives the input, uses `bind(to: ..)` internally to proxy the same input down to children.

It's possible that we would have to remove the manual calls to `didSetInputReady` across the codebase, such as in (IIRC) `BatchProcedure`, perhaps I should address this in this PR as well...

Fixes #936