### PR TITLE
Swift Tools (Version 5 Support)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ DerivedData
 *.hmap
 *.ipa
 *.xcuserstate
+.swiftpm/
 
 # CocoaPods
 #

--- a/Package.swift
+++ b/Package.swift
@@ -1,32 +1,41 @@
-// swift-tools-version:4.0
+// swift-tools-version:5.0
 
 import PackageDescription
 
-let pkg = Package(name: "ProcedureKit")
-
-pkg.products = [
-    .library(name: "ProcedureKit", targets: ["ProcedureKit"]),
-    .library(name: "ProcedureKitCloud", targets: ["ProcedureKitCloud"]),
-    .library(name: "ProcedureKitCoreData", targets: ["ProcedureKitCoreData"]),
-    .library(name: "ProcedureKitLocation", targets: ["ProcedureKitLocation"]),
-    .library(name: "ProcedureKitMac", targets: ["ProcedureKitMac"]),
-    .library(name: "ProcedureKitNetwork", targets: ["ProcedureKitNetwork"]),
-    .library(name: "TestingProcedureKit", targets: ["TestingProcedureKit"])
-]
-
-pkg.targets = [
-    .target(name: "ProcedureKit"),
-    .target(name: "ProcedureKitCloud", dependencies: ["ProcedureKit"]),
-    .target(name: "ProcedureKitCoreData", dependencies: ["ProcedureKit"]),    
-    .target(name: "ProcedureKitLocation", dependencies: ["ProcedureKit"]),
-    .target(name: "ProcedureKitMac", dependencies: ["ProcedureKit"]),
-    .target(name: "ProcedureKitNetwork", dependencies: ["ProcedureKit"]),
-    .target(name: "TestingProcedureKit", dependencies: ["ProcedureKit"]),
-    .testTarget(name: "ProcedureKitTests", dependencies: ["ProcedureKit", "TestingProcedureKit"]),
-    .testTarget(name: "ProcedureKitStressTests", dependencies: ["ProcedureKit", "TestingProcedureKit"]),
-    .testTarget(name: "ProcedureKitCloudTests", dependencies: ["ProcedureKitCloud", "TestingProcedureKit"]),
-    .testTarget(name: "ProcedureKitCoreDataTests", dependencies: ["ProcedureKitCoreData", "TestingProcedureKit"]),    
-    .testTarget(name: "ProcedureKitLocationTests", dependencies: ["ProcedureKitLocation", "TestingProcedureKit"]),
-    .testTarget(name: "ProcedureKitMacTests", dependencies: ["ProcedureKitMac", "TestingProcedureKit"]),
-    .testTarget(name: "ProcedureKitNetworkTests", dependencies: ["ProcedureKitNetwork", "TestingProcedureKit"]),
-]
+let package = Package(
+    name: "ProcedureKit",
+    platforms: [
+        .macOS(.v10_11),
+        .iOS(.v9),
+        .tvOS(.v9),
+        .watchOS(.v3),
+    ],
+    products: [
+        .library(name: "ProcedureKit", targets: ["ProcedureKit"]),
+        .library(name: "ProcedureKitCloud", targets: ["ProcedureKitCloud"]),
+        .library(name: "ProcedureKitCoreData", targets: ["ProcedureKitCoreData"]),
+        .library(name: "ProcedureKitLocation", targets: ["ProcedureKitLocation"]),
+        .library(name: "ProcedureKitMac", targets: ["ProcedureKitMac"]),
+        .library(name: "ProcedureKitNetwork", targets: ["ProcedureKitNetwork"]),
+        .library(name: "TestingProcedureKit", targets: ["TestingProcedureKit"])
+    ],
+    dependencies: [
+    ],
+    targets: [
+        .target(name: "ProcedureKit"),
+        .target(name: "ProcedureKitCloud", dependencies: ["ProcedureKit"]),
+        .target(name: "ProcedureKitCoreData", dependencies: ["ProcedureKit"]),
+        .target(name: "ProcedureKitLocation", dependencies: ["ProcedureKit"]),
+        .target(name: "ProcedureKitMac", dependencies: ["ProcedureKit"]),
+        .target(name: "ProcedureKitNetwork", dependencies: ["ProcedureKit"]),
+        .target(name: "TestingProcedureKit", dependencies: ["ProcedureKit"]),
+        .testTarget(name: "ProcedureKitTests", dependencies: ["ProcedureKit", "TestingProcedureKit"]),
+        .testTarget(name: "ProcedureKitStressTests", dependencies: ["ProcedureKit", "TestingProcedureKit"]),
+        .testTarget(name: "ProcedureKitCloudTests", dependencies: ["ProcedureKitCloud", "TestingProcedureKit"]),
+        .testTarget(name: "ProcedureKitCoreDataTests", dependencies: ["ProcedureKitCoreData", "TestingProcedureKit"]),
+        .testTarget(name: "ProcedureKitLocationTests", dependencies: ["ProcedureKitLocation", "TestingProcedureKit"]),
+        .testTarget(name: "ProcedureKitMacTests", dependencies: ["ProcedureKitMac", "TestingProcedureKit"]),
+        .testTarget(name: "ProcedureKitNetworkTests", dependencies: ["ProcedureKitNetwork", "TestingProcedureKit"]),
+    ],
+    swiftLanguageVersions: [.v5]
+)

--- a/Tests/ProcedureKitCoreDataTests/InsertManagedObjectsProcedureTests.swift
+++ b/Tests/ProcedureKitCoreDataTests/InsertManagedObjectsProcedureTests.swift
@@ -9,6 +9,7 @@ import ProcedureKit
 import TestingProcedureKit
 @testable import ProcedureKitCoreData
 
+@available(macOS 10.12, iOS 10.0, tvOS 10.0, watchOS 3.0, *)
 final class InsertManagedObjectsProcedureTests: ProcedureKitCoreDataTestCase {
 
     func test__insert_multiple_items_and_save() {

--- a/Tests/ProcedureKitCoreDataTests/LoadCoreDataProcedureTests.swift
+++ b/Tests/ProcedureKitCoreDataTests/LoadCoreDataProcedureTests.swift
@@ -9,6 +9,7 @@ import ProcedureKit
 import TestingProcedureKit
 @testable import ProcedureKitCoreData
 
+@available(macOS 10.12, iOS 10.0, tvOS 10.0, watchOS 3.0, *)
 final class LoadCoreDataProcedureTests: ProcedureKitCoreDataTestCase {
 
     func test__load_core_data_stack_with_custom_model() {

--- a/Tests/ProcedureKitCoreDataTests/MakeFetchedResultsControllerProcedureTests.swift
+++ b/Tests/ProcedureKitCoreDataTests/MakeFetchedResultsControllerProcedureTests.swift
@@ -10,6 +10,7 @@ import ProcedureKit
 import TestingProcedureKit
 @testable import ProcedureKitCoreData
 
+@available(macOS 10.12, iOS 10.0, tvOS 10.0, watchOS 3.0, *)
 final class MakeFetchedResultsControllerProcedureTests: ProcedureKitCoreDataTestCase {
 
     func test__make_frc() {

--- a/Tests/ProcedureKitCoreDataTests/ProcedureKitCoreDataTests.swift
+++ b/Tests/ProcedureKitCoreDataTests/ProcedureKitCoreDataTests.swift
@@ -9,6 +9,7 @@ import ProcedureKit
 import TestingProcedureKit
 @testable import ProcedureKitCoreData
 
+@available(macOS 10.12, iOS 10.0, tvOS 10.0, watchOS 3.0, *)
 open class ProcedureKitCoreDataTestCase: ProcedureKitTestCase {
 
     typealias Insert = InsertManagedObjectsProcedure<TestEntityItem, TestEntity>
@@ -63,9 +64,32 @@ open class ProcedureKitCoreDataTestCase: ProcedureKitTestCase {
 
     var managedObjectModel: NSManagedObjectModel {
         let bundle = Bundle(for: type(of: self))
-        guard let model = NSManagedObjectModel.mergedModel(from: [bundle]) else {
-            fatalError("Unable to load TestDataModel.xcdatamodeld from test bundle.")
+        if let model = NSManagedObjectModel.mergedModel(from: [bundle]), model.entities.count > 0 {
+            return model
         }
+        
+        // Running the tests using `swift test` or through an xcode project generated
+        // with `swift package generate-xcodeproj` will not have the Core Data model
+        // bundled. So, we're going to construct the simple model manually.
+        
+        let testEntity = NSEntityDescription()
+        testEntity.name = "TestEntity"
+        testEntity.managedObjectClassName = "TestEntity"
+        
+        let identifier = NSAttributeDescription()
+        identifier.name = "identifier"
+        identifier.attributeType = .stringAttributeType
+        
+        let name = NSAttributeDescription()
+        name.name = "name"
+        name.attributeType = .stringAttributeType
+        
+        testEntity.properties.append(identifier)
+        testEntity.properties.append(name)
+        
+        let model = NSManagedObjectModel()
+        model.entities = [testEntity]
+        
         return model
     }
 

--- a/Tests/ProcedureKitCoreDataTests/SaveManagedObjectContextProcedureTests.swift
+++ b/Tests/ProcedureKitCoreDataTests/SaveManagedObjectContextProcedureTests.swift
@@ -10,6 +10,7 @@ import ProcedureKit
 import TestingProcedureKit
 @testable import ProcedureKitCoreData
 
+@available(macOS 10.12, iOS 10.0, tvOS 10.0, watchOS 3.0, *)
 final class SaveManagedObjectContextProcedureTests: ProcedureKitCoreDataTestCase {
 
     func test__inserting_and_saving() {

--- a/Tests/ProcedureKitCoreDataTests/TestEntity+CoreDataClass.swift
+++ b/Tests/ProcedureKitCoreDataTests/TestEntity+CoreDataClass.swift
@@ -1,0 +1,13 @@
+//
+//  ProcedureKit
+//
+//  Copyright © 2015-2019 ProcedureKit. All rights reserved.
+//
+
+import Foundation
+import CoreData
+
+@objc(TestEntity)
+public class TestEntity: NSManagedObject {
+
+}

--- a/Tests/ProcedureKitCoreDataTests/TestEntity+CoreDataProperties.swift
+++ b/Tests/ProcedureKitCoreDataTests/TestEntity+CoreDataProperties.swift
@@ -1,0 +1,20 @@
+//
+//  ProcedureKit
+//
+//  Copyright © 2015-2019 ProcedureKit. All rights reserved.
+//
+
+import Foundation
+import CoreData
+
+
+extension TestEntity {
+
+    @nonobjc public class func fetchRequest() -> NSFetchRequest<TestEntity> {
+        return NSFetchRequest<TestEntity>(entityName: "TestEntity")
+    }
+
+    @NSManaged public var identifier: String?
+    @NSManaged public var name: String?
+
+}

--- a/Tests/ProcedureKitMacTests/ProcessProcedureTests.swift
+++ b/Tests/ProcedureKitMacTests/ProcessProcedureTests.swift
@@ -6,6 +6,7 @@
 
 
 import XCTest
+import ProcedureKit
 import TestingProcedureKit
 import Foundation
 @testable import ProcedureKitMac

--- a/Tests/ProcedureKitTests/GroupTests.swift
+++ b/Tests/ProcedureKitTests/GroupTests.swift
@@ -162,7 +162,7 @@ class GroupTests: GroupTestCase {
 
         let customDispatchQueueLabel = "run.kit.procedure.ProcedureKit.Tests.TestUnderlyingQueue"
         let customDispatchQueue = DispatchQueue(label: customDispatchQueueLabel, attributes: [.concurrent])
-        let customScheduler = ProcedureKit.Scheduler(queue: customDispatchQueue)
+        let customScheduler = Scheduler(queue: customDispatchQueue)
 
         let procedureQueue = ProcedureQueue()
         procedureQueue.underlyingQueue = customDispatchQueue

--- a/Tests/ProcedureKitTests/ProcedureTests.swift
+++ b/Tests/ProcedureKitTests/ProcedureTests.swift
@@ -275,7 +275,7 @@ class ExecutionTests: ProcedureKitTestCase {
 
         let customDispatchQueueLabel = "run.kit.procedure.ProcedureKit.Tests.TestUnderlyingQueue"
         let customDispatchQueue = DispatchQueue(label: customDispatchQueueLabel, attributes: [.concurrent])
-        let customScheduler = ProcedureKit.Scheduler(queue: customDispatchQueue)
+        let customScheduler = Scheduler(queue: customDispatchQueue)
 
         let procedureQueue = ProcedureQueue()
         procedureQueue.underlyingQueue = customDispatchQueue


### PR DESCRIPTION
This PR updates the Swift `Package.swift` file to the tools version 5 format.
Along with that change, the minimum supported platforms are added (using **platforms: []**), and the supported language versions are listed (using **swiftLanguageVersions: []**).

Due to now listed the minimum os support, files in `ProcedureKitCoreDataTests` needed to have a '@available' attribute applied making sure the tests where only run on supported platforms. (Primarily due to the use of `NSPersistentContainer`).

Also, since some build environments may not understand what an `.xcdatamodeld` file is, I've added the TestEntity class definitions, as well as, creating the `NSManagedObjectModel` definition in code. This allows the tests to run and pass while using the `swift test` command.

These updates were tested with Xcode 11.1 using swift packages.
(Could relate to https://github.com/ProcedureKit/ProcedureKit/issues/939)